### PR TITLE
Push content to /current directory when on staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,6 @@ jobs:
 
       - name: "Deploy to S3: Staging"
         if: github.ref == 'refs/heads/master'
-        run: aws s3 sync dist s3://${{ secrets.AWS_STAGING_BUCKET_NAME }} --delete
+        run: aws s3 sync dist s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
 
       


### PR DESCRIPTION
On staging bucket we are gonna push to `/current` directory, while each tagged version will have its own specific directory.