### PR TITLE
Issue 19/generic layout menu

### DIFF
--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -9,7 +9,7 @@ import { GlobalModalInstance } from 'components/OuterModal'
 import { rootReducer, INITIAL_STATE } from 'reducers-actions'
 
 import { GenericLayout } from 'components/layout'
-import { Menu } from 'components/layout/GenericLayout/Menu'
+import { Navigation } from 'components/layout/GenericLayout/Navigation'
 import { Header } from 'components/layout/GenericLayout/Header'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,7 +33,7 @@ const Home = React.lazy(
 
 const HEADER = (
   <Header>
-    <Menu>
+    <Navigation>
       <li>
         <Link to="/">Batches</Link>
       </li>
@@ -43,7 +43,7 @@ const HEADER = (
       <li>
         <Link to="/markets">Markets</Link>
       </li>
-    </Menu>
+    </Navigation>
   </Header>
 )
 

--- a/src/apps/trade/TradeApp.tsx
+++ b/src/apps/trade/TradeApp.tsx
@@ -12,7 +12,7 @@ import { GlobalModalInstance } from 'components/OuterModal'
 import { rootReducer, INITIAL_STATE } from 'reducers-actions'
 
 import { GenericLayout } from 'components/layout'
-import { Menu } from 'components/layout/GenericLayout/Menu'
+import { Navigation } from 'components/layout/GenericLayout/Navigation'
 import { NavTools } from 'components/layout/GenericLayout/NavTools'
 import { Header } from 'components/layout/GenericLayout/Header'
 
@@ -61,7 +61,7 @@ const PortfolioLink = styled.li`
 
 const HEADER = (
   <Header>
-    <Menu>
+    <Navigation>
       <li>
         <Link to="/">Trade</Link>
       </li>
@@ -71,7 +71,7 @@ const HEADER = (
       <li>
         <Link to="/liquidity">Liquidity</Link>
       </li>
-    </Menu>
+    </Navigation>
     <NavTools hasWallet hasNotifications hasSettings>
       <PortfolioLink>
         <Link to="/portfolio">Portfolio</Link>

--- a/src/components/layout/GenericLayout/GenericLayout.stories.tsx
+++ b/src/components/layout/GenericLayout/GenericLayout.stories.tsx
@@ -6,7 +6,7 @@ import { Meta, Story } from '@storybook/react/types-6-0'
 import { GenericLayout, Props } from '.'
 import { Router, ThemeToggler } from 'storybook/decorators'
 import { LoremIpsum } from 'storybook/LoremIpsum'
-import { Menu } from './Menu'
+import { Navigation } from './Navigation'
 import { Header } from './Header'
 import { Footer, FooterType } from './Footer'
 
@@ -35,12 +35,12 @@ WithCustomHeaderAndFooter.args = {
   ...ShortPage.args,
   header: (
     <Header>
-      <Menu>
+      <Navigation>
         <li>Item 1</li>
         <li>Item 2</li>
         <li>Item 3</li>
         <li>Item 4</li>
-      </Menu>
+      </Navigation>
     </Header>
   ),
   footer: <Footer {...footerProps} />,

--- a/src/components/layout/GenericLayout/NavTools/index.tsx
+++ b/src/components/layout/GenericLayout/NavTools/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { MEDIA } from 'const'
-import { NavStyled } from '../Menu'
+import { Navigation } from '../Navigation'
 
 // Components
 import UserWallet from 'components/UserWallet'
@@ -48,7 +48,7 @@ const NotificationsLink = styled.li`
   }
 `
 
-const Wrapper = styled(NavStyled)`
+const Wrapper = styled(Navigation)`
   margin: 0 0 0 auto;
   padding: 0;
 

--- a/src/components/layout/GenericLayout/Navigation/index.tsx
+++ b/src/components/layout/GenericLayout/Navigation/index.tsx
@@ -1,16 +1,9 @@
-import React, { PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
-import { MEDIA } from 'const'
-
-export const NavStyled = styled.ol`
+export const Navigation = styled.ol`
   list-style: none;
   display: flex;
   padding: 0;
-
-  /* @media ${MEDIA.mediumDown} {
-    margin: 0 0 0 auto;
-  } */
 
   > li {
     font-size: var(--font-size-larger);
@@ -56,7 +49,3 @@ export const NavStyled = styled.ol`
     transition: width 0.3s ease-in-out, background 0.3s ease-in-out;
   }
 `
-
-type Props = PropsWithChildren<unknown>
-
-export const Menu: React.FC<Props> = ({ children }) => <NavStyled>{children}</NavStyled>

--- a/src/components/layout/GenericLayout/Navigation/index.tsx
+++ b/src/components/layout/GenericLayout/Navigation/index.tsx
@@ -1,9 +1,15 @@
 import styled from 'styled-components'
 
+import { MEDIA } from 'const'
+
 export const Navigation = styled.ol`
   list-style: none;
   display: flex;
   padding: 0;
+
+  /* @media ${MEDIA.mediumDown} {
+    margin: 0 0 0 auto;
+  } */
 
   > li {
     font-size: var(--font-size-larger);


### PR DESCRIPTION
# Summary

Part of #19 

Waterfalls into #31 

Refactoring `GenericLayout/Menu`.

It' just a glorified `<ol>` tag, so I removed the component and renamed it to Navigation.

Don't think this needs a storybook of its own.

# :warning: Warning

Don't merge before #31 