### PR TITLE
62/order util fns

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -15,6 +15,8 @@ export interface FeeInformation {
 
 export type OrderKind = 'sell' | 'buy'
 
+export type OrderStatus = 'open' | 'filled' | 'expired' | 'partially filled'
+
 // Raw API response
 export type RawOrder = {
   creationDate: string

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 
 import { calculatePrice, invertPrice } from '@gnosis.pm/dex-js'
 
-import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER } from 'const'
+import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
 import { OrderStatus, RawOrder } from './types'
 
@@ -131,6 +131,12 @@ export function getOrderExecutedPrice({
   inverted,
 }: GetOrderPriceParams): BigNumber {
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
+
+  // Only calculate the price when both values are set
+  // Having only one value > 0 is anyway an invalid state
+  if (executedBuyAmount.isZero() || executedSellAmount.isZero()) {
+    return ZERO_BIG_NUMBER
+  }
 
   const price = calculatePrice({
     numerator: { amount: executedBuyAmount, decimals: buyTokenDecimals },

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -65,9 +65,7 @@ export function getOrderFilledAmount(order: RawOrder): { amount: BigNumber; perc
     totalAmount = new BigNumber(order.sellAmount)
   }
 
-  const percentage = executedAmount.isZero() ? executedAmount : executedAmount.div(totalAmount)
-
-  return { amount: executedAmount, percentage }
+  return { amount: executedAmount, percentage: executedAmount.div(totalAmount) }
 }
 
 /**

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -1,10 +1,10 @@
 // Util functions that only pertain to/deal with operator API related stuff
-
 import BigNumber from 'bignumber.js'
 
-import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER } from 'const'
+import { calculatePrice, invertPrice } from '@gnosis.pm/dex-js'
 
 import { RawOrder } from './types'
+import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER } from 'const'
 
 export type OrderStatus = 'open' | 'filled' | 'expired' | 'partially filled'
 
@@ -84,4 +84,33 @@ export function getOrderExecutedAmounts(
     executedBuyAmount: new BigNumber(order.executedBuyAmount),
     executedSellAmount: new BigNumber(order.executedSellAmount).minus(order.executedFeeAmount),
   }
+}
+
+type GetOrderLimitPriceParams = {
+  order: RawOrder
+  buyTokenDecimals: number
+  sellTokenDecimals: number
+  inverted?: boolean
+}
+
+/**
+ * Calculates order limit price base on order and buy/sell token decimals
+ * Result is given in sell token units
+ *
+ * @param order The order
+ * @param buyTokenDecimals The buy token decimals
+ * @param sellTokenDecimals The sell token decimals
+ */
+export function getOrderLimitPrice({
+  order,
+  buyTokenDecimals,
+  sellTokenDecimals,
+  inverted,
+}: GetOrderLimitPriceParams): BigNumber {
+  const price = calculatePrice({
+    numerator: { amount: order.buyAmount, decimals: buyTokenDecimals },
+    denominator: { amount: order.sellAmount, decimals: sellTokenDecimals },
+  })
+
+  return inverted ? invertPrice(price) : price
 }

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -86,7 +86,7 @@ export function getOrderExecutedAmounts(
   }
 }
 
-type GetOrderLimitPriceParams = {
+export type GetOrderPriceParams = {
   order: RawOrder
   buyTokenDecimals: number
   sellTokenDecimals: number
@@ -100,16 +100,42 @@ type GetOrderLimitPriceParams = {
  * @param order The order
  * @param buyTokenDecimals The buy token decimals
  * @param sellTokenDecimals The sell token decimals
+ * @param inverted Optional. Whether to invert the price (1/price).
  */
 export function getOrderLimitPrice({
   order,
   buyTokenDecimals,
   sellTokenDecimals,
   inverted,
-}: GetOrderLimitPriceParams): BigNumber {
+}: GetOrderPriceParams): BigNumber {
   const price = calculatePrice({
     numerator: { amount: order.buyAmount, decimals: buyTokenDecimals },
     denominator: { amount: order.sellAmount, decimals: sellTokenDecimals },
+  })
+
+  return inverted ? invertPrice(price) : price
+}
+
+/**
+ * Calculates order executed price base on order and buy/sell token decimals
+ * Result is given in sell token units
+ *
+ * @param order The order
+ * @param buyTokenDecimals The buy token decimals
+ * @param sellTokenDecimals The sell token decimals
+ * @param inverted Optional. Whether to invert the price (1/price).
+ */
+export function getOrderExecutedPrice({
+  order,
+  buyTokenDecimals,
+  sellTokenDecimals,
+  inverted,
+}: GetOrderPriceParams): BigNumber {
+  const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
+
+  const price = calculatePrice({
+    numerator: { amount: executedBuyAmount, decimals: buyTokenDecimals },
+    denominator: { amount: executedSellAmount, decimals: sellTokenDecimals },
   })
 
   return inverted ? invertPrice(price) : price

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -49,3 +49,24 @@ export function getOrderStatus(order: RawOrder): OrderStatus {
     return 'open'
   }
 }
+
+/**
+ * Get order filled amount, both as raw amount (in atoms) and as percentage (from 0 to 1)
+ *
+ * @param order The order
+ */
+export function getOrderFilledAmount(order: RawOrder): { amount: BigNumber; percentage: BigNumber } {
+  let executedAmount, totalAmount
+
+  if (order.kind === 'buy') {
+    executedAmount = new BigNumber(order.executedBuyAmount)
+    totalAmount = new BigNumber(order.buyAmount)
+  } else {
+    executedAmount = new BigNumber(order.executedSellAmount).minus(order.executedFeeAmount)
+    totalAmount = new BigNumber(order.sellAmount)
+  }
+
+  const percentage = executedAmount.isZero() ? executedAmount : executedAmount.div(totalAmount)
+
+  return { amount: executedAmount, percentage }
+}

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -70,3 +70,18 @@ export function getOrderFilledAmount(order: RawOrder): { amount: BigNumber; perc
 
   return { amount: executedAmount, percentage }
 }
+
+/**
+ * Syntactic sugar to get the order's executed amounts as a BigNumber (in atoms)
+ * Mostly because `executedSellAmount` is derived from 2 fields (at time or writing)
+ *
+ * @param order The order
+ */
+export function getOrderExecutedAmounts(
+  order: RawOrder,
+): { executedBuyAmount: BigNumber; executedSellAmount: BigNumber } {
+  return {
+    executedBuyAmount: new BigNumber(order.executedBuyAmount),
+    executedSellAmount: new BigNumber(order.executedSellAmount).minus(order.executedFeeAmount),
+  }
+}

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -3,10 +3,9 @@ import BigNumber from 'bignumber.js'
 
 import { calculatePrice, invertPrice } from '@gnosis.pm/dex-js'
 
-import { RawOrder } from './types'
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER } from 'const'
 
-export type OrderStatus = 'open' | 'filled' | 'expired' | 'partially filled'
+import { OrderStatus, RawOrder } from './types'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount

--- a/test/api/OperatorApi/orderFilledAmount.test.ts
+++ b/test/api/OperatorApi/orderFilledAmount.test.ts
@@ -1,0 +1,138 @@
+import BigNumber from 'bignumber.js'
+
+import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
+
+import { RawOrder } from 'api/operator'
+import { getOrderFilledAmount } from 'api/operator/utils'
+
+import { ORDER } from '../../../test/data'
+
+const TEN_PERCENT = new BigNumber('0.1')
+const ONE_HUNDRED_PERCENT = ONE_BIG_NUMBER
+
+describe('Order not filled', () => {
+  describe('Buy order', () => {
+    test('0% filled', () => {
+      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '0' }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
+    })
+  })
+  describe('Sell order', () => {
+    test('0% filled', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '100',
+        executedSellAmount: '0',
+        executedFeeAmount: '0',
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
+    })
+  })
+})
+
+describe('Order partially filled', () => {
+  describe('Buy order', () => {
+    test('10% filled', () => {
+      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '10' }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
+    })
+  })
+  describe('Sell order', () => {
+    test('10% filled, without fee', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '100',
+        executedSellAmount: '10',
+        executedFeeAmount: '0',
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
+    })
+    test('10% filled, with fee', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '100',
+        executedSellAmount: '11',
+        executedFeeAmount: '1',
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
+    })
+  })
+})
+
+describe('Order filled', () => {
+  describe('Buy order', () => {
+    test('100% filled, no surplus', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'buy',
+        buyAmount: '100',
+        executedBuyAmount: '100',
+        sellAmount: '100',
+        executedSellAmount: '100',
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
+    })
+    test('100% filled, with surplus', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'buy',
+        buyAmount: '100',
+        executedBuyAmount: '100',
+        sellAmount: '100',
+        executedSellAmount: '90', // sold less for the same buy amount
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
+    })
+  })
+  describe('Sell order', () => {
+    test('100% filled, no surplus, no fee', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '100',
+        executedSellAmount: '100',
+        executedFeeAmount: '0',
+        buyAmount: '100',
+        executedBuyAmount: '100',
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
+    })
+    test('100% filled, with fee', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '100',
+        executedSellAmount: '110',
+        executedFeeAmount: '10',
+        buyAmount: '100',
+        executedBuyAmount: '100',
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
+    })
+    test('100% filled, with surplus', () => {
+      const order: RawOrder = {
+        ...ORDER,
+        kind: 'sell',
+        sellAmount: '100',
+        executedSellAmount: '100',
+        executedFeeAmount: '0',
+        buyAmount: '100',
+        executedBuyAmount: '110', // bought more for the same sell amount
+      }
+
+      expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
+    })
+  })
+})

--- a/test/api/OperatorApi/orderLimitPrice.test.ts
+++ b/test/api/OperatorApi/orderLimitPrice.test.ts
@@ -1,0 +1,48 @@
+import BigNumber from 'bignumber.js'
+
+import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
+
+import { RawOrder } from 'api/operator'
+import { getOrderLimitPrice } from 'api/operator/utils'
+
+import { ORDER } from '../../data'
+
+const ZERO_DOT_ONE = new BigNumber('0.1')
+
+describe('Buy order', () => {
+  const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
+
+  test('Buy token decimals == sell token decimals', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(TEN_BIG_NUMBER)
+  })
+  test('Buy token decimals > sell token decimals', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 1 })).toEqual(ONE_BIG_NUMBER)
+  })
+  test('Buy token decimals < sell token decimals', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 1, sellTokenDecimals: 2 })).toEqual(ONE_HUNDRED_BIG_NUMBER)
+  })
+  test('Inverted price', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(
+      ZERO_DOT_ONE,
+    )
+  })
+})
+
+describe('Sell order', () => {
+  const order: RawOrder = { ...ORDER, kind: 'sell', buyAmount: '1000', sellAmount: '100' }
+
+  test('Buy token decimals == sell token decimals', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(TEN_BIG_NUMBER)
+  })
+  test('Buy token decimals > sell token decimals', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 1 })).toEqual(ONE_BIG_NUMBER)
+  })
+  test('Buy token decimals < sell token decimals', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 1, sellTokenDecimals: 2 })).toEqual(ONE_HUNDRED_BIG_NUMBER)
+  })
+  test('Inverted price', () => {
+    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(
+      ZERO_DOT_ONE,
+    )
+  })
+})

--- a/test/api/OperatorApi/orderPrice.test.ts
+++ b/test/api/OperatorApi/orderPrice.test.ts
@@ -3,37 +3,63 @@ import BigNumber from 'bignumber.js'
 import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
 
 import { RawOrder } from 'api/operator'
-import { getOrderLimitPrice } from 'api/operator/utils'
+import { getOrderExecutedPrice, getOrderLimitPrice, GetOrderPriceParams } from 'api/operator/utils'
 
 import { ORDER } from '../../data'
 
 const ZERO_DOT_ONE = new BigNumber('0.1')
 
-function _assertOrderPrice(order: RawOrder): void {
+function _assertOrderPrice(order: RawOrder, getPriceFn: (params: GetOrderPriceParams) => BigNumber): void {
   test('Buy token decimals == sell token decimals', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(TEN_BIG_NUMBER)
+    expect(getPriceFn({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(TEN_BIG_NUMBER)
   })
   test('Buy token decimals > sell token decimals', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 1 })).toEqual(ONE_BIG_NUMBER)
+    expect(getPriceFn({ order, buyTokenDecimals: 2, sellTokenDecimals: 1 })).toEqual(ONE_BIG_NUMBER)
   })
   test('Buy token decimals < sell token decimals', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 1, sellTokenDecimals: 2 })).toEqual(ONE_HUNDRED_BIG_NUMBER)
+    expect(getPriceFn({ order, buyTokenDecimals: 1, sellTokenDecimals: 2 })).toEqual(ONE_HUNDRED_BIG_NUMBER)
   })
   test('Inverted price', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(
-      ZERO_DOT_ONE,
-    )
+    expect(getPriceFn({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(ZERO_DOT_ONE)
   })
 }
 
-describe('Buy order', () => {
-  const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
+describe('Limit price', () => {
+  describe('Buy order', () => {
+    const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
 
-  _assertOrderPrice(order)
+    _assertOrderPrice(order, getOrderLimitPrice)
+  })
+
+  describe('Sell order', () => {
+    const order: RawOrder = { ...ORDER, kind: 'sell', buyAmount: '1000', sellAmount: '100' }
+
+    _assertOrderPrice(order, getOrderLimitPrice)
+  })
 })
 
-describe('Sell order', () => {
-  const order: RawOrder = { ...ORDER, kind: 'sell', buyAmount: '1000', sellAmount: '100' }
+describe('Executed price', () => {
+  describe('Buy order', () => {
+    const order: RawOrder = {
+      ...ORDER,
+      kind: 'buy',
+      executedBuyAmount: '1000',
+      executedSellAmount: '110',
+      executedFeeAmount: '10',
+    }
 
-  _assertOrderPrice(order)
+    _assertOrderPrice(order, getOrderExecutedPrice)
+  })
+
+  describe('Sell order', () => {
+    const order: RawOrder = {
+      ...ORDER,
+      kind: 'sell',
+      executedBuyAmount: '1000',
+      executedSellAmount: '110',
+      executedFeeAmount: '10',
+    }
+
+    _assertOrderPrice(order, getOrderExecutedPrice)
+  })
 })

--- a/test/api/OperatorApi/orderPrice.test.ts
+++ b/test/api/OperatorApi/orderPrice.test.ts
@@ -9,9 +9,7 @@ import { ORDER } from '../../data'
 
 const ZERO_DOT_ONE = new BigNumber('0.1')
 
-describe('Buy order', () => {
-  const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
-
+function _assertOrderPrice(order: RawOrder): void {
   test('Buy token decimals == sell token decimals', () => {
     expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(TEN_BIG_NUMBER)
   })
@@ -26,23 +24,16 @@ describe('Buy order', () => {
       ZERO_DOT_ONE,
     )
   })
+}
+
+describe('Buy order', () => {
+  const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
+
+  _assertOrderPrice(order)
 })
 
 describe('Sell order', () => {
   const order: RawOrder = { ...ORDER, kind: 'sell', buyAmount: '1000', sellAmount: '100' }
 
-  test('Buy token decimals == sell token decimals', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(TEN_BIG_NUMBER)
-  })
-  test('Buy token decimals > sell token decimals', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 1 })).toEqual(ONE_BIG_NUMBER)
-  })
-  test('Buy token decimals < sell token decimals', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 1, sellTokenDecimals: 2 })).toEqual(ONE_HUNDRED_BIG_NUMBER)
-  })
-  test('Inverted price', () => {
-    expect(getOrderLimitPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(
-      ZERO_DOT_ONE,
-    )
-  })
+  _assertOrderPrice(order)
 })

--- a/test/api/OperatorApi/orderPrice.test.ts
+++ b/test/api/OperatorApi/orderPrice.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 
-import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
+import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
 import { RawOrder } from 'api/operator'
 import { getOrderExecutedPrice, getOrderLimitPrice, GetOrderPriceParams } from 'api/operator/utils'
@@ -21,6 +21,23 @@ function _assertOrderPrice(order: RawOrder, getPriceFn: (params: GetOrderPricePa
   })
   test('Inverted price', () => {
     expect(getPriceFn({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(ZERO_DOT_ONE)
+  })
+}
+
+function _assertOrderPriceWithoutFills(_order: RawOrder): void {
+  const order = {
+    ..._order,
+    executedBuyAmount: '0',
+    executedSellAmount: '0',
+    executedFeeAmount: '0',
+  }
+  test('Regular', () => {
+    expect(getOrderExecutedPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2 })).toEqual(ZERO_BIG_NUMBER)
+  })
+  test('Inverted price', () => {
+    expect(getOrderExecutedPrice({ order, buyTokenDecimals: 2, sellTokenDecimals: 2, inverted: true })).toEqual(
+      ZERO_BIG_NUMBER,
+    )
   })
 }
 
@@ -48,7 +65,12 @@ describe('Executed price', () => {
       executedFeeAmount: '10',
     }
 
-    _assertOrderPrice(order, getOrderExecutedPrice)
+    describe('With fills', () => {
+      _assertOrderPrice(order, getOrderExecutedPrice)
+    })
+    describe('Without fills', () => {
+      _assertOrderPriceWithoutFills(order)
+    })
   })
 
   describe('Sell order', () => {
@@ -60,6 +82,11 @@ describe('Executed price', () => {
       executedFeeAmount: '10',
     }
 
-    _assertOrderPrice(order, getOrderExecutedPrice)
+    describe('With fills', () => {
+      _assertOrderPrice(order, getOrderExecutedPrice)
+    })
+    describe('Without fills', () => {
+      _assertOrderPriceWithoutFills(order)
+    })
   })
 })


### PR DESCRIPTION
# Summary

Part of #62 

Small util functions to be used when dealing with orders
- `getOrderFilledAmount` 
  Returns filed amount per order both as raw amount and as a percentage. Will be useful for the percentage and filled part of:
![screenshot_2021-02-03_13-44-08](https://user-images.githubusercontent.com/43217/106813512-efec5c80-6625-11eb-9638-8081133f18e8.png)
  Has unit tests

- `getOrderExecutedAmounts`
  Returns both buy/sell executed amounts as BigNumber. Will be useful anywhere we need to use executed amounts (the right most value in the picture above)
  Syntactic sugar because `executedSellAmount` is derived
  No unit tests (too dumb to deserve one)

- `getOrderLimitPrice`
  Returns order limit price.
  Optionally returns the price inverted:
![screenshot_2021-02-03_14-55-08](https://user-images.githubusercontent.com/43217/106820212-cfc19b00-662f-11eb-9a83-30753adc7975.png)
  Has unit tests

- `getOrderExecutedPrice`
  Same as the previous, except that it returns the price for executed amounts. 
  Not in the UI AFAICT, but I'm sure we'll need it.
  Has unit tests