### PR TITLE
[Generic Tabs: Part 1] - Cleanup (logic, types)

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,6 +4,7 @@
     "stylelint-prettier/recommended"
   ],
   "rules": {
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "declaration-bang-space-before": "never"
   }
 }

--- a/src/components/OrderBookTradesWidget/index.tsx
+++ b/src/components/OrderBookTradesWidget/index.tsx
@@ -1,20 +1,20 @@
 import React from 'react'
 import styled from 'styled-components'
-import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemInterface } from 'components/common/Tabs/Tabs'
 import OrderBook from 'components/OrderBook'
 import PairTradeHistory from 'components/PairTradeHistory'
 import { OrderBookTradesStyled as Wrapper } from './OrderBookTrades.styled'
 import { dummyOrders } from 'components/OrderBook/dummyTradingData'
 
-const tabItems = (orders: OrderBookWidgetsProp['orders']): TabItemType[] => [
+const tabItems = (orders: OrderBookWidgetsProp['orders']): TabItemInterface[] => [
   {
     id: 1,
-    title: 'Orderbook',
+    tab: 'Orderbook',
     content: <OrderBook orders={orders} />,
   },
   {
     id: 2,
-    title: 'Trades',
+    tab: 'Trades',
     content: <PairTradeHistory />,
   },
 ]

--- a/src/components/OrderBookTradesWidget/index.tsx
+++ b/src/components/OrderBookTradesWidget/index.tsx
@@ -21,14 +21,14 @@ const tabItems = (orders: OrderBookWidgetsProp['orders']): TabItemInterface[] =>
 
 // Provide a custom theme
 const tabThemeConfig = getTabTheme({
-  activeBg: '--color-transparent',
-  inactiveBg: '--color-transparent',
-  activeText: '--color-text-primary',
-  inactiveText: '--color-text-secondary2',
-  activeBorder: '--color-text-primary',
-  inactiveBorder: '--color-text-secondary2',
+  activeBg: 'var(--color-transparent)',
+  inactiveBg: 'var(--color-transparent)',
+  activeText: 'var(--color-text-primary)',
+  inactiveText: 'var(--color-text-secondary2)',
+  activeBorder: 'var(--color-text-primary)',
+  inactiveBorder: 'var(--color-text-secondary2)',
   borderRadius: false,
-  fontSize: '--font-size-default',
+  fontSize: 'var(--font-size-default)',
 })
 
 const TabsWrapper = styled.div`

--- a/src/components/OrderBookTradesWidget/index.tsx
+++ b/src/components/OrderBookTradesWidget/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import Tabs, { getTabTheme, TabItemInterface } from 'components/common/Tabs/Tabs'
 import OrderBook from 'components/OrderBook'
@@ -59,12 +59,16 @@ interface OrderBookWidgetsProp {
   readonly orders?: typeof dummyOrders
 }
 
-export const OrderBookTradesWidget: React.FC<OrderBookWidgetsProp> = ({ orders }) => (
-  <Wrapper>
-    <TabsWrapper>
-      <Tabs tabItems={tabItems(orders)} tabTheme={tabThemeConfig} />
-    </TabsWrapper>
-  </Wrapper>
-)
+export const OrderBookTradesWidget: React.FC<OrderBookWidgetsProp> = ({ orders }) => {
+  const tabsList = useMemo(() => tabItems(orders), [orders])
+
+  return (
+    <Wrapper>
+      <TabsWrapper>
+        <Tabs tabItems={tabsList} tabTheme={tabThemeConfig} />
+      </TabsWrapper>
+    </Wrapper>
+  )
+}
 
 export default OrderBookTradesWidget

--- a/src/components/OrderBookTradesWidget/index.tsx
+++ b/src/components/OrderBookTradesWidget/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import Tabs, { TabItemType, TabThemeType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
 import OrderBook from 'components/OrderBook'
 import PairTradeHistory from 'components/PairTradeHistory'
 import { OrderBookTradesStyled as Wrapper } from './OrderBookTrades.styled'
@@ -20,7 +20,7 @@ const tabItems = (orders: OrderBookWidgetsProp['orders']): TabItemType[] => [
 ]
 
 // Provide a custom theme
-const tabThemeConfig: TabThemeType = {
+const tabThemeConfig = getTabTheme({
   activeBg: '--color-transparent',
   inactiveBg: '--color-transparent',
   activeText: '--color-text-primary',
@@ -29,7 +29,7 @@ const tabThemeConfig: TabThemeType = {
   inactiveBorder: '--color-text-secondary2',
   borderRadius: false,
   fontSize: '--font-size-default',
-}
+})
 
 const TabsWrapper = styled.div`
   display: flex;

--- a/src/components/OrderBuySell/index.tsx
+++ b/src/components/OrderBuySell/index.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import styled from 'styled-components'
-import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemInterface } from 'components/common/Tabs/Tabs'
 
-const tabItems: TabItemType[] = [
+const tabItems: TabItemInterface[] = [
   {
     id: 1,
-    title: 'BUY',
+    tab: 'BUY',
     content: '- buy component -',
   },
   {
     id: 2,
-    title: 'SELL',
+    tab: 'SELL',
     content: '- sell component -',
   },
 ]

--- a/src/components/OrderBuySell/index.tsx
+++ b/src/components/OrderBuySell/index.tsx
@@ -16,11 +16,15 @@ const tabItems: TabItemInterface[] = [
 ]
 
 const tabThemeConfig = getTabTheme({
-  activeBg: '--color-long',
-  activeBgAlt: '--color-short',
-  inactiveBg: '--color-primary',
-  activeText: '--color-primary',
-  inactiveText: '--color-primary2',
+  activeBg: 'var(--color-long)',
+  activeBgAlt: 'var(--color-short)',
+  inactiveBg: 'var(--color-primary)',
+  activeText: 'var(--color-primary)',
+  inactiveText: 'var(--color-primary2)',
+  activeBorder: 'none',
+  fontSize: 'var(--font-size-large)',
+  fontWeight: 'var(--font-weight-bold)',
+  borderRadius: true,
 })
 
 const Wrapper = styled.div`

--- a/src/components/OrderBuySell/index.tsx
+++ b/src/components/OrderBuySell/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import Tabs, { TabItemType, TabThemeType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
 
 const tabItems: TabItemType[] = [
   {
@@ -15,13 +15,13 @@ const tabItems: TabItemType[] = [
   },
 ]
 
-const tabThemeConfig: TabThemeType = {
+const tabThemeConfig = getTabTheme({
   activeBg: '--color-long',
   activeBgAlt: '--color-short',
   inactiveBg: '--color-primary',
   activeText: '--color-primary',
   inactiveText: '--color-primary2',
-}
+})
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/components/OrdersWidgetDemo/index.tsx
+++ b/src/components/OrdersWidgetDemo/index.tsx
@@ -23,12 +23,13 @@ const tabItems: TabItemInterface[] = [
 
 // Provide a custom theme
 const tabThemeConfig = getTabTheme({
-  activeBg: '--color-primary',
-  activeText: '--color-text-primary',
-  inactiveBg: '--color-transparent',
-  inactiveText: '--color-text-secondary2',
-  fontWeight: '--font-weight-normal',
-  fontSize: '--font-size-default',
+  activeBg: 'var(--color-primary)',
+  activeText: 'var(--color-text-primary)',
+  inactiveBg: 'var(--color-transparent)',
+  inactiveText: 'var(--color-text-secondary2)',
+  activeBorder: 'none',
+  fontWeight: 'var(--font-weight-normal)',
+  fontSize: 'var(--font-size-default)',
   letterSpacing: '0.03rem',
 })
 

--- a/src/components/OrdersWidgetDemo/index.tsx
+++ b/src/components/OrdersWidgetDemo/index.tsx
@@ -1,26 +1,23 @@
 import React from 'react'
-import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemInterface } from 'components/common/Tabs/Tabs'
 import { OrdersWidgetDemo as Wrapper } from './OrdersWidgetDemo.styled'
 import { ActiveOrdersContent } from './ActiveOrdersContent'
 
-const tabItems: TabItemType[] = [
+const tabItems: TabItemInterface[] = [
   {
     id: 1,
-    title: 'Active Orders',
+    tab: 'Active Orders: ' + 5,
     content: <ActiveOrdersContent />,
-    count: 5,
   },
   {
     id: 2,
-    title: 'Order History',
+    tab: 'Order History: ' + 10,
     content: <ActiveOrdersContent />,
-    count: 10,
   },
   {
     id: 3,
-    title: 'Closed Orders',
+    tab: 'Closed Orders: ' + 21,
     content: 'content',
-    count: 21,
   },
 ]
 

--- a/src/components/OrdersWidgetDemo/index.tsx
+++ b/src/components/OrdersWidgetDemo/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Tabs, { TabItemType, TabThemeType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
 import { OrdersWidgetDemo as Wrapper } from './OrdersWidgetDemo.styled'
 import { ActiveOrdersContent } from './ActiveOrdersContent'
 
@@ -25,7 +25,7 @@ const tabItems: TabItemType[] = [
 ]
 
 // Provide a custom theme
-const tabThemeConfig: TabThemeType = {
+const tabThemeConfig = getTabTheme({
   activeBg: '--color-primary',
   activeText: '--color-text-primary',
   inactiveBg: '--color-transparent',
@@ -33,7 +33,7 @@ const tabThemeConfig: TabThemeType = {
   fontWeight: '--font-weight-normal',
   fontSize: '--font-size-default',
   letterSpacing: '0.03rem',
-}
+})
 
 const OrdersWidgetDemo: React.FC = () => {
   return (

--- a/src/components/PriceDepthChartWidget/index.tsx
+++ b/src/components/PriceDepthChartWidget/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import Tabs, { TabItemType, TabThemeType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
 
 import OrderBookWidget from 'components/OrderBookWidget'
 import PriceChart from 'components/PriceChart'
@@ -32,7 +32,7 @@ const demo = {
   networkId: 1,
 }
 
-const tabItems = (): TabItemType[] => [
+const tabItems: TabItemType[] = [
   {
     id: 1,
     title: 'Price Chart',
@@ -46,7 +46,7 @@ const tabItems = (): TabItemType[] => [
 ]
 
 // Provide a custom tabTheme
-const tabThemeConfig: TabThemeType = {
+const tabThemeConfig = getTabTheme({
   activeBg: '--color-transparent',
   inactiveBg: '--color-transparent',
   activeText: '--color-text-primary',
@@ -55,7 +55,7 @@ const tabThemeConfig: TabThemeType = {
   inactiveBorder: '--color-text-secondary2',
   borderRadius: false,
   fontSize: '--font-size-default',
-}
+})
 
 const TabsWrapper = styled.div`
   display: flex;
@@ -84,7 +84,7 @@ const TabsWrapper = styled.div`
 export const PriceDepthChartWidget: React.FC = () => (
   <Wrapper>
     <TabsWrapper>
-      <Tabs tabItems={tabItems()} tabTheme={tabThemeConfig} />
+      <Tabs tabItems={tabItems} tabTheme={tabThemeConfig} />
     </TabsWrapper>
   </Wrapper>
 )

--- a/src/components/PriceDepthChartWidget/index.tsx
+++ b/src/components/PriceDepthChartWidget/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import Tabs, { getTabTheme, TabItemType } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme } from 'components/common/Tabs/Tabs'
 
 import OrderBookWidget from 'components/OrderBookWidget'
 import PriceChart from 'components/PriceChart'
@@ -32,15 +32,15 @@ const demo = {
   networkId: 1,
 }
 
-const tabItems: TabItemType[] = [
+const tabItems = [
   {
     id: 1,
-    title: 'Price Chart',
+    tab: 'Price Chart',
     content: <PriceChart />,
   },
   {
     id: 2,
-    title: 'Depth Chart',
+    tab: 'Depth Chart',
     content: <OrderBookWidget baseToken={demo.baseToken} quoteToken={demo.quoteToken} networkId={demo.networkId} />,
   },
 ]

--- a/src/components/PriceDepthChartWidget/index.tsx
+++ b/src/components/PriceDepthChartWidget/index.tsx
@@ -47,14 +47,14 @@ const tabItems = [
 
 // Provide a custom tabTheme
 const tabThemeConfig = getTabTheme({
-  activeBg: '--color-transparent',
-  inactiveBg: '--color-transparent',
-  activeText: '--color-text-primary',
-  inactiveText: '--color-text-secondary2',
-  activeBorder: '--color-text-primary',
-  inactiveBorder: '--color-text-secondary2',
+  activeBg: 'var(--color-transparent)',
+  inactiveBg: 'var(--color-transparent)',
+  activeText: 'var(--color-text-primary)',
+  inactiveText: 'var(--color-text-secondary2)',
+  activeBorder: 'var(--color-text-primary)',
+  inactiveBorder: 'var(--color-text-secondary2)',
   borderRadius: false,
-  fontSize: '--font-size-default',
+  fontSize: 'var(--font-size-default)',
 })
 
 const TabsWrapper = styled.div`

--- a/src/components/common/Tabs/TabContent.tsx
+++ b/src/components/common/Tabs/TabContent.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react'
-import { TabItemType } from 'components/common/Tabs/Tabs'
+import { TabItemInterface } from 'components/common/Tabs/Tabs'
 
 type Props = {
-  tabItems: TabItemType[]
+  tabItems: TabItemInterface[]
   activeTab: number
 }
 

--- a/src/components/common/Tabs/TabContent.tsx
+++ b/src/components/common/Tabs/TabContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { TabItemType } from 'components/common/Tabs/Tabs'
 
 type Props = {
@@ -8,13 +8,11 @@ type Props = {
 
 const TabContent: React.FC<Props> = (props) => {
   const { tabItems, activeTab } = props
-  return (
-    <div>
-      {tabItems.map((tab) => {
-        return tab.id === activeTab ? tab.content : null
-      })}
-    </div>
-  )
+  const displayTab = useMemo(() => tabItems.find((tab) => tab.id === activeTab), [activeTab, tabItems])
+
+  if (!displayTab) return null
+
+  return <div>{displayTab.content}</div>
 }
 
 export default TabContent

--- a/src/components/common/Tabs/TabItem.tsx
+++ b/src/components/common/Tabs/TabItem.tsx
@@ -1,75 +1,66 @@
 import React from 'react'
 import styled from 'styled-components'
 import { TabThemeType } from 'components/common/Tabs/Tabs'
+import { ButtonBase } from '../Button'
 
 interface TabProps {
   title: string
-  readonly id: number
-  onTabClick: (arg: number) => void
   isActive: boolean
-  readonly tabTheme: TabThemeType
+  readonly id: number
   readonly count?: number
+  readonly tabTheme: TabThemeType
+  onTabClick: (id: number) => void
 }
 
-interface WrapperProps {
+interface TabItemWrapperProps {
   isActive: boolean
   readonly tabTheme: TabThemeType
 }
+
+const TabItemBase = styled(ButtonBase)`
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+
+  border: 0;
+  /* TODO: move this into baseStyles or sth similar */
+  height: var(--height-button-default);
+
+  text-align: center;
+
+  appearance: none;
+`
 
 // TODO: replace with DefaultTheme and remove `var` approach
 // Make Tabs and TabItem it's own common component with theme
-const Wrapper = styled.button<WrapperProps>`
-  background: ${({ isActive, tabTheme }): string =>
-    `var(${
-      isActive && tabTheme.activeBg ? tabTheme.activeBg : tabTheme.inactiveBg ? tabTheme.inactiveBg : '--color-primary'
-    })`};
+const TabItemWrapper = styled(TabItemBase)<TabItemWrapperProps>`
+  background: ${({ isActive, tabTheme }): string => `var(${isActive ? tabTheme.activeBg : tabTheme.inactiveBg})`};
   color: ${({ isActive, tabTheme }): string =>
-    `var(${
-      isActive && tabTheme.activeText
-        ? tabTheme.activeText
-        : !isActive && tabTheme.inactiveText
-        ? tabTheme.inactiveText
-        : '--color-text-secondary2'
-    })`};
-  height: var(--height-button-default);
-  display: flex;
-  align-items: center;
-  flex: 1 1 0;
-  font-weight: ${({ tabTheme }): string => `${tabTheme.fontWeight ? tabTheme.fontWeight : 'var(--font-weight-bold)'}`};
-  font-size: ${({ tabTheme }): string =>
-    `${tabTheme.fontSize ? `var(${tabTheme.fontSize})` : 'var(--font-size-large)'}`};
-  letter-spacing: ${({ tabTheme }): string => `${tabTheme.letterSpacing ? tabTheme.letterSpacing : '0'}`};
-  border: 0;
+    isActive ? `var(${tabTheme.activeText})` : `var(${tabTheme.inactiveText})`};
+
+  font-weight: ${({ tabTheme }): string => tabTheme.fontWeight};
+  font-size: ${({ tabTheme }): string => tabTheme.fontSize};
+  letter-spacing: ${({ tabTheme }): string => tabTheme.letterSpacing};
+
   border-bottom: ${({ isActive, tabTheme }): string =>
-    `${
-      isActive && tabTheme.activeBorder
-        ? `.1rem solid var(${tabTheme.activeBorder})`
-        : !isActive && tabTheme.inactiveBorder
-        ? `.1rem solid var(${tabTheme.inactiveBorder})`
-        : 'none'
-    }`};
-  text-align: center;
-  appearance: none;
-  justify-content: center;
-  cursor: pointer;
-  outline: 0;
+    `.1rem solid var(${isActive ? tabTheme.activeBorder : tabTheme.inactiveBorder})`};
 
   /* TODO: Provide alternative :focus styling because of using outline: 0; */
 
   &:first-of-type {
     border-top-left-radius: ${({ tabTheme }): string =>
-      `${tabTheme.borderRadius === false ? '0' : 'var(--border-radius-default)'}`};
+      `${!tabTheme.borderRadius ? '0' : 'var(--border-radius-default)'}`};
     border-bottom-left-radius: ${({ tabTheme }): string =>
-      `${tabTheme.borderRadius === false ? '0' : 'var(--border-radius-default)'}`};
+      `${!tabTheme.borderRadius ? '0' : 'var(--border-radius-default)'}`};
   }
 
   &:last-of-type {
     border-top-right-radius: ${({ tabTheme }): string =>
-      `${tabTheme.borderRadius === false ? '0' : 'var(--border-radius-default)'}`};
+      `${!tabTheme.borderRadius ? '0' : 'var(--border-radius-default)'}`};
     border-bottom-right-radius: ${({ tabTheme }): string =>
-      `${tabTheme.borderRadius === false ? '0' : 'var(--border-radius-default)'}`};
-    ${({ isActive, tabTheme }): string | undefined =>
-      isActive && tabTheme.activeBgAlt ? `background: var(${tabTheme.activeBgAlt})` : undefined}
+      `${!tabTheme.borderRadius ? '0' : 'var(--border-radius-default)'}`};
+    ${({ isActive, tabTheme }): string | false => isActive && `background: var(${tabTheme.activeBgAlt});`}
   }
 `
 
@@ -77,7 +68,7 @@ const TabItem: React.FC<TabProps> = (props) => {
   const { onTabClick, id, title, isActive, tabTheme } = props
 
   return (
-    <Wrapper
+    <TabItemWrapper
       role="tab"
       aria-selected={isActive}
       isActive={isActive}
@@ -85,7 +76,7 @@ const TabItem: React.FC<TabProps> = (props) => {
       tabTheme={tabTheme}
     >
       {title}
-    </Wrapper>
+    </TabItemWrapper>
   )
 }
 

--- a/src/components/common/Tabs/TabItem.tsx
+++ b/src/components/common/Tabs/TabItem.tsx
@@ -30,16 +30,15 @@ const TabItemBase = styled(ButtonBase)`
 // TODO: replace with DefaultTheme and remove `var` approach
 // Make Tabs and TabItemBase it's own common component with theme
 const TabItemWrapper = styled(TabItemBase)<TabItemWrapperProps>`
-  background: ${({ isActive, tabTheme }): string => `var(${isActive ? tabTheme.activeBg : tabTheme.inactiveBg})`};
-  color: ${({ isActive, tabTheme }): string =>
-    isActive ? `var(${tabTheme.activeText})` : `var(${tabTheme.inactiveText})`};
+  background: ${({ isActive, tabTheme }): string => (isActive ? tabTheme.activeBg : tabTheme.inactiveBg)};
+  color: ${({ isActive, tabTheme }): string => (isActive ? tabTheme.activeText : tabTheme.inactiveText)};
 
   font-weight: ${({ tabTheme }): string => tabTheme.fontWeight};
   font-size: ${({ tabTheme }): string => tabTheme.fontSize};
   letter-spacing: ${({ tabTheme }): string => tabTheme.letterSpacing};
 
   border-bottom: ${({ isActive, tabTheme }): string =>
-    `.1rem solid var(${isActive ? tabTheme.activeBorder : tabTheme.inactiveBorder})`};
+    `.1rem solid ${isActive ? tabTheme.activeBorder : tabTheme.inactiveBorder}`};
 
   /* TODO: Provide alternative :focus styling because of using outline: 0; */
 
@@ -55,7 +54,7 @@ const TabItemWrapper = styled(TabItemBase)<TabItemWrapperProps>`
       `${!tabTheme.borderRadius ? '0' : 'var(--border-radius-default)'}`};
     border-bottom-right-radius: ${({ tabTheme }): string =>
       `${!tabTheme.borderRadius ? '0' : 'var(--border-radius-default)'}`};
-    ${({ isActive, tabTheme }): string | false => isActive && `background: var(${tabTheme.activeBgAlt});`}
+    ${({ isActive, tabTheme }): string | false => isActive && `background: ${tabTheme.activeBgAlt};`}
   }
 `
 

--- a/src/components/common/Tabs/TabItem.tsx
+++ b/src/components/common/Tabs/TabItem.tsx
@@ -1,21 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
-import { TabThemeType } from 'components/common/Tabs/Tabs'
+import { TabItemInterface, TabTheme } from 'components/common/Tabs/Tabs'
 import { ButtonBase } from '../Button'
 
-interface TabProps {
-  title: string
+interface TabProps extends Omit<TabItemInterface, 'content'> {
   isActive: boolean
-  readonly id: number
-  readonly count?: number
-  readonly tabTheme: TabThemeType
+  readonly tabTheme: TabTheme
   onTabClick: (id: number) => void
 }
 
-interface TabItemWrapperProps {
-  isActive: boolean
-  readonly tabTheme: TabThemeType
-}
+type TabItemWrapperProps = Pick<TabProps, 'isActive' | 'tabTheme'>
 
 const TabItemBase = styled(ButtonBase)`
   display: flex;
@@ -24,6 +18,7 @@ const TabItemBase = styled(ButtonBase)`
   justify-content: center;
 
   border: 0;
+  border-radius: 0;
   /* TODO: move this into baseStyles or sth similar */
   height: var(--height-button-default);
 
@@ -33,7 +28,7 @@ const TabItemBase = styled(ButtonBase)`
 `
 
 // TODO: replace with DefaultTheme and remove `var` approach
-// Make Tabs and TabItem it's own common component with theme
+// Make Tabs and TabItemBase it's own common component with theme
 const TabItemWrapper = styled(TabItemBase)<TabItemWrapperProps>`
   background: ${({ isActive, tabTheme }): string => `var(${isActive ? tabTheme.activeBg : tabTheme.inactiveBg})`};
   color: ${({ isActive, tabTheme }): string =>
@@ -65,7 +60,7 @@ const TabItemWrapper = styled(TabItemBase)<TabItemWrapperProps>`
 `
 
 const TabItem: React.FC<TabProps> = (props) => {
-  const { onTabClick, id, title, isActive, tabTheme } = props
+  const { onTabClick, id, tab, isActive, tabTheme } = props
 
   return (
     <TabItemWrapper
@@ -75,7 +70,7 @@ const TabItem: React.FC<TabProps> = (props) => {
       onClick={(): void => onTabClick(id)}
       tabTheme={tabTheme}
     >
-      {title}
+      {tab}
     </TabItemWrapper>
   )
 }

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -47,16 +47,16 @@ const Wrapper = styled.div`
 `
 
 export const DEFAULT_TAB_THEME: TabTheme = {
-  activeBg: '--color-transparent',
-  inactiveBg: '--color-transparent',
-  activeText: '--color-text-primary',
-  inactiveText: '--color-text-secondary2',
-  activeBorder: '--color-text-primary',
-  inactiveBorder: '--color-text-secondary2',
-  fontSize: '--font-size-default',
+  activeBg: 'var(--color-transparent)',
   activeBgAlt: 'initial',
+  inactiveBg: 'var(--color-transparent)',
+  activeText: 'var(--color-text-primary)',
+  inactiveText: 'var(--color-text-secondary2)',
+  activeBorder: 'var(--color-text-primary)',
+  inactiveBorder: 'none',
+  fontSize: 'var(--font-size-default)',
+  fontWeight: 'var(--font-weight-normal)',
   letterSpacing: 'initial',
-  fontWeight: 'normal',
   borderRadius: false,
 }
 

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -5,13 +5,15 @@ import styled from 'styled-components'
 import TabItem from 'components/common/Tabs/TabItem'
 import TabContent from 'components/common/Tabs/TabContent'
 
-export interface TabItemType {
-  readonly id: number
-  readonly title: string
+type TabId = number
+
+export interface TabItemInterface {
+  readonly tab: React.ReactNode
   readonly content: React.ReactNode
-  readonly count?: number
+  readonly id: TabId
 }
-export interface TabThemeType {
+
+export interface TabTheme {
   readonly activeBg: string
   readonly activeBgAlt: string
   readonly inactiveBg: string
@@ -25,8 +27,9 @@ export interface TabThemeType {
   readonly borderRadius: boolean
 }
 interface Props {
-  readonly tabItems: TabItemType[]
-  readonly tabTheme: TabThemeType
+  readonly tabItems: TabItemInterface[]
+  readonly tabTheme: TabTheme
+  readonly defaultTab?: TabId
 }
 
 const Wrapper = styled.div`
@@ -43,7 +46,7 @@ const Wrapper = styled.div`
   }
 `
 
-export const DEFAULT_TAB_THEME: TabThemeType = {
+export const DEFAULT_TAB_THEME: TabTheme = {
   activeBg: '--color-transparent',
   inactiveBg: '--color-transparent',
   activeText: '--color-text-primary',
@@ -58,22 +61,21 @@ export const DEFAULT_TAB_THEME: TabThemeType = {
 }
 
 const Tabs: React.FC<Props> = (props) => {
-  const { tabTheme = DEFAULT_TAB_THEME, tabItems } = props
+  const { tabTheme = DEFAULT_TAB_THEME, tabItems, defaultTab = 1 } = props
 
-  const [activeTab, setActiveTab] = useState(1)
+  const [activeTab, setActiveTab] = useState(defaultTab)
 
   return (
     <Wrapper>
       <div role="tablist" className="tablist">
-        {tabItems.map(({ id, title, count }) => (
+        {tabItems.map(({ tab, id }) => (
           <TabItem
             key={id}
             id={id}
-            title={title}
+            tab={tab}
             onTabClick={setActiveTab}
             isActive={activeTab === id}
             tabTheme={tabTheme}
-            count={count}
           />
         ))}
       </div>
@@ -84,7 +86,7 @@ const Tabs: React.FC<Props> = (props) => {
 
 export default Tabs
 
-export function getTabTheme(tabStyles: Partial<TabThemeType> = {}): TabThemeType {
+export function getTabTheme(tabStyles: Partial<TabTheme> = {}): TabTheme {
   return {
     ...DEFAULT_TAB_THEME,
     ...tabStyles,

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -12,17 +12,17 @@ export interface TabItemType {
   readonly count?: number
 }
 export interface TabThemeType {
-  readonly activeBg?: string
-  readonly activeBgAlt?: string
-  readonly inactiveBg?: string
-  readonly activeText?: string
-  readonly inactiveText?: string
-  readonly activeBorder?: string
-  readonly inactiveBorder?: string
-  readonly letterSpacing?: string
-  readonly fontWeight?: string
-  readonly fontSize?: string
-  readonly borderRadius?: boolean
+  readonly activeBg: string
+  readonly activeBgAlt: string
+  readonly inactiveBg: string
+  readonly activeText: string
+  readonly inactiveText: string
+  readonly activeBorder: string
+  readonly inactiveBorder: string
+  readonly letterSpacing: string
+  readonly fontWeight: string
+  readonly fontSize: string
+  readonly borderRadius: boolean
 }
 interface Props {
   readonly tabItems: TabItemType[]
@@ -43,28 +43,50 @@ const Wrapper = styled.div`
   }
 `
 
+export const DEFAULT_TAB_THEME: TabThemeType = {
+  activeBg: '--color-transparent',
+  inactiveBg: '--color-transparent',
+  activeText: '--color-text-primary',
+  inactiveText: '--color-text-secondary2',
+  activeBorder: '--color-text-primary',
+  inactiveBorder: '--color-text-secondary2',
+  fontSize: '--font-size-default',
+  activeBgAlt: 'initial',
+  letterSpacing: 'initial',
+  fontWeight: 'normal',
+  borderRadius: false,
+}
+
 const Tabs: React.FC<Props> = (props) => {
-  const [activeTab, setActiveTab] = useState<number>(1)
-  const { tabTheme } = props
+  const { tabTheme = DEFAULT_TAB_THEME, tabItems } = props
+
+  const [activeTab, setActiveTab] = useState(1)
 
   return (
     <Wrapper>
       <div role="tablist" className="tablist">
-        {props.tabItems.map(({ id, title, count }) => (
+        {tabItems.map(({ id, title, count }) => (
           <TabItem
             key={id}
             id={id}
             title={title}
-            onTabClick={(): void => setActiveTab(id)}
+            onTabClick={setActiveTab}
             isActive={activeTab === id}
             tabTheme={tabTheme}
             count={count}
           />
         ))}
       </div>
-      <TabContent tabItems={props.tabItems} activeTab={activeTab} />
+      <TabContent tabItems={tabItems} activeTab={activeTab} />
     </Wrapper>
   )
 }
 
 export default Tabs
+
+export function getTabTheme(tabStyles: Partial<TabThemeType> = {}): TabThemeType {
+  return {
+    ...DEFAULT_TAB_THEME,
+    ...tabStyles,
+  }
+}


### PR DESCRIPTION
Part of #41 

This is the first part, I am cleaning up the current implementation by Michel which is already very good. Best to do this now before PR gets bigger

Happy to take comments here but i dont see `common/Tabs` - the generic tab part being too different from the already implements `TabItem` file