### PR TITLE
Refactoring CSS logic to external function

### DIFF
--- a/src/components/order/StatusLabel/index.tsx
+++ b/src/components/order/StatusLabel/index.tsx
@@ -42,7 +42,7 @@ const Wrapper = styled.div<Props>`
   padding: 0.75em;
   display: inline-block;
 
-  ${(...params): string => setStatusColors(...params)}
+  ${({ theme, status }): string => setStatusColors({ theme, status })}
 `
 
 const StyledFAIcon = styled(FontAwesomeIcon)`

--- a/src/components/order/StatusLabel/index.tsx
+++ b/src/components/order/StatusLabel/index.tsx
@@ -1,11 +1,36 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { DefaultTheme } from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle, faClock, faDotCircle, IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
 import { OrderStatus } from 'api/operator'
 
 export type Props = { status: OrderStatus }
+
+function setStatusColors({ theme, status }: { theme: DefaultTheme; status: OrderStatus }): string {
+  let background, text
+
+  switch (status) {
+    case 'expired':
+      text = theme.labelTextExpired
+      background = theme.labelBgExpired
+      break
+    case 'filled':
+    case 'partially filled':
+      text = theme.labelTextFilled
+      background = theme.labelBgFilled
+      break
+    case 'open':
+      text = theme.labelTextOpen
+      background = theme.labelBgOpen
+      break
+  }
+
+  return `
+      background: ${background};
+      color: ${text};
+    `
+}
 
 const Wrapper = styled.div<Props>`
   font-size: ${({ theme }): string => theme.fontSizeNormal};
@@ -17,29 +42,7 @@ const Wrapper = styled.div<Props>`
   padding: 0.75em;
   display: inline-block;
 
-  ${({ theme, status }): string => {
-    let background, color
-
-    switch (status) {
-      case 'expired':
-        color = theme.labelTextExpired
-        background = theme.labelBgExpired
-        break
-      case 'filled':
-      case 'partially filled':
-        color = theme.labelTextFilled
-        background = theme.labelBgFilled
-        break
-      case 'open':
-        color = theme.labelTextOpen
-        background = theme.labelBgOpen
-        break
-    }
-    return `
-      background: ${background};
-      color: ${color};
-    `
-  }}
+  ${(...params): string => setStatusColors(...params)}
 `
 
 const StyledFAIcon = styled(FontAwesomeIcon)`


### PR DESCRIPTION
Part of #62 

Follow up to comment on #104: https://github.com/gnosis/gp-ui/pull/104#discussion_r570513618

2 equivalent approaches for the refactoring, shown together:
![screenshot_2021-02-04_14-03-56](https://user-images.githubusercontent.com/43217/106961377-55a61a80-66f2-11eb-8df5-06395f3f02cb.png)

This change for now (commit 8de77dc) uses the first, returning CSS from the helper function
