### PR TITLE
[Theming//Styles] - Re-vamp media query templates on theme + add where necessary

### DIFF
--- a/src/apps/trade/TradeApp.tsx
+++ b/src/apps/trade/TradeApp.tsx
@@ -3,8 +3,6 @@ import styled from 'styled-components'
 import { BrowserRouter, HashRouter, Route, Switch, Link, Redirect } from 'react-router-dom'
 import { hot } from 'react-hot-loader/root'
 
-import { MEDIA } from 'const'
-
 import { withGlobalContext } from 'hooks/useGlobalState'
 import useNetworkCheck from 'hooks/useNetworkCheck'
 import Console from 'Console'
@@ -18,6 +16,7 @@ import { Header } from 'components/layout/GenericLayout/Header'
 
 import PortfolioImage from 'assets/img/portfolio.svg'
 import PortfolioImageWhite from 'assets/img/portfolio-white.svg'
+import { applyMediaStyles } from 'theme'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Router: typeof BrowserRouter & typeof HashRouter = (window as any).IS_IPFS ? HashRouter : BrowserRouter
@@ -41,9 +40,9 @@ const Trading = React.lazy(
 const PortfolioLink = styled.li`
   margin: 0 2.4rem 0 0;
 
-  @media ${MEDIA.mediumDown} {
+  ${applyMediaStyles('upToMedium')`
     order: 2;
-  }
+  `}
 
   > a::before {
     display: block;

--- a/src/apps/trade/pages/Trading.styled.ts
+++ b/src/apps/trade/pages/Trading.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { MEDIA } from 'const'
+import { applyMediaStyles } from 'theme'
 
 export const TradingStyled = styled.div`
   flex: 1 1 auto;
@@ -20,16 +20,16 @@ export const TradingStyled = styled.div`
   grid-template-rows: var(--height-bar-default) 65% 35%;
   align-items: start;
 
-  @media ${MEDIA.tablet} {
+  ${applyMediaStyles('tabletPortrait')`
     grid-template-areas:
       'orderform marketnavbar marketnavbar marketnavbar'
       'orderform priceDepthChartWidget priceDepthChartWidget priceDepthChartWidget'
       'orderform orderbook orderbook orderbook'
       'orderform orders orders orders';
     grid-template-rows: var(--height-bar-default) 33% 33% 34%;
-  }
+  `}
 
-  @media ${MEDIA.mobile} {
+  ${applyMediaStyles('upToSmall')`
     grid-template-areas:
       'orderform marketnavbar marketnavbar marketnavbar'
       'orderform priceDepthChartWidget priceDepthChartWidget priceDepthChartWidget'
@@ -44,5 +44,5 @@ export const TradingStyled = styled.div`
     grid-template-rows:
       [marketnavbar] minmax(var(--height-bar-default), var(--height-bar-default))
       [orderbook] 5rem;
-  }
+  `}
 `

--- a/src/components/layout/GenericLayout/NavTools/index.tsx
+++ b/src/components/layout/GenericLayout/NavTools/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { MEDIA } from 'const'
 import { Navigation } from '../Navigation'
 
 // Components
@@ -12,6 +11,8 @@ import SettingsImage from 'assets/img/settings.svg'
 import SettingsImageWhite from 'assets/img/settings-white.svg'
 import NotificationsImage from 'assets/img/bell.svg'
 import NotificationsImageWhite from 'assets/img/bell-white.svg'
+
+import { applyMediaStyles } from 'theme'
 
 const SettingsLink = styled.li`
   margin: 0 2.4rem 0 0;
@@ -52,7 +53,7 @@ const Wrapper = styled(Navigation)`
   margin: 0 0 0 auto;
   padding: 0;
 
-  /* @media ${MEDIA.mediumDown} {
+  /* ${applyMediaStyles('upToMedium')`
     flex-direction: row;
     justify-content: flex-start;
     justify-self: center;
@@ -65,7 +66,7 @@ const Wrapper = styled(Navigation)`
     height: 7.2rem;
     border-radius: 0;
     background-color: var(--color-gradient-2);
-  } */
+  `} */
 
   > li {
     display: flex;
@@ -82,11 +83,11 @@ const Wrapper = styled(Navigation)`
       right: -2.8rem;
     }
 
-    /* @media ${MEDIA.mediumDown} {
+    /* ${applyMediaStyles('upToMedium')`
       &:first-of-type::after {
         content: none;
       }
-    } */
+    `} */
 
     > a {
       transition: background 0.2s ease-in-out;

--- a/src/components/layout/GenericLayout/Navigation/index.tsx
+++ b/src/components/layout/GenericLayout/Navigation/index.tsx
@@ -1,15 +1,15 @@
 import styled from 'styled-components'
-
-import { MEDIA } from 'const'
+import { applyMediaStyles } from 'theme'
 
 export const Navigation = styled.ol`
   list-style: none;
   display: flex;
   padding: 0;
 
-  /* @media ${MEDIA.mediumDown} {
+  /* ${applyMediaStyles('upToMedium')`
     margin: 0 0 0 auto;
-  } */
+  `}
+   */
 
   > li {
     font-size: var(--font-size-larger);

--- a/src/components/trade/Price.tsx
+++ b/src/components/trade/Price.tsx
@@ -6,7 +6,7 @@ import { invertPrice } from '@gnosis.pm/dex-js'
 // types, utils
 import { TokenDetails } from 'types'
 import { parseBigNumber } from 'utils'
-import { DEFAULT_PRECISION, MEDIA } from 'const'
+import { DEFAULT_PRECISION } from 'const'
 
 // Components
 import { OrderBookBtn } from 'components/OrderBookBtn'
@@ -19,6 +19,7 @@ import { FormMessage } from 'components/common/FormMessage'
 import { TradeFormData } from 'components/TradeWidget'
 import { useNumberInput } from 'components/TradeWidget/useNumberInput'
 import { SwapPrice } from 'components/common/SwapPrice'
+import { applyMediaStyles } from 'theme'
 
 const Wrapper = styled.div`
   display: flex;
@@ -38,9 +39,9 @@ const Wrapper = styled.div`
     box-sizing: border-box;
     font-size: 1.5rem;
 
-    @media ${MEDIA.mobile} {
+    ${applyMediaStyles('upToSmall')`
       font-size: 1.3rem;
-    }
+    `}
 
     > ${FormMessage} {
       width: min-content;
@@ -70,10 +71,10 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
   position: relative;
   outline: 0;
 
-  @media ${MEDIA.mobile} {
+  ${applyMediaStyles('upToSmall')`
     width: 100%;
     margin: 0 0 1.6rem;
-  }
+  `}
 
   label {
     display: flex;
@@ -82,9 +83,9 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
     height: 5.6rem;
     position: relative;
 
-    @media ${MEDIA.mobile} {
+    ${applyMediaStyles('upToSmall')`
       width: 100%;
-    }
+    `}
   }
 
   label > div:not(.radio-container) {
@@ -104,10 +105,11 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
     text-align: right;
     font-weight: var(--font-weight-bold);
 
-    @media ${MEDIA.mobile} {
+    ${applyMediaStyles('upToSmall')`
       font-size: 1rem;
       letter-spacing: 0.03rem;
-    }
+    `}
+
     > small:nth-child(2) {
       margin: 0 0.3rem;
       font-size: 1rem;
@@ -129,10 +131,10 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
     padding: 0 15ch 0 1rem;
     outline: 0;
 
-    @media ${MEDIA.mobile} {
+    ${applyMediaStyles('upToSmall')`
       font-size: 1.3rem;
       width: 100%;
-    }
+    `}
 
     &:focus {
       border-bottom: 0.2rem solid var(--color-text-active);

--- a/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { MEDIA } from 'const'
-
 import { HelpTooltip, HelpTooltipContainer } from 'components/Tooltip'
 import { SwapPrice } from 'components/common/SwapPrice'
 import { EllipsisText } from 'components/common/EllipsisText'
@@ -11,6 +9,7 @@ import { PriceSuggestionItem } from 'components/trade/PriceSuggestions/PriceSugg
 import BigNumber from 'bignumber.js'
 import { TokenDex } from '@gnosis.pm/dex-js'
 import { isNonZeroNumber } from 'utils'
+import { applyMediaStyles } from 'theme'
 
 export const PriceSuggestionsWrapper = styled.div`
   > div {
@@ -39,9 +38,9 @@ export const PriceSuggestionsWrapper = styled.div`
       margin-left: auto;
       font-size: 1.2rem;
 
-      @media ${MEDIA.xSmallDown} {
+      ${applyMediaStyles('upToExtraSmall')`
         display: flex;
-      }
+      `}
     }
   }
 
@@ -83,7 +82,7 @@ export const PriceSuggestionsWrapper = styled.div`
       }
     }
 
-    @media ${MEDIA.xSmallDown} {
+    ${applyMediaStyles('upToExtraSmall')`
       grid-auto-flow: row;
 
       > div {
@@ -99,7 +98,7 @@ export const PriceSuggestionsWrapper = styled.div`
           }
         }
       }
-    }
+    `}
   }
 `
 

--- a/src/hooks/useTabs.tsx
+++ b/src/hooks/useTabs.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
-import { MEDIA } from 'const'
 import useSafeState from 'hooks/useSafeState'
+import { applyMediaStyles } from 'theme'
 
 const TabsWrapper = styled.div`
   margin: 0 auto;
@@ -13,9 +13,9 @@ const TabsWrapper = styled.div`
   border-bottom: 0.1rem solid var(--color-text-secondary);
   align-items: center;
 
-  @media ${MEDIA.mobile} {
+  ${applyMediaStyles('upToSmall')`
     margin: 0 auto;
-  }
+  `}
 
   .countContainer {
     display: flex;
@@ -60,7 +60,7 @@ const TabsWrapper = styled.div`
         margin: 0 0 0 0.5rem;
       }
 
-      @media ${MEDIA.mobile} {
+      ${applyMediaStyles('upToSmall')`
         flex: 1;
         font-size: 1.2rem;
         min-height: 5.4rem;
@@ -70,15 +70,15 @@ const TabsWrapper = styled.div`
           height: 1.3rem;
           line-height: 1.36rem;
         }
-      }
+      `}
 
-      @media ${MEDIA.xSmallDown} {
+      ${applyMediaStyles('upToExtraSmall')`
         flex-flow: column nowrap;
 
         > i {
           margin: 0.3rem auto;
         }
-      }
+      `}
     }
 
     > button.selected {

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -10,7 +10,24 @@ import {
 } from 'styled-components'
 
 import { useThemeMode } from 'hooks/useThemeManager'
-import { getFonts, getThemePalette } from './styles'
+import { getFonts, getThemePalette, mediaWidthTemplates as mediaQueries } from './styles'
+import { Theme } from './types'
+
+const getBaseTheme = ({
+  mode,
+  componentKey,
+}: {
+  mode: Theme
+  componentKey?: Partial<DefaultTheme['componentKey']>
+}): Pick<DefaultTheme, 'mode' | 'componentKey' | 'mediaQueries'> => ({
+  mode,
+  // unfold in any extensions
+  // for example to make big/small buttons -> see src/components/Button ThemeWrappedButtonBase
+  // to see it in action
+  componentKey,
+  // media queries
+  mediaQueries,
+})
 
 // This type is all React.ReactElement & StyledComponents combined
 type ReactOrStyledNode = React.ReactElement &
@@ -21,25 +38,21 @@ const ThemeProvider: React.FC<{ componentKey?: Partial<DefaultTheme['componentKe
   children,
   componentKey,
 }) => {
-  const themeMode = useThemeMode()
+  const mode = useThemeMode()
 
   const themeObject = useMemo(() => {
-    const themePalette = getThemePalette(themeMode)
-    const fontPalette = getFonts(themeMode)
+    const themePalette = getThemePalette(mode)
+    const fontPalette = getFonts(mode)
 
     const computedTheme: DefaultTheme = {
       // Compute the app colour pallette using the passed in themeMode
       ...themePalette,
       ...fontPalette,
-      mode: themeMode,
-      // unfold in any extensions
-      // for example to make big/small buttons -> see src/components/Button ThemeWrappedButtonBase
-      // to see it in action
-      componentKey,
+      ...getBaseTheme({ mode, componentKey }),
     }
 
     return computedTheme
-  }, [themeMode, componentKey])
+  }, [mode, componentKey])
 
   // We want to pass the ThemeProvider theme to all children implicitly, no need to manually pass it
   return (

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -11,22 +11,13 @@ import {
 
 import { useThemeMode } from 'hooks/useThemeManager'
 import { getFonts, getThemePalette, mediaWidthTemplates as mediaQueries } from './styles'
-import { Theme } from './types'
 
-const getBaseTheme = ({
-  mode,
-  componentKey,
-}: {
-  mode: Theme
-  componentKey?: Partial<DefaultTheme['componentKey']>
-}): Pick<DefaultTheme, 'mode' | 'componentKey' | 'mediaQueries'> => ({
-  mode,
-  // unfold in any extensions
-  // for example to make big/small buttons -> see src/components/Button ThemeWrappedButtonBase
-  // to see it in action
-  componentKey,
+const getBaseTheme = (): Pick<DefaultTheme, 'mediaQueries' | 'mq'> => ({
   // media queries
   mediaQueries,
+  get mq(): DefaultTheme['mq'] {
+    return this.mediaQueries
+  },
 })
 
 // This type is all React.ReactElement & StyledComponents combined
@@ -45,14 +36,16 @@ const ThemeProvider: React.FC<{ componentKey?: Partial<DefaultTheme['componentKe
     const fontPalette = getFonts(mode)
 
     const computedTheme: DefaultTheme = {
+      mode,
+      componentKey,
       // Compute the app colour pallette using the passed in themeMode
       ...themePalette,
       ...fontPalette,
-      ...getBaseTheme({ mode, componentKey }),
+      ...getBaseTheme(),
     }
 
     return computedTheme
-  }, [mode, componentKey])
+  }, [componentKey, mode])
 
   // We want to pass the ThemeProvider theme to all children implicitly, no need to manually pass it
   return (

--- a/src/theme/styles/index.ts
+++ b/src/theme/styles/index.ts
@@ -1,3 +1,4 @@
 export * from './global'
 export * from './colours'
 export * from './fonts'
+export * from './mediaQueries'

--- a/src/theme/styles/mediaQueries.ts
+++ b/src/theme/styles/mediaQueries.ts
@@ -42,3 +42,20 @@ export const mediaWidthTemplates = Object.keys(mediaQueriesObject).reduce<MediaW
   },
   {} as MediaWidth,
 )
+
+type ThemeProps = {
+  theme: DefaultTheme
+}
+
+/**
+ * @name applyMediaStyles
+ * @param mediaSize size to activate on
+ * @example 
+ *  applyMediaStyles('upToMedium')`
+        flex-direction: row;
+        justify-content: flex-start;
+    `
+ */
+export const applyMediaStyles = (mediaSize: keyof MediaWidth) => (
+  stylesAndStuff: CSSObject | TemplateStringsArray,
+) => ({ theme }: ThemeProps): FlattenSimpleInterpolation => theme.mq[mediaSize](stylesAndStuff)

--- a/src/theme/styles/mediaQueries.ts
+++ b/src/theme/styles/mediaQueries.ts
@@ -1,27 +1,44 @@
-import { ThemedCssFunction, DefaultTheme, CSSObject, FlattenSimpleInterpolation, css } from 'styled-components'
+import { ThemedCssFunction, DefaultTheme, CSSObject, css, FlattenSimpleInterpolation } from 'styled-components'
 
-const MEDIA_WIDTHS = {
-  upToExtraSmall: 500,
-  upToSmall: 720,
-  upToMedium: 960,
-  upToLarge: 1280,
+const PORTRAIT = 'portrait'
+const LANDSCAPE = 'landscape'
+
+// Use this to set the media widths
+export const MEDIA_WIDTHS = {
+  extraSmall: 500,
+  small: 720,
+  medium: 960,
+  large: 1280,
 }
 
-type MediaWidthKeys = keyof typeof MEDIA_WIDTHS
+// this builds our end media object that shouldn't be tweaked by us
+const mediaQueriesObject = {
+  upToExtraSmall: [0, MEDIA_WIDTHS.extraSmall, PORTRAIT],
+  upToSmall: [0, MEDIA_WIDTHS.small, PORTRAIT],
+  upToMedium: [0, MEDIA_WIDTHS.medium, PORTRAIT],
+  upToLarge: [0, MEDIA_WIDTHS.large, PORTRAIT],
 
-type MediaWidth = {
+  tabletPortrait: [MEDIA_WIDTHS.small, MEDIA_WIDTHS.medium, PORTRAIT],
+  tabletLandscape: [MEDIA_WIDTHS.small, MEDIA_WIDTHS.medium, LANDSCAPE],
+}
+
+type MediaWidthKeys = keyof typeof mediaQueriesObject
+
+export type MediaWidth = {
   [key in MediaWidthKeys]: ThemedCssFunction<DefaultTheme>
 }
 
-export const mediaWidthTemplates = Object.keys(MEDIA_WIDTHS).reduce<MediaWidth>((accumulator, size: unknown) => {
-  ;(accumulator[size as MediaWidthKeys] as unknown) = (
-    a: CSSObject,
-    b: CSSObject,
-    c: CSSObject,
-  ): ThemedCssFunction<DefaultTheme> | FlattenSimpleInterpolation => css`
-    @media (max-width: ${MEDIA_WIDTHS[size as MediaWidthKeys]}px) {
-      ${css(a, b, c)}
-    }
-  `
-  return accumulator
-}, {} as MediaWidth)
+export const mediaWidthTemplates = Object.keys(mediaQueriesObject).reduce<MediaWidth>(
+  (accumulator, size: MediaWidthKeys) => {
+    const [min, max, orientation] = mediaQueriesObject[size]
+    accumulator[size] = (a: CSSObject, b: CSSObject, c: CSSObject): FlattenSimpleInterpolation =>
+      css`
+        @media (min-device-width: ${min}px) and (max-device-width: ${max}px),
+          (min-device-width: ${min}px) and (max-device-width: ${max}px) and (orientation: ${orientation}) {
+          ${css(a, b, c)}
+        }
+      `
+    return accumulator
+  },
+  {} as MediaWidth,
+)

--- a/src/theme/styles/mediaQueries.ts
+++ b/src/theme/styles/mediaQueries.ts
@@ -55,6 +55,14 @@ type ThemeProps = {
         flex-direction: row;
         justify-content: flex-start;
     `
+ * @example {
+ *  upToExtraSmall: 500,
+ *  upToSmall: 720,
+ *  upToMedium: 960,
+ *  upToLarge: 1280,
+ *  tabletPortrait: 720 to 960, orientation: portrait,
+ *  tabletLandscape: 720 to 960, orientation: landscape,
+ * }
  */
 export const applyMediaStyles = (mediaSize: keyof MediaWidth) => (
   stylesAndStuff: CSSObject | TemplateStringsArray,

--- a/src/theme/styles/mediaQueries.ts
+++ b/src/theme/styles/mediaQueries.ts
@@ -1,0 +1,27 @@
+import { ThemedCssFunction, DefaultTheme, CSSObject, FlattenSimpleInterpolation, css } from 'styled-components'
+
+const MEDIA_WIDTHS = {
+  upToExtraSmall: 500,
+  upToSmall: 720,
+  upToMedium: 960,
+  upToLarge: 1280,
+}
+
+type MediaWidthKeys = keyof typeof MEDIA_WIDTHS
+
+type MediaWidth = {
+  [key in MediaWidthKeys]: ThemedCssFunction<DefaultTheme>
+}
+
+export const mediaWidthTemplates = Object.keys(MEDIA_WIDTHS).reduce<MediaWidth>((accumulator, size: unknown) => {
+  ;(accumulator[size as MediaWidthKeys] as unknown) = (
+    a: CSSObject,
+    b: CSSObject,
+    c: CSSObject,
+  ): ThemedCssFunction<DefaultTheme> | FlattenSimpleInterpolation => css`
+    @media (max-width: ${MEDIA_WIDTHS[size as MediaWidthKeys]}px) {
+      ${css(a, b, c)}
+    }
+  `
+  return accumulator
+}, {} as MediaWidth)

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,4 +1,4 @@
-import { Colors, Fonts } from './styles'
+import { Colors, Fonts, MediaWidth } from './styles'
 
 export enum Theme {
   DARK = 'DARK',
@@ -8,24 +8,42 @@ export enum Theme {
 export const THEME_LIST = Object.entries(Theme)
 
 declare module 'styled-components' {
-  export interface DefaultTheme extends Colors, Fonts {
+  export interface DefaultTheme extends DefaultThemeAliases, Colors, Fonts {
     // theming
     mode: Theme
     // used to key in on component variants
     componentKey?: keyof JSX.IntrinsicElements
-    // Media query templates
-    // can be used like:
-    /* 
-    theme.mediaQueries.upToSmall`
-      font-size: 2rem;
-      margin: 0;
-    `
-    */
-    mediaQueries: {
-      upToExtraSmall: ThemedCssFunction<DefaultTheme>
-      upToSmall: ThemedCssFunction<DefaultTheme>
-      upToMedium: ThemedCssFunction<DefaultTheme>
-      upToLarge: ThemedCssFunction<DefaultTheme>
-    }
+    /**
+     * @name mediaQueries
+     *
+     * @example theme.mediaQueries.upToMedium` font-size: larger; color: red; `
+     *
+     * @example {
+     *  upToExtraSmall: 500,
+     *  upToSmall: 720,
+     *  upToMedium: 960,
+     *  upToLarge: 1280,
+     *  tabletPortrait: 720 to 960, orientation: portrait,
+     *  tabletLandscape: 720 to 960, orientation: landscape,
+     * }
+     */
+    mediaQueries: MediaWidth
+  }
+  interface DefaultThemeAliases {
+    /**
+     * @name mq - alias for mediaQueries
+     *
+     * @example theme.mq.upToMedium` font-size: larger; color: red; `
+     *
+     * @example {
+     *  upToExtraSmall: 500,
+     *  upToSmall: 720,
+     *  upToMedium: 960,
+     *  upToLarge: 1280,
+     *  tabletPortrait: 720 to 960, orientation: portrait,
+     *  tabletLandscape: 720 to 960, orientation: landscape,
+     * }
+     */
+    mq: DefaultTheme['mediaQueries']
   }
 }

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -13,5 +13,19 @@ declare module 'styled-components' {
     mode: Theme
     // used to key in on component variants
     componentKey?: keyof JSX.IntrinsicElements
+    // Media query templates
+    // can be used like:
+    /* 
+    theme.mediaQueries.upToSmall`
+      font-size: 2rem;
+      margin: 0;
+    `
+    */
+    mediaQueries: {
+      upToExtraSmall: ThemedCssFunction<DefaultTheme>
+      upToSmall: ThemedCssFunction<DefaultTheme>
+      upToMedium: ThemedCssFunction<DefaultTheme>
+      upToLarge: ThemedCssFunction<DefaultTheme>
+    }
   }
 }


### PR DESCRIPTION
This PR reverts back to the Uni style media query template logic that works roughly like:
```tsx
// original logic
// inside styled component
// would be @media screen only and (max-width: 720px) { ... }
${({ theme }): FlattenSimpleInterpolation => theme.mediaQueries.upToSmall`
  font-size: 1.2rem;
  color: black;
`}
```

### This PR differs from this a bit to be more inclusive of different sizes AND makes it easier via utils / type descriptions:
#### `applyMediaStyles` helper util
- found inside `theme/styles/mediaQueries`:
- *used to be*:
```tsx
${({ theme }): FlattenSimpleInterpolation => theme.mediaQueries.upToSmall`
  font-size: 1.2rem;
  color: black;
`}
```
*changed to*:
```tsx
// note types aren't needed
${applyMediaStyles('upToSmall')`
  font-size: 1.2rem;
  color: black;
`}
```

#### Descriptions (on-hover)
![Screenshot from 2021-01-16 13-20-23](https://user-images.githubusercontent.com/21335563/104812933-a4504b00-57fd-11eb-973d-955032561d43.png)
