### PR TITLE
62/order details component

### DIFF
--- a/src/apps/explorer/components/OrderWidget/OrderDetails.tsx
+++ b/src/apps/explorer/components/OrderWidget/OrderDetails.tsx
@@ -1,0 +1,111 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+
+import { RawOrder } from 'api/operator'
+
+import { SimpleTable } from 'components/common/SimpleTable'
+
+const COLUMN_COLOR = '#252535'
+
+const Table = styled(SimpleTable)`
+  > tbody > tr {
+    grid-template-columns: minmax(10rem, 25rem) auto;
+
+    background: ${({ theme }): string => theme.bg2};
+    border-right: 0.1em solid;
+    border-color: ${COLUMN_COLOR};
+
+    :first-of-type {
+      /* border on top of the first row to close the table */
+      border-top: 0.1rem solid ${COLUMN_COLOR};
+    }
+
+    &:last-of-type {
+      /* Remove weird block at the end of the table */
+      margin: 0;
+    }
+
+    > td {
+      justify-content: flex-start;
+
+      :first-of-type {
+        /* First column same color as border */
+        background: ${COLUMN_COLOR};
+
+        /* Question mark */
+        > svg {
+          margin-right: 2rem;
+        }
+
+        /* Column after text on first column */
+        ::after {
+          content: ':';
+        }
+      }
+
+      height: 5rem;
+
+      :not(:first-of-type) {
+        padding-left: 2.5rem;
+      }
+    }
+  }
+`
+
+// TODO: either use a RichOrder object or transform it here
+// TODO: for that we'll need token info (decimals, symbol)
+export type Props = { order: RawOrder }
+
+export function OrderDetails(props: Props): JSX.Element {
+  const { order } = props
+  const { uid } = order
+
+  const questionMark = useMemo(() => <FontAwesomeIcon icon={faQuestionCircle} />, [])
+
+  return (
+    <Table
+      body={
+        <>
+          <tr>
+            <td>{questionMark}Order Id</td>
+            <td>{uid}</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Sell order</td>
+            <td>Swap 10 WETH for DAI</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Status</td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Fill Price</td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Filled</td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Submission Time</td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Limit Price</td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Expiration Time</td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td>{questionMark}Gas Fee</td>
+            <td>TODO</td>
+          </tr>
+        </>
+      }
+    />
+  )
+}

--- a/src/apps/explorer/components/OrderWidget/OrderDetails.tsx
+++ b/src/apps/explorer/components/OrderWidget/OrderDetails.tsx
@@ -7,6 +7,7 @@ import { RawOrder } from 'api/operator'
 
 import { SimpleTable } from 'components/common/SimpleTable'
 
+// TODO: move to theme AAAAND pick color for white variant
 const COLUMN_COLOR = '#252535'
 
 const Table = styled(SimpleTable)`

--- a/src/apps/explorer/components/OrderWidget/OrderDetails.tsx
+++ b/src/apps/explorer/components/OrderWidget/OrderDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
@@ -55,6 +55,9 @@ const Table = styled(SimpleTable)`
   }
 `
 
+// TODO: use tooltip component once we have tooltips
+const questionMark = <FontAwesomeIcon icon={faQuestionCircle} />
+
 // TODO: either use a RichOrder object or transform it here
 // TODO: for that we'll need token info (decimals, symbol)
 export type Props = { order: RawOrder }
@@ -62,8 +65,6 @@ export type Props = { order: RawOrder }
 export function OrderDetails(props: Props): JSX.Element {
   const { order } = props
   const { uid } = order
-
-  const questionMark = useMemo(() => <FontAwesomeIcon icon={faQuestionCircle} />, [])
 
   return (
     <Table

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -1,7 +1,19 @@
 import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
 import { useParams } from 'react-router'
 
 import { getOrder, RawOrder } from 'api/operator'
+
+import { OrderDetails } from './OrderDetails'
+
+// TODO: create a `View` component to abstract display elements away from logic/hooks
+const Wrapper = styled.div`
+  padding: 4rem 3rem;
+
+  > * {
+    margin-bottom: 2rem;
+  }
+`
 
 export const OrderWidget: React.FC = () => {
   const [order, setOrder] = useState<RawOrder | null>(null)
@@ -21,10 +33,12 @@ export const OrderWidget: React.FC = () => {
   }, [orderId])
 
   return (
-    <div>
-      <h1>Details for order id: {orderId}</h1>
-      {order && <p>{JSON.stringify(order)}</p>}
+    <Wrapper>
+      <h2>Order details</h2>
+      {order ? <OrderDetails order={order} /> : <p>Order not found</p>}
+      <h2>Order fills</h2>
+      <p>No fills</p>
       {error && <p>{error}</p>}
-    </div>
+    </Wrapper>
   )
 }

--- a/src/components/common/SimpleTable/index.stories.tsx
+++ b/src/components/common/SimpleTable/index.stories.tsx
@@ -107,3 +107,6 @@ CustomTableStyle.args = {
     </>
   ),
 }
+
+export const NoHeader = Template.bind({})
+NoHeader.args = { ...BasicTable.args, header: undefined }

--- a/src/components/common/SimpleTable/index.tsx
+++ b/src/components/common/SimpleTable/index.tsx
@@ -95,7 +95,7 @@ const Wrapper = styled.table<{ $numColumns?: number }>`
 `
 
 export type Props = {
-  header: JSX.Element
+  header?: JSX.Element
   body: JSX.Element
   className?: string
   numColumns?: number
@@ -103,7 +103,7 @@ export type Props = {
 
 export const SimpleTable = ({ header, body, className, numColumns }: Props): JSX.Element => (
   <Wrapper $numColumns={numColumns} className={className}>
-    <thead>{header}</thead>
+    {header && <thead>{header}</thead>}
     <tbody>{body}</tbody>
   </Wrapper>
 )


### PR DESCRIPTION
# Summary

Part of #62 

Depends on #89 (which depends on #83 and #82)

Implementing initial order details table UI from mocks https://www.figma.com/file/fVplwOLPOAvZrqVFbeKOtw/Explorer?node-id=0%3A1
Almost no functionality as of now, only the table visuals.

![screenshot_2021-01-25_15-01-56](https://user-images.githubusercontent.com/43217/105776871-3a7f2200-5f1e-11eb-8d0f-72940aa63953.png)

# Testing

Open the app and go to https://pr90--gpui.review.gnosisdev.com/order/whateverYouWantDoesntMatterRightNowItsMockedYay/