### PR TITLE
62/order status part2

### DIFF
--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -16,7 +16,7 @@ function isOrderFilled(order: RawOrder): boolean {
     executedAmount = new BigNumber(order.executedBuyAmount)
   } else {
     amount = new BigNumber(order.sellAmount)
-    executedAmount = new BigNumber(order.executedSellAmount)
+    executedAmount = new BigNumber(order.executedSellAmount).minus(order.executedFeeAmount)
   }
 
   const minimumAmount = amount.multipliedBy(ONE_BIG_NUMBER.minus(FILLED_ORDER_EPSILON))

--- a/test/api/OperatorApi/orderStatus.test.ts
+++ b/test/api/OperatorApi/orderStatus.test.ts
@@ -55,6 +55,19 @@ describe('Filled status', () => {
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
+    test('Filled, fee does not affect output', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'buy',
+        buyAmount: '100',
+        executedBuyAmount: '100',
+        sellAmount: '1000',
+        executedSellAmount: '1100',
+        executedFeeAmount: '100',
+      }
+
+      expect(getOrderStatus(order)).toEqual('filled')
+    })
   })
   describe('Sell order', () => {
     test('Filled, within epsilon', () => {
@@ -79,6 +92,17 @@ describe('Filled status', () => {
         sellAmount: '100',
         executedSellAmount: '100',
         validTo: _getCurrentTimestamp(),
+      }
+
+      expect(getOrderStatus(order)).toEqual('filled')
+    })
+    test('Filled, with fee', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '90',
+        executedSellAmount: '100',
+        executedFeeAmount: '10',
       }
 
       expect(getOrderStatus(order)).toEqual('filled')
@@ -126,6 +150,17 @@ describe('Partially filled status', () => {
   describe('Sell order', () => {
     test('Partially filled, on the border to be considered filled', () => {
       const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9998' }
+
+      expect(getOrderStatus(order)).toEqual('partially filled')
+    })
+    test('Partially filled, with fee, on the border to be considered filled', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '9000',
+        executedSellAmount: '9996',
+        executedFeeAmount: '998',
+      }
 
       expect(getOrderStatus(order)).toEqual('partially filled')
     })

--- a/test/api/OperatorApi/orderStatus.test.ts
+++ b/test/api/OperatorApi/orderStatus.test.ts
@@ -27,11 +27,6 @@ describe('Filled status', () => {
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
-    test('Filled, surplus', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', executedBuyAmount: '1001' }
-
-      expect(getOrderStatus(order)).toEqual('filled')
-    })
     test('Filled, not yet expired', () => {
       const order: RawOrder = {
         ...ORDER,
@@ -77,11 +72,6 @@ describe('Filled status', () => {
     })
     test('Filled, exact amount', () => {
       const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '100', executedSellAmount: '100' }
-
-      expect(getOrderStatus(order)).toEqual('filled')
-    })
-    test('Filled, surplus', () => {
-      const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '1000', executedSellAmount: '1001' }
 
       expect(getOrderStatus(order)).toEqual('filled')
     })


### PR DESCRIPTION
Follow up to https://github.com/gnosis/gp-ui/pull/97, part of #62 
Changes referring to comments, but the PR was approved and merged by Mergify before I could send them.

Short summary:
- Update filled status for sell order
- Update unit tests to reflect changes
- Remove surplus unit tests that are irrelevant for status calculation