### PR TITLE
66/split global state

### DIFF
--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -6,7 +6,7 @@ import { withGlobalContext } from 'hooks/useGlobalState'
 import useNetworkCheck from 'hooks/useNetworkCheck'
 import Console from 'Console'
 import { GlobalModalInstance } from 'components/OuterModal'
-import { rootReducer, INITIAL_STATE } from 'reducers-actions'
+import { rootReducer, INITIAL_STATE } from 'apps/explorer/state'
 
 import { GenericLayout } from 'components/layout'
 import { Navigation } from 'components/layout/GenericLayout/Navigation'

--- a/src/apps/explorer/state.ts
+++ b/src/apps/explorer/state.ts
@@ -1,0 +1,12 @@
+import { GlobalState, GLOBAL_INITIAL_STATE, globalRootReducer } from 'reducers-actions'
+import combineReducers from 'combine-reducers'
+
+export type ExplorerAppState = GlobalState
+
+export const INITIAL_STATE = (): ExplorerAppState => ({
+  ...GLOBAL_INITIAL_STATE(),
+})
+
+export const rootReducer = combineReducers({
+  ...globalRootReducer,
+})

--- a/src/apps/gp-v1/GpV1App.tsx
+++ b/src/apps/gp-v1/GpV1App.tsx
@@ -113,7 +113,7 @@ function getInitialUrl(): string {
 const Router: typeof BrowserRouter & typeof HashRouter = (window as any).IS_IPFS ? HashRouter : BrowserRouter
 const initialUrl = getInitialUrl()
 
-export const SwapAppV1: React.FC = () => {
+export const GpV1App: React.FC = () => {
   // Deal with incorrect network
   useNetworkCheck()
 
@@ -149,7 +149,7 @@ export const SwapAppV1: React.FC = () => {
 
 export default hot(
   withGlobalContext(
-    SwapAppV1,
+    GpV1App,
     // Initial State
     INITIAL_STATE,
     rootReducer,

--- a/src/apps/gp-v1/SwapAppV1.tsx
+++ b/src/apps/gp-v1/SwapAppV1.tsx
@@ -13,7 +13,7 @@ import { ToastContainer } from 'setupToastify'
 import Console from 'Console'
 import { GlobalModalInstance } from 'components/OuterModal'
 import { LegacyTradeLayout } from 'components/layout'
-import { rootReducer, INITIAL_STATE } from 'reducers-actions'
+import { rootReducer, INITIAL_STATE } from 'apps/gp-v1/state'
 
 // Pages
 const About = React.lazy(

--- a/src/apps/gp-v1/index.tsx
+++ b/src/apps/gp-v1/index.tsx
@@ -3,7 +3,7 @@ import 'react-hot-loader'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import SwapAppV1 from './SwapAppV1'
+import GpV1App from './GpV1App'
 
 const root = document.getElementById('root')
-ReactDOM.render(<SwapAppV1 />, root)
+ReactDOM.render(<GpV1App />, root)

--- a/src/apps/gp-v1/state.ts
+++ b/src/apps/gp-v1/state.ts
@@ -1,0 +1,57 @@
+import { GlobalState, GLOBAL_INITIAL_STATE, globalRootReducer, addSideEffect } from 'reducers-actions'
+import { reducer as TokenRowReducer, TokenLocalState, TokenRowInitialState as tokens } from 'reducers-actions/tokenRow'
+import {
+  reducer as PendingOrderReducer,
+  PendingOrdersState,
+  PendingOrdersInitialState as pendingOrders,
+  sideEffect as PendingOrdersSideEffect,
+} from 'reducers-actions/pendingOrders'
+import {
+  reducer as OrdersReducer,
+  OrdersState,
+  INITIAL_ORDERS_STATE as orders,
+  sideEffect as OrdersSideEffect,
+} from 'reducers-actions/orders'
+import { reducer as TradeReducer, TradeState, INITIAL_TRADE_STATE as trade } from 'reducers-actions/trade'
+import {
+  reducer as TradesReducer,
+  TradesState,
+  initialState as trades,
+  sideEffect as TradesSideEffect,
+} from 'reducers-actions/trades'
+import {
+  reducer as LocalTokensReducer,
+  LocalTokensState,
+  INITIAL_LOCAL_TOKENS_STATE as localTokens,
+  sideEffect as LocalTokensSideEffect,
+} from 'reducers-actions/localTokens'
+import combineReducers from 'combine-reducers'
+
+export interface GpV1AppState extends GlobalState {
+  tokens: TokenLocalState
+  pendingOrders: PendingOrdersState
+  orders: OrdersState
+  trade: TradeState
+  trades: TradesState
+  localTokens: LocalTokensState
+}
+
+export const INITIAL_STATE = (): GpV1AppState => ({
+  ...GLOBAL_INITIAL_STATE(),
+  tokens,
+  pendingOrders,
+  orders,
+  trade,
+  trades,
+  localTokens,
+})
+
+export const rootReducer = combineReducers({
+  ...globalRootReducer,
+  tokens: TokenRowReducer,
+  pendingOrders: addSideEffect(PendingOrderReducer, PendingOrdersSideEffect),
+  orders: addSideEffect(OrdersReducer, OrdersSideEffect),
+  trade: TradeReducer,
+  trades: addSideEffect(TradesReducer, TradesSideEffect),
+  localTokens: addSideEffect(LocalTokensReducer, LocalTokensSideEffect),
+})

--- a/src/apps/trade/TradeApp.tsx
+++ b/src/apps/trade/TradeApp.tsx
@@ -7,7 +7,7 @@ import { withGlobalContext } from 'hooks/useGlobalState'
 import useNetworkCheck from 'hooks/useNetworkCheck'
 import Console from 'Console'
 import { GlobalModalInstance } from 'components/OuterModal'
-import { rootReducer, INITIAL_STATE } from 'reducers-actions'
+import { rootReducer, INITIAL_STATE } from 'apps/trade/state'
 
 import { GenericLayout } from 'components/layout'
 import { Navigation } from 'components/layout/GenericLayout/Navigation'

--- a/src/apps/trade/state.ts
+++ b/src/apps/trade/state.ts
@@ -1,0 +1,12 @@
+import { GlobalState, GLOBAL_INITIAL_STATE, globalRootReducer } from 'reducers-actions'
+import combineReducers from 'combine-reducers'
+
+export type TradeAppState = GlobalState
+
+export const INITIAL_STATE = (): TradeAppState => ({
+  ...GLOBAL_INITIAL_STATE(),
+})
+
+export const rootReducer = combineReducers({
+  ...globalRootReducer,
+})

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -30,7 +30,8 @@ import { useEthBalances } from 'hooks/useEthBalance'
 import useDataFilter from 'hooks/useDataFilter'
 
 // Reducer/Actions
-import { GlobalState, TokenLocalState } from 'reducers-actions'
+import { GpV1AppState } from 'apps/gp-v1/state'
+import { TokenLocalState } from 'reducers-actions'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { web3 } from 'apps/gp-v1/api'
 
@@ -261,7 +262,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const { networkIdOrDefault } = useWalletConnection()
   const windowSpecs = useWindowSizes()
 
-  const [{ localTokens }] = useGlobalState<GlobalState>()
+  const [{ localTokens }] = useGlobalState<GpV1AppState>()
 
   const memoizedSearchFilterParams = useMemo(
     () => ({
@@ -395,7 +396,7 @@ const DepositWidget: React.FC = () => {
   // get all token balances, including deprecated
   const { balances: allBalances, error } = useTokenBalances()
 
-  const [{ localTokens }] = useGlobalState<GlobalState>()
+  const [{ localTokens }] = useGlobalState<GpV1AppState>()
 
   const balances = useMemo(() => {
     return allBalances.filter((bal) => !localTokens.disabled.has(bal.address))

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -30,7 +30,7 @@ import { useEthBalances } from 'hooks/useEthBalance'
 import useDataFilter from 'hooks/useDataFilter'
 
 // Reducer/Actions
-import { TokenLocalState } from 'reducers-actions'
+import { GlobalState, TokenLocalState } from 'reducers-actions'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { web3 } from 'apps/gp-v1/api'
 
@@ -261,7 +261,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const { networkIdOrDefault } = useWalletConnection()
   const windowSpecs = useWindowSizes()
 
-  const [{ localTokens }] = useGlobalState()
+  const [{ localTokens }] = useGlobalState<GlobalState>()
 
   const memoizedSearchFilterParams = useMemo(
     () => ({
@@ -395,7 +395,7 @@ const DepositWidget: React.FC = () => {
   // get all token balances, including deprecated
   const { balances: allBalances, error } = useTokenBalances()
 
-  const [{ localTokens }] = useGlobalState()
+  const [{ localTokens }] = useGlobalState<GlobalState>()
 
   const balances = useMemo(() => {
     return allBalances.filter((bal) => !localTokens.disabled.has(bal.address))

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -1,13 +1,12 @@
 import React, { useContext, useReducer } from 'react'
-import { GlobalState } from 'reducers-actions'
 import { AnyAction } from 'combine-reducers'
 
 const GlobalStateContext = React.createContext({})
 
-export function withGlobalContext<P>(
+export function withGlobalContext<P, State>(
   WrappedComponent: React.FC<P>,
-  initialStateFunc: () => GlobalState,
-  reducer: React.Reducer<GlobalState, AnyAction>,
+  initialStateFunc: () => State,
+  reducer: React.Reducer<State, AnyAction>,
 ): (props: P) => JSX.Element {
   return function WrappedComponentWithGlobalState(props: P): JSX.Element {
     const [state, dispatch] = useReducer(reducer, initialStateFunc())
@@ -20,7 +19,8 @@ export function withGlobalContext<P>(
   }
 }
 
-const useGlobalState = (): [globalState: GlobalState, dispatch: React.Dispatch<AnyAction>] =>
-  useContext(GlobalStateContext) as [GlobalState, React.Dispatch<AnyAction>]
+function useGlobalState<State>(): [globalState: State, dispatch: React.Dispatch<AnyAction>] {
+  return useContext(GlobalStateContext) as [State, React.Dispatch<AnyAction>]
+}
 
 export default useGlobalState

--- a/src/hooks/useManageTokens.tsx
+++ b/src/hooks/useManageTokens.tsx
@@ -9,6 +9,7 @@ import { useDebounce } from './useDebounce'
 import searchIcon from 'assets/img/search.svg'
 import { useBetterAddTokenModal, UseAddTokenModalResult } from './useBetterAddTokenModal'
 import useGlobalState from 'hooks/useGlobalState'
+import { GlobalState } from 'reducers-actions'
 import { updateLocalTokens } from 'reducers-actions/localTokens'
 import { Toggle } from 'components/Toggle'
 
@@ -194,7 +195,7 @@ const ManageTokensContainer: React.FC = () => {
     [tokensShown, setDebouncedSearch],
   )
 
-  const [{ localTokens }, dispatch] = useGlobalState()
+  const [{ localTokens }, dispatch] = useGlobalState<GlobalState>()
 
   const [tokensDisabledState, setDisabledTokens] = useState(localTokens.disabled)
   const disabledTokensRef = useRef<typeof localTokens.disabled>(localTokens.disabled)

--- a/src/hooks/useManageTokens.tsx
+++ b/src/hooks/useManageTokens.tsx
@@ -9,7 +9,7 @@ import { useDebounce } from './useDebounce'
 import searchIcon from 'assets/img/search.svg'
 import { useBetterAddTokenModal, UseAddTokenModalResult } from './useBetterAddTokenModal'
 import useGlobalState from 'hooks/useGlobalState'
-import { GlobalState } from 'reducers-actions'
+import { GpV1AppState } from 'apps/gp-v1/state'
 import { updateLocalTokens } from 'reducers-actions/localTokens'
 import { Toggle } from 'components/Toggle'
 
@@ -195,7 +195,7 @@ const ManageTokensContainer: React.FC = () => {
     [tokensShown, setDebouncedSearch],
   )
 
-  const [{ localTokens }, dispatch] = useGlobalState<GlobalState>()
+  const [{ localTokens }, dispatch] = useGlobalState<GpV1AppState>()
 
   const [tokensDisabledState, setDisabledTokens] = useState(localTokens.disabled)
   const disabledTokensRef = useRef<typeof localTokens.disabled>(localTokens.disabled)

--- a/src/hooks/usePendingOrders.ts
+++ b/src/hooks/usePendingOrders.ts
@@ -6,7 +6,7 @@ import useGlobalState from './useGlobalState'
 import useSafeState from './useSafeState'
 import { useWalletConnection } from './useWalletConnection'
 // Reducers/Actions
-import { GlobalState } from 'reducers-actions'
+import { GpV1AppState } from 'apps/gp-v1/state'
 import { removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 // Constants/Types/Misc.
 import { EMPTY_ARRAY } from 'const'
@@ -41,7 +41,7 @@ async function getDetailedPendingOrders({
 function usePendingOrders(): DetailedPendingOrder[] {
   const { blockNumber, userAddress, networkId } = useWalletConnection()
 
-  const [{ pendingOrders }, dispatch] = useGlobalState<GlobalState>()
+  const [{ pendingOrders }, dispatch] = useGlobalState<GpV1AppState>()
   const [detailedPendingOrders, setDetailedPendingOrders] = useSafeState<DetailedPendingOrder[]>([])
 
   // Handle Pending Orders

--- a/src/hooks/usePendingOrders.ts
+++ b/src/hooks/usePendingOrders.ts
@@ -6,6 +6,7 @@ import useGlobalState from './useGlobalState'
 import useSafeState from './useSafeState'
 import { useWalletConnection } from './useWalletConnection'
 // Reducers/Actions
+import { GlobalState } from 'reducers-actions'
 import { removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 // Constants/Types/Misc.
 import { EMPTY_ARRAY } from 'const'
@@ -40,7 +41,7 @@ async function getDetailedPendingOrders({
 function usePendingOrders(): DetailedPendingOrder[] {
   const { blockNumber, userAddress, networkId } = useWalletConnection()
 
-  const [{ pendingOrders }, dispatch] = useGlobalState()
+  const [{ pendingOrders }, dispatch] = useGlobalState<GlobalState>()
   const [detailedPendingOrders, setDetailedPendingOrders] = useSafeState<DetailedPendingOrder[]>([])
 
   // Handle Pending Orders

--- a/src/hooks/useThemeManager.tsx
+++ b/src/hooks/useThemeManager.tsx
@@ -1,19 +1,19 @@
 import { useCallback, useMemo } from 'react'
 
-import { updateTheme } from 'reducers-actions/theme'
+import { ThemeState, updateTheme } from 'reducers-actions/theme'
 import useGlobalState from './useGlobalState'
 
 import { Theme } from 'theme'
 
-export const useThemeMode = (): Theme => {
-  const [state] = useGlobalState()
+export function useThemeMode<State extends { theme: ThemeState }>(): Theme {
+  const [state] = useGlobalState<State>()
 
   return useMemo(() => state.theme || Theme.DARK, [state.theme])
 }
 
-export function useThemeManager(): [Theme, (newTheme: Theme) => void] {
-  const [, dispatch] = useGlobalState()
-  const theme = useThemeMode()
+export function useThemeManager<State extends { theme: ThemeState }>(): [Theme, (newTheme: Theme) => void] {
+  const [, dispatch] = useGlobalState<State>()
+  const theme = useThemeMode<State>()
 
   const setNewTheme = useCallback(
     (newTheme: Theme) => {

--- a/src/reducers-actions/index.ts
+++ b/src/reducers-actions/index.ts
@@ -1,25 +1,4 @@
 import combineReducers, { Reducer, AnyAction, Action } from 'combine-reducers'
-import { reducer as TokenRowReducer, TokenLocalState, TokenRowInitialState as tokens } from './tokenRow'
-import {
-  reducer as PendingOrderReducer,
-  PendingOrdersState,
-  PendingOrdersInitialState as pendingOrders,
-  sideEffect as PendingOrdersSideEffect,
-} from './pendingOrders'
-import {
-  reducer as OrdersReducer,
-  OrdersState,
-  INITIAL_ORDERS_STATE as orders,
-  sideEffect as OrdersSideEffect,
-} from './orders'
-import { reducer as TradeReducer, TradeState, INITIAL_TRADE_STATE as trade } from './trade'
-import { reducer as TradesReducer, TradesState, initialState as trades, sideEffect as TradesSideEffect } from './trades'
-import {
-  reducer as LocalTokensReducer,
-  LocalTokensState,
-  INITIAL_LOCAL_TOKENS_STATE as localTokens,
-  sideEffect as LocalTokensSideEffect,
-} from './localTokens'
 import {
   reducer as ThemeReducer,
   ThemeState,
@@ -39,12 +18,6 @@ export type ActionCreator<T, P> = (payload: P) => Actions<T, P>
 export type ReducerCreator<S, A> = (state: S, action: A) => S
 
 export interface GlobalState {
-  tokens: TokenLocalState
-  pendingOrders: PendingOrdersState
-  orders: OrdersState
-  trade: TradeState
-  trades: TradesState
-  localTokens: LocalTokensState
   theme: ThemeState
 }
 
@@ -55,17 +28,7 @@ export interface GlobalState {
  * make sure the name of the state key(s) is/are the same as the reducer key(s) below
  */
 
-export const INITIAL_STATE = (): GlobalState => {
-  return {
-    tokens,
-    pendingOrders,
-    orders,
-    trade,
-    trades,
-    localTokens,
-    theme,
-  }
-}
+export const GLOBAL_INITIAL_STATE = (): GlobalState => ({ theme })
 
 /**********************************
  * Side Effect after a reducer has run its course
@@ -74,7 +37,7 @@ export const INITIAL_STATE = (): GlobalState => {
  * to log, save to Storage, etc.
  */
 
-const addSideEffect = <S, A extends Action = AnyAction>(
+export const addSideEffect = <S, A extends Action = AnyAction>(
   reducer: Reducer<S, A>,
   sideEffect: (newState: S, action: A) => void,
 ): Reducer<S, A> => {
@@ -93,12 +56,6 @@ const addSideEffect = <S, A extends Action = AnyAction>(
  * reduces all reducers into 1 reducer function
  * make sure the name of the Reducer key is the same as the state key you'd like from src/App
  */
-export const rootReducer = combineReducers({
-  tokens: TokenRowReducer,
-  pendingOrders: addSideEffect(PendingOrderReducer, PendingOrdersSideEffect),
-  orders: addSideEffect(OrdersReducer, OrdersSideEffect),
-  trade: TradeReducer,
-  trades: addSideEffect(TradesReducer, TradesSideEffect),
-  localTokens: addSideEffect(LocalTokensReducer, LocalTokensSideEffect),
+export const globalRootReducer = combineReducers({
   theme: addSideEffect(ThemeReducer, ThemeSideEffect),
 })

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -16,7 +16,7 @@ import { ThemeToggle } from 'components/common/Button'
 import { useThemeManager } from 'hooks/useThemeManager'
 
 import { withGlobalContext } from 'hooks/useGlobalState'
-import { INITIAL_STATE, rootReducer } from 'reducers-actions'
+import { GLOBAL_INITIAL_STATE, globalRootReducer } from 'reducers-actions'
 
 export const GlobalStyles = (DecoratedStory: () => StoryFnReactReturnType): JSX.Element => (
   <>
@@ -47,7 +47,7 @@ const ThemeTogglerUnwrapped: React.FC = ({ children }) => {
     </>
   )
 }
-const WrappedThemeToggler: React.FC = withGlobalContext(ThemeTogglerUnwrapped, INITIAL_STATE, rootReducer)
+const WrappedThemeToggler: React.FC = withGlobalContext(ThemeTogglerUnwrapped, GLOBAL_INITIAL_STATE, globalRootReducer)
 
 // Redux aware ThemeToggler - necessary for Theme
 export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,8 +23,8 @@ const { name: appTitle } = config
 
 const TRADE_APP = { name: 'trade', title: 'Gnosis Protocol Exchange', filename: 'trade.html' }
 const EXPLORER_APP = { name: 'explorer', title: 'Gnosis Protocol Explorer', filename: 'index.html' }
-const SWAP_APP_V1 = { name: 'gp-v1', title: appTitle, filename: 'gp-v1.html', disabled: true }
-const ALL_APPS = [TRADE_APP, EXPLORER_APP, SWAP_APP_V1]
+const GP_V1 = { name: 'gp-v1', title: appTitle, filename: 'gp-v1.html', disabled: true }
+const ALL_APPS = [TRADE_APP, EXPLORER_APP, GP_V1]
 
 function getSelectedApps() {
   const appName = process.env.APP


### PR DESCRIPTION
# Summary

Closes #66 

Split global state per app

Main changes:
- `app/state.ts` contains all state definitions/reducers/etc. Same that was before defined on `reducers-actions`
- Some duplication might be required on each app's `state.ts` definition
- `useGlobalState` now requires the state type to tell TS what type is your global state holding. Example:
![screenshot_2021-02-04_13-33-50](https://user-images.githubusercontent.com/43217/106957980-93547480-66ed-11eb-92ea-3bed27cf7ac6.png)
- For now only `theme` state is part of the global state

Let me know what you think about this approach.
