### PR TITLE
62/erc20 global state

### DIFF
--- a/src/apps/explorer/api.ts
+++ b/src/apps/explorer/api.ts
@@ -1,1 +1,9 @@
-export { web3 } from 'api'
+import { createErc20Api } from 'api'
+
+import { web3 } from 'api'
+
+const injectedDependencies = { web3 }
+
+const erc20Api = createErc20Api(injectedDependencies)
+
+export { web3, erc20Api }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router'
 import { getOrder, RawOrder } from 'api/operator'
 
 import { OrderWidgetView } from './view'
+import { useErc20 } from 'hooks/useErc20'
 
 export const OrderWidget: React.FC = () => {
   // TODO: move order loading to a hook
@@ -26,6 +27,13 @@ export const OrderWidget: React.FC = () => {
       .catch((e) => setError(e.message))
       .finally(() => setIsLoading(false))
   }, [orderId])
+
+  // TODO: this is just for testing. The hooks will not be here
+  const { value: buyToken } = useErc20(order?.buyToken, 4)
+  const { value: sellToken } = useErc20(order?.sellToken, 4)
+
+  console.log(`buy token`, buyToken)
+  console.log(`sell token`, sellToken)
 
   return <OrderWidgetView order={order} isLoading={isLoading} error={error} />
 }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -29,8 +29,8 @@ export const OrderWidget: React.FC = () => {
   }, [orderId])
 
   // TODO: this is just for testing. The hooks will not be here
-  const { value: buyToken } = useErc20(order?.buyToken, 4)
-  const { value: sellToken } = useErc20(order?.sellToken, 4)
+  const { value: buyToken } = useErc20({ address: order?.buyToken, networkId: 4 })
+  const { value: sellToken } = useErc20({ address: order?.sellToken, networkId: 4 })
 
   console.log(`buy token`, buyToken)
   console.log(`sell token`, sellToken)

--- a/src/apps/explorer/state.ts
+++ b/src/apps/explorer/state.ts
@@ -1,12 +1,17 @@
 import { GlobalState, GLOBAL_INITIAL_STATE, globalRootReducer } from 'reducers-actions'
+import { Erc20State, INITIAL_ERC20_STATE, reducer as erc20sReducer } from 'reducers-actions/erc20'
 import combineReducers from 'combine-reducers'
 
-export type ExplorerAppState = GlobalState
+export type ExplorerAppState = GlobalState & {
+  erc20s: Erc20State
+}
 
 export const INITIAL_STATE = (): ExplorerAppState => ({
   ...GLOBAL_INITIAL_STATE(),
+  erc20s: INITIAL_ERC20_STATE,
 })
 
 export const rootReducer = combineReducers({
   ...globalRootReducer,
+  erc20s: erc20sReducer,
 })

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -14,10 +14,16 @@ import { web3, erc20Api } from 'apps/explorer/api'
 
 import { ExplorerAppState } from 'apps/explorer/state'
 
-export function useErc20(
-  address?: string,
-  networkId?: Network,
-): { isLoading: boolean; error?: string; value?: TokenErc20 } {
+type Params = {
+  address?: string
+  networkId?: Network
+}
+
+type Return = { isLoading: boolean; error?: string; value?: TokenErc20 }
+
+export function useErc20(params: Params): Return {
+  const { address, networkId } = params
+
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
 

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+
+import { Network } from 'types'
+
+import { buildErc20Key, saveSingleErc20 } from 'reducers-actions/erc20'
+
+import useGlobalState from 'hooks/useGlobalState'
+
+import { getErc20Info } from 'services/helpers'
+
+import { web3, erc20Api } from 'apps/explorer/api'
+
+import { ExplorerAppState } from 'apps/explorer/state'
+
+export function useErc20(
+  address?: string,
+  networkId?: Network,
+): { isLoading: boolean; error?: string; value?: TokenErc20 } {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const [{ erc20s }, dispatch] = useGlobalState<ExplorerAppState>()
+
+  // Initial state from global state
+  const [erc20, setErc20] = useState<TokenErc20 | undefined>(
+    address && networkId ? erc20s.get(buildErc20Key(networkId, address)) : undefined,
+  )
+
+  useEffect(() => {
+    // Only try to fetch it if not on global state
+    if (!erc20 && address && networkId) {
+      setIsLoading(true)
+      setError('')
+
+      getErc20Info({ tokenAddress: address, networkId, web3, erc20Api })
+        .then((fetchedErc20) => {
+          // When not found, it returns null
+          if (fetchedErc20) {
+            dispatch(saveSingleErc20(fetchedErc20, networkId))
+            setErc20(fetchedErc20)
+          }
+        })
+        .catch((e) => {
+          // Set error only when the call fails
+          // Not finding the token is not an error
+          const msg = `Failed to fetch erc20 details for ${address} on network ${networkId}`
+          console.error(msg, e)
+          setError(msg)
+        })
+        .finally(() => {
+          setIsLoading(false)
+        })
+    }
+  }, [address, dispatch, erc20, networkId])
+
+  return { isLoading, error, value: erc20 }
+}

--- a/src/reducers-actions/erc20.ts
+++ b/src/reducers-actions/erc20.ts
@@ -36,8 +36,10 @@ export function reducer(state: Erc20State, action: ReducerActionType): Erc20Stat
       const { erc20s, networkId } = action.payload
 
       erc20s.forEach((erc20) => {
-        // add/overwrite details for given key
-        map.set(buildErc20Key(networkId, erc20.address), erc20)
+        const key = buildErc20Key(networkId, erc20.address)
+        const existing = map.get(key) || {}
+        // merge existing erc20 info, if any
+        map.set(key, { ...existing, ...erc20 })
       })
 
       return map

--- a/src/reducers-actions/erc20.ts
+++ b/src/reducers-actions/erc20.ts
@@ -1,0 +1,48 @@
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+
+import { Actions } from 'reducers-actions'
+
+import { Network } from 'types'
+
+export type ActionTypes = 'SAVE_MULTIPLE_ERC20'
+
+export type Erc20State = Map<string, TokenErc20>
+
+type SaveMultipleErc20ActionType = Actions<ActionTypes, { erc20s: TokenErc20[]; networkId: Network }>
+type ReducerActionType = SaveMultipleErc20ActionType
+
+export const saveMultipleErc20 = (erc20s: TokenErc20[], networkId: Network): SaveMultipleErc20ActionType => ({
+  type: 'SAVE_MULTIPLE_ERC20',
+  payload: { erc20s, networkId },
+})
+
+// Syntactic sugar
+export const saveSingleErc20 = (erc20: TokenErc20, networkId: Network): SaveMultipleErc20ActionType =>
+  saveMultipleErc20([erc20], networkId)
+
+// TODO: load initial state from local storage
+export const INITIAL_ERC20_STATE: Erc20State = new Map<string, TokenErc20>()
+
+function buildKey(networkId: Network, address: string): string {
+  return `${networkId}|${address}`
+}
+
+export function reducer(state: Erc20State, action: ReducerActionType): Erc20State {
+  switch (action.type) {
+    case 'SAVE_MULTIPLE_ERC20': {
+      // Clone current state
+      const map = new Map(state)
+
+      const { erc20s, networkId } = action.payload
+
+      erc20s.forEach((erc20) => {
+        // add/overwrite details for given key
+        map.set(buildKey(networkId, erc20.address), erc20)
+      })
+
+      return map
+    }
+    default:
+      return state
+  }
+}

--- a/src/reducers-actions/erc20.ts
+++ b/src/reducers-actions/erc20.ts
@@ -23,7 +23,7 @@ export const saveSingleErc20 = (erc20: TokenErc20, networkId: Network): SaveMult
 // TODO: load initial state from local storage
 export const INITIAL_ERC20_STATE: Erc20State = new Map<string, TokenErc20>()
 
-function buildKey(networkId: Network, address: string): string {
+export function buildErc20Key(networkId: Network, address: string): string {
   return `${networkId}|${address}`
 }
 
@@ -37,7 +37,7 @@ export function reducer(state: Erc20State, action: ReducerActionType): Erc20Stat
 
       erc20s.forEach((erc20) => {
         // add/overwrite details for given key
-        map.set(buildKey(networkId, erc20.address), erc20)
+        map.set(buildErc20Key(networkId, erc20.address), erc20)
       })
 
       return map

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -1,5 +1,7 @@
 import { RawOrder } from 'api/operator'
 
+import { FEE_TOKEN } from './basic'
+
 export const ORDER: RawOrder = {
   creationDate: '2021-01-20T23:15:07.892538607Z',
   owner: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
@@ -11,8 +13,8 @@ export const ORDER: RawOrder = {
   feeAmount: '0',
   executedFeeAmount: '0',
   invalidated: false,
-  sellToken: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
-  buyToken: '0xc7ad46e0b8a400bb3c915120d284aafba8fc4735',
+  sellToken: '0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d',
+  buyToken: FEE_TOKEN,
   validTo: 0,
   appData: 0,
   kind: 'sell',


### PR DESCRIPTION
# Summary

Part of #62 

Implementing `Erc20` state manager using reducer style.
Added hook `useErc20` to get erc20 from global context or fetch from the network.

Right now the hook is plugged into OrderWidget and logging the sell/buy token on the console, but that's not where it's intended to be used. Will be addressed in a future PR.
