### PR TITLE
[GP-V1::FIX] - use old MEDIA queries

### DIFF
--- a/src/components/trade/Price.tsx
+++ b/src/components/trade/Price.tsx
@@ -6,7 +6,7 @@ import { invertPrice } from '@gnosis.pm/dex-js'
 // types, utils
 import { TokenDetails } from 'types'
 import { parseBigNumber } from 'utils'
-import { DEFAULT_PRECISION } from 'const'
+import { DEFAULT_PRECISION, MEDIA } from 'const'
 
 // Components
 import { OrderBookBtn } from 'components/OrderBookBtn'
@@ -19,7 +19,6 @@ import { FormMessage } from 'components/common/FormMessage'
 import { TradeFormData } from 'components/TradeWidget'
 import { useNumberInput } from 'components/TradeWidget/useNumberInput'
 import { SwapPrice } from 'components/common/SwapPrice'
-import { applyMediaStyles } from 'theme'
 
 const Wrapper = styled.div`
   display: flex;
@@ -39,9 +38,9 @@ const Wrapper = styled.div`
     box-sizing: border-box;
     font-size: 1.5rem;
 
-    ${applyMediaStyles('upToSmall')`
+    @media ${MEDIA.mobile} {
       font-size: 1.3rem;
-    `}
+    }
 
     > ${FormMessage} {
       width: min-content;
@@ -71,10 +70,10 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
   position: relative;
   outline: 0;
 
-  ${applyMediaStyles('upToSmall')`
+  @media ${MEDIA.mobile} {
     width: 100%;
     margin: 0 0 1.6rem;
-  `}
+  }
 
   label {
     display: flex;
@@ -83,9 +82,9 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
     height: 5.6rem;
     position: relative;
 
-    ${applyMediaStyles('upToSmall')`
+    @media ${MEDIA.mobile} {
       width: 100%;
-    `}
+    }
   }
 
   label > div:not(.radio-container) {
@@ -105,10 +104,10 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
     text-align: right;
     font-weight: var(--font-weight-bold);
 
-    ${applyMediaStyles('upToSmall')`
+    @media ${MEDIA.mobile} {
       font-size: 1rem;
       letter-spacing: 0.03rem;
-    `}
+    }
 
     > small:nth-child(2) {
       margin: 0 0.3rem;
@@ -131,10 +130,10 @@ const PriceInputBox = styled.div<{ hidden?: boolean }>`
     padding: 0 15ch 0 1rem;
     outline: 0;
 
-    ${applyMediaStyles('upToSmall')`
+    @media ${MEDIA.mobile} {
       font-size: 1.3rem;
       width: 100%;
-    `}
+    }
 
     &:focus {
       border-bottom: 0.2rem solid var(--color-text-active);

--- a/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
@@ -9,7 +9,7 @@ import { PriceSuggestionItem } from 'components/trade/PriceSuggestions/PriceSugg
 import BigNumber from 'bignumber.js'
 import { TokenDex } from '@gnosis.pm/dex-js'
 import { isNonZeroNumber } from 'utils'
-import { applyMediaStyles } from 'theme'
+import { MEDIA } from 'const'
 
 export const PriceSuggestionsWrapper = styled.div`
   > div {
@@ -38,9 +38,9 @@ export const PriceSuggestionsWrapper = styled.div`
       margin-left: auto;
       font-size: 1.2rem;
 
-      ${applyMediaStyles('upToExtraSmall')`
+      @media ${MEDIA.xSmallDown} {
         display: flex;
-      `}
+      }
     }
   }
 
@@ -82,7 +82,7 @@ export const PriceSuggestionsWrapper = styled.div`
       }
     }
 
-    ${applyMediaStyles('upToExtraSmall')`
+    @media ${MEDIA.xSmallDown} {
       grid-auto-flow: row;
 
       > div {
@@ -98,7 +98,7 @@ export const PriceSuggestionsWrapper = styled.div`
           }
         }
       }
-    `}
+    }
   }
 `
 

--- a/src/hooks/useTabs.tsx
+++ b/src/hooks/useTabs.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 import useSafeState from 'hooks/useSafeState'
-import { applyMediaStyles } from 'theme'
+import { MEDIA } from 'const'
 
 const TabsWrapper = styled.div`
   margin: 0 auto;
@@ -13,9 +13,9 @@ const TabsWrapper = styled.div`
   border-bottom: 0.1rem solid var(--color-text-secondary);
   align-items: center;
 
-  ${applyMediaStyles('upToSmall')`
+  @media ${MEDIA.mobile} {
     margin: 0 auto;
-  `}
+  }
 
   .countContainer {
     display: flex;
@@ -60,25 +60,22 @@ const TabsWrapper = styled.div`
         margin: 0 0 0 0.5rem;
       }
 
-      ${applyMediaStyles('upToSmall')`
+      @media ${MEDIA.mobile} {
         flex: 1;
         font-size: 1.2rem;
         min-height: 5.4rem;
-
         > i {
           font-size: 0.9rem;
           height: 1.3rem;
           line-height: 1.36rem;
         }
-      `}
-
-      ${applyMediaStyles('upToExtraSmall')`
+      }
+      @media ${MEDIA.xSmallDown} {
         flex-flow: column nowrap;
-
         > i {
           margin: 0.3rem auto;
         }
-      `}
+      }
     }
 
     > button.selected {


### PR DESCRIPTION
Fixes broken media queries in gp-v1 due to using `applyMediaStyles` which requires `theme`