### PR TITLE
Optimize token image fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-react",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-react",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -32,6 +32,7 @@ import useDataFilter from 'hooks/useDataFilter'
 // Reducer/Actions
 import { TokenLocalState } from 'reducers-actions'
 import { useWalletConnection } from 'hooks/useWalletConnection'
+import { web3 } from 'api'
 
 interface WithdrawState {
   amount: BN
@@ -227,7 +228,9 @@ interface BalanceDisplayProps extends TokenLocalState {
 const customFilterFnFactory = (searchTxt: string) => (token: TokenBalanceDetails): boolean => {
   if (searchTxt === '') return true
 
-  return checkTokenAgainstSearch(token, searchTxt)
+  const searchIsAddress = web3.utils.isAddress(searchTxt)
+
+  return checkTokenAgainstSearch(token, searchTxt, searchIsAddress)
 }
 
 const customHideZeroFilterFn = ({

--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -76,7 +76,14 @@ const useFailOnceImage = ({ address, addressMainnet, symbol, name }: Omit<Props,
   }, [address, addressMainnet, symbol, name])
 }
 
+export const TokenImg: React.FC<Props> = (props) => {
+  const { faded } = props
+
   const imageProps = useFailOnceImage(props)
+
+  return <Wrapper {...imageProps} faded={faded} />
+}
+
 export const TokenImgWrapper = styled(TokenImg)`
   margin: 0 1rem 0 0;
 `

--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -13,9 +13,15 @@ const Wrapper = styled.img<WrapperProps>`
   padding: 2px;
   opacity: ${(props): number => (props.faded ? 0.4 : 1)};
 `
+// keep track of 404 token images
+// so we don't retry fetching them
+const failedTokenImages = new Set<string>()
 
 function _loadFallbackTokenImage(event: React.SyntheticEvent<HTMLImageElement>): void {
   const image = event.currentTarget
+
+  failedTokenImages.add(image.src)
+
   image.src = unknownTokenImg
 }
 
@@ -58,11 +64,14 @@ export const TokenImg: React.FC<Props> = (props) => {
     ? tokensIconsRequire(iconFile).default
     : getImageUrl(addressMainnet || address)
 
+  // if we know the image failed before, use fallback image right away
+  const imgSrc = iconFileUrl && !failedTokenImages.has(iconFileUrl) ? iconFileUrl : unknownTokenImg
+
   // TODO: Simplify safeTokenName signature, it doesn't need the addressMainnet or id!
   // https://github.com/gnosis/dex-react/issues/1442
   const safeName = safeTokenName({ address, symbol, name })
 
-  return <Wrapper alt={safeName} src={iconFileUrl} onError={_loadFallbackTokenImage} {...props} />
+  return <Wrapper alt={safeName} src={imgSrc} onError={_loadFallbackTokenImage} {...props} />
 }
 
 export const TokenImgWrapper = styled(TokenImg)`

--- a/src/const.ts
+++ b/src/const.ts
@@ -21,6 +21,7 @@ import { Network } from 'types'
 import { DisabledTokensMaps, TokenOverride, AddressToOverrideMap } from 'types/config'
 
 export const BATCH_TIME_IN_MS = BATCH_TIME * 1000
+export const DEFAULT_TIMEOUT = 5000
 
 export const ZERO_BIG_NUMBER = new BigNumber(0)
 export const ONE_BIG_NUMBER = new BigNumber(1)

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -5,7 +5,7 @@ import { TokenDetails, Unpromise } from 'types'
 import { AssertionError } from 'assert'
 import { AuctionElement, Trade, Order } from 'api/exchange/ExchangeApi'
 import { batchIdToDate } from './time'
-import { ORDER_FILLED_FACTOR, MINIMUM_ALLOWANCE_DECIMALS } from 'const'
+import { ORDER_FILLED_FACTOR, MINIMUM_ALLOWANCE_DECIMALS, DEFAULT_TIMEOUT } from 'const'
 import { TEN, ZERO } from '@gnosis.pm/dex-js'
 
 export function assertNonNull<T>(val: T, message: string): asserts val is NonNullable<T> {
@@ -72,7 +72,8 @@ export function getToken<T extends TokenDetails, K extends keyof T>(
   return token
 }
 
-export const delay = <T>(ms = 100, result?: T): Promise<T> => new Promise((resolve) => setTimeout(resolve, ms, result))
+export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(resolve, ms, result))
 
 /**
  * Uses images from https://github.com/trustwallet/tokens
@@ -210,3 +211,21 @@ export function notEmpty<TValue>(value: TValue | null | undefined): value is TVa
 }
 
 export const isNonZeroNumber = (value?: string | number): boolean => !!value && !!+value
+
+export interface TimeoutParams<T> {
+  time?: number
+  result?: T
+  timeoutErrorMsg?: string
+}
+
+export function timeout(params: TimeoutParams<undefined>): Promise<never> // never means function throws
+export function timeout<T>(params: TimeoutParams<T extends undefined ? never : T>): Promise<T>
+export async function timeout<T>(params: TimeoutParams<T>): Promise<T | never> {
+  const { time = DEFAULT_TIMEOUT, result, timeoutErrorMsg: timeoutMsg = 'Timeout' } = params
+
+  await delay(time)
+  // provided defined result -- return it
+  if (result !== undefined) return result
+  // no defined result -- throw message
+  throw new Error(timeoutMsg)
+}


### PR DESCRIPTION
> Recreate https://github.com/gnosis/gp-v1-ui/pull/1647

After a suggestion by @biocom 
There are a lot of `GET https://.../<address>/logo.png 404` errors in the console for token images that aren't there. And while we can't get rid of these reports (as these are browser fetch errors), we can not retry failed images (on route change, on `TokenImage` remount)

So let's keep track of failed images and use fallback right away.

Also stop passing extra props to `Wrapper`s, that's plain bad manners :stern_look: