### PR TITLE
62/order status component

### DIFF
--- a/src/api/operator/index.ts
+++ b/src/api/operator/index.ts
@@ -1,6 +1,7 @@
 import * as realApi from './operatorApi'
 import * as mockApi from './operatorMock'
 export * from './types'
+export * from './utils'
 
 const useMock = process.env.MOCK_OPERATOR === 'true'
 

--- a/src/components/order/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/order/StatusLabel/StatusLabel.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+
+import { StatusLabel, Props } from '.'
+
+export default {
+  title: 'Order/StatusLabel',
+  component: StatusLabel,
+  decorators: [GlobalStyles, ThemeToggler],
+} as Meta
+
+const Template: Story<Props> = (args) => <StatusLabel {...args} />
+
+export const Expired = Template.bind({})
+Expired.args = { status: 'expired' }
+
+export const Filled = Template.bind({})
+Filled.args = { status: 'filled' }
+export const PartiallyFilled = Template.bind({})
+PartiallyFilled.args = { status: 'partially filled' }
+export const Open = Template.bind({})
+Open.args = { status: 'open' }

--- a/src/components/order/StatusLabel/index.tsx
+++ b/src/components/order/StatusLabel/index.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheckCircle, faClock, faDotCircle } from '@fortawesome/free-solid-svg-icons'
+
+import { OrderStatus } from 'api/operator'
+
+export type Props = { status: OrderStatus }
+
+const Wrapper = styled.div<Props>`
+  font-size: ${({ theme }): string => theme.fontSizeNormal};
+  font-weight: ${({ theme }): string => theme.fontWeightBold};
+  text-transform: capitalize;
+
+  border-radius: 4px;
+
+  padding: 0.75em;
+  display: inline-block;
+
+  & > svg {
+    margin: 0 0.75rem 0 0;
+  }
+
+  ${({ theme, status }): string => {
+    // TODO: move all colors to theme
+    let background, color
+
+    switch (status) {
+      case 'expired':
+        color = '#DB843A'
+        background = 'rgba(219, 132, 58, 0.1)'
+        break
+      case 'filled':
+      case 'partially filled':
+        color = '#41C29B'
+        background = 'rgba(0, 216, 151, 0.1)'
+        break
+      case 'open':
+        // light theme
+        // color = '#77838F'
+        // background = 'rgba(119, 131, 143, 0.1)'
+        // dark theme
+        color = '#FFFFFF'
+        background = 'rgba(151, 151, 184, 0.3)'
+        break
+    }
+    return `
+      background: ${background};
+      color: ${color};
+    `
+  }}
+`
+
+export const StatusLabel = (props: Props): JSX.Element => {
+  const { status } = props
+
+  const icon = useMemo(() => {
+    switch (status) {
+      case 'expired':
+        return <FontAwesomeIcon icon={faClock} />
+      case 'filled':
+      case 'partially filled':
+        return <FontAwesomeIcon icon={faCheckCircle} />
+      case 'open':
+        return <FontAwesomeIcon icon={faDotCircle} />
+    }
+  }, [status])
+
+  return (
+    <Wrapper status={status}>
+      {icon}
+      {status}
+    </Wrapper>
+  )
+}

--- a/src/components/order/StatusLabel/index.tsx
+++ b/src/components/order/StatusLabel/index.tsx
@@ -22,26 +22,21 @@ const Wrapper = styled.div<Props>`
   }
 
   ${({ theme, status }): string => {
-    // TODO: move all colors to theme
     let background, color
 
     switch (status) {
       case 'expired':
-        color = '#DB843A'
-        background = 'rgba(219, 132, 58, 0.1)'
+        color = theme.labelTextExpired
+        background = theme.labelBgExpired
         break
       case 'filled':
       case 'partially filled':
-        color = '#41C29B'
-        background = 'rgba(0, 216, 151, 0.1)'
+        color = theme.labelTextFilled
+        background = theme.labelBgFilled
         break
       case 'open':
-        // light theme
-        // color = '#77838F'
-        // background = 'rgba(119, 131, 143, 0.1)'
-        // dark theme
-        color = '#FFFFFF'
-        background = 'rgba(151, 151, 184, 0.3)'
+        color = theme.labelTextOpen
+        background = theme.labelBgOpen
         break
     }
     return `

--- a/src/components/order/StatusLabel/index.tsx
+++ b/src/components/order/StatusLabel/index.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div<Props>`
   font-weight: ${({ theme }): string => theme.fontWeightBold};
   text-transform: capitalize;
 
-  border-radius: 4px;
+  border-radius: 0.4rem;
 
   padding: 0.75em;
   display: inline-block;

--- a/src/theme/styles/colours.ts
+++ b/src/theme/styles/colours.ts
@@ -19,6 +19,14 @@ export interface Colors {
   gradient1: Color
   gradient2: Color
 
+  // labels
+  labelTextOpen: Color
+  labelTextExpired: Color
+  labelTextFilled: Color
+  labelBgOpen: Color
+  labelBgExpired: Color
+  labelBgFilled: Color
+
   // Base
   white: Color
   black: Color
@@ -50,6 +58,12 @@ export const BASE_COLOURS = {
   yellow2: '#f1851d',
   blue1: '#2172E5',
   blue2: '#3F77FF',
+
+  // labels
+  labelTextExpired: '#DB843A',
+  labelTextFilled: '#41C29B',
+  labelBgExpired: '#DB843A1A',
+  labelBgFilled: '#00D8971A',
 }
 
 export const LIGHT_COLOURS = {
@@ -68,6 +82,10 @@ export const LIGHT_COLOURS = {
   // gradients
   gradient1: '#8958FF',
   gradient2: '#3F77FF',
+
+  // labels
+  labelTextOpen: '#77838F',
+  labelBgOpen: '#77838F1A',
 }
 
 export const DARK_COLOURS = {
@@ -86,6 +104,10 @@ export const DARK_COLOURS = {
   // gradients
   gradient1: '#21222E',
   gradient2: '#2C2D3F',
+
+  // labels
+  labelTextOpen: '#FFFFFF',
+  labelBgOpen: '#9797B84D',
 
   // TODO: add to theme, not colour palette
   // gradientForm1: 'linear-gradient(270deg, #8958FF 0%, #3F77FF 100%)',


### PR DESCRIPTION
# Summary

Part of #62

Implemented order status component as per [design](https://www.figma.com/file/zcWhLymqovrJ4Lj1v9FoSI/GP-Explorer?node-id=0%3A1):
![screenshot_2021-02-02_15-09-50](https://user-images.githubusercontent.com/43217/106674758-b86baa80-6568-11eb-8e37-539eee472d88.png)

# Testing
Check orderbook https://pr104--gpui.review.gnosisdev.com/storybook/?path=/docs/order-statuslabel--expired
