### PR TITLE
Web3 instance per network

### DIFF
--- a/src/api/web3/hooks.ts
+++ b/src/api/web3/hooks.ts
@@ -1,39 +1,16 @@
 import { useMemo } from 'react'
 import Web3 from 'web3'
 
-import { getNetworkFromId } from '@gnosis.pm/dex-js'
-
 import { useNetworkId } from 'state/network'
 
-import { Network } from 'types'
+import { createWeb3Api, getProviderByNetwork } from '.'
 
-import { INFURA_ID } from 'const'
-
-import { createWeb3Api } from '.'
-
-function infuraProvider(networkId: Network): string {
-  // INFURA_ID relies on mesa `config` file logic.
-  // We can be independent of that config by relying on the env var directly
-  if (!INFURA_ID) {
-    throw new Error(`INFURA_ID not set`)
-  }
-  return `wss://${getNetworkFromId(networkId).toLowerCase()}.infura.io/ws/v3/${INFURA_ID}`
-}
-
-function infuraProviderByNetworkId(networkId: Network | null): string | undefined {
-  switch (networkId) {
-    case Network.Mainnet:
-    case Network.Rinkeby:
-    case Network.xDAI:
-      return infuraProvider(networkId)
-    default:
-      return undefined
-  }
-}
-
+// Approach 1: create one web3 instance per network
+// Must be used inside components, since it's a hook
+// Can also be used outside by calling `createWeb3Api` directly
 export function useWeb3(): Web3 {
   const networkId = useNetworkId()
-  const provider = infuraProviderByNetworkId(networkId)
+  const provider = getProviderByNetwork(networkId)
 
   // createWeb3 caches instances per provider, safe to call multiple times
   return useMemo(() => createWeb3Api(provider), [provider])

--- a/src/api/web3/hooks.ts
+++ b/src/api/web3/hooks.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import Web3 from 'web3'
+
+import { getNetworkFromId } from '@gnosis.pm/dex-js'
+
+import { useNetworkId } from 'state/network'
+
+import { Network } from 'types'
+
+import { INFURA_ID } from 'const'
+
+import { createWeb3Api } from '.'
+
+function infuraProvider(networkId: Network): string {
+  // INFURA_ID relies on mesa `config` file logic.
+  // We can be independent of that config by relying on the env var directly
+  if (!INFURA_ID) {
+    throw new Error(`INFURA_ID not set`)
+  }
+  return `wss://${getNetworkFromId(networkId).toLowerCase()}.infura.io/ws/v3/${INFURA_ID}`
+}
+
+function infuraProviderByNetworkId(networkId: Network | null): string | undefined {
+  switch (networkId) {
+    case Network.Mainnet:
+    case Network.Rinkeby:
+    case Network.xDAI:
+      return infuraProvider(networkId)
+    default:
+      return undefined
+  }
+}
+
+export function useWeb3(): Web3 {
+  const networkId = useNetworkId()
+  const provider = infuraProviderByNetworkId(networkId)
+
+  // createWeb3 caches instances per provider, safe to call multiple times
+  return useMemo(() => createWeb3Api(provider), [provider])
+}

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -5,9 +5,16 @@ import { ETH_NODE_URL } from 'const'
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null => (process.env.NODE_ENV === 'test' ? null : ETH_NODE_URL)
 
-export function createWeb3Api(): Web3 {
+const web3cache = {}
+
+export function createWeb3Api(provider?: string): Web3 {
+  const _provider = provider || getDefaultProvider() || ''
+
+  if (web3cache[_provider]) {
+    return web3cache[_provider]
+  }
   // TODO: Create an `EthereumApi` https://github.com/gnosis/gp-v1-ui/issues/331
-  const web3 = new Web3(getDefaultProvider())
+  const web3 = new Web3(_provider)
   // `handleRevert = true` makes `require` failures to throw
   // For more details see https://github.com/gnosis/gp-v1-ui/issues/511
   web3.eth['handleRevert'] = true
@@ -16,5 +23,7 @@ export function createWeb3Api(): Web3 {
     // Only function that needs to be mocked so far. We can add more and add extra logic as needed
     web3.eth.getCode = async (address: string): Promise<string> => address
   }
+
+  web3cache[_provider] = web3
   return web3
 }

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -1,6 +1,9 @@
 import Web3 from 'web3'
+import { getNetworkFromId } from '@gnosis.pm/dex-js'
 
-import { ETH_NODE_URL } from 'const'
+import { Network } from 'types'
+
+import { ETH_NODE_URL, INFURA_ID } from 'const'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null => (process.env.NODE_ENV === 'test' ? null : ETH_NODE_URL)
@@ -26,4 +29,39 @@ export function createWeb3Api(provider?: string): Web3 {
 
   web3cache[_provider] = web3
   return web3
+}
+
+function infuraProvider(networkId: Network): string {
+  // INFURA_ID relies on mesa `config` file logic.
+  // We can be independent of that config by relying on the env var directly
+  if (!INFURA_ID) {
+    throw new Error(`INFURA_ID not set`)
+  }
+  return `wss://${getNetworkFromId(networkId).toLowerCase()}.infura.io/ws/v3/${INFURA_ID}`
+}
+
+// For now only infura provider is available
+export function getProviderByNetwork(networkId: Network | null): string | undefined {
+  switch (networkId) {
+    case Network.Mainnet:
+    case Network.Rinkeby:
+    case Network.xDAI:
+      return infuraProvider(networkId)
+    default:
+      return undefined
+  }
+}
+
+// Approach 2: update the provider in a single web3 instance
+// Advantage is that regular APIs that require web3 instance should work without any changes
+// Also, there's no change to consumers currently importing from <app>/api module
+// Side effect is applied at reducer level (state/network/updater module)
+export function updateWeb3Provider(web3: Web3, networkId?: Network | null): void {
+  if (!networkId) {
+    return
+  }
+
+  const provider = getProviderByNetwork(networkId)
+
+  provider && web3.setProvider(provider)
 }

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import Web3 from 'web3'
 
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 
@@ -14,17 +13,14 @@ import {
 
 import { getErc20Info } from 'services/helpers'
 
-import { useWeb3 } from 'api/web3/hooks'
-
-import { erc20Api } from 'apps/explorer/api'
+import { web3, erc20Api } from 'apps/explorer/api'
 
 async function _fetchErc20FromNetwork(params: {
   address: string
   networkId: number
   setError: (error: string) => void
-  web3: Web3
 }): Promise<SingleErc20State> {
-  const { address, networkId, setError, web3 } = params
+  const { address, networkId, setError } = params
 
   try {
     return getErc20Info({ tokenAddress: address, networkId, web3, erc20Api })
@@ -59,7 +55,6 @@ export function useErc20(params: UseErc20Params): Return<string, SingleErc20Stat
 
   const erc20 = useErc20State({ networkId, address })
   const saveErc20s = useSaveErc20s(networkId)
-  const web3 = useWeb3()
 
   const fetchAndUpdateState = useCallback(async (): Promise<void> => {
     if (!address || !networkId) {
@@ -69,13 +64,13 @@ export function useErc20(params: UseErc20Params): Return<string, SingleErc20Stat
     setIsLoading(true)
     setError('')
 
-    const fetched = await _fetchErc20FromNetwork({ address, networkId, setError, web3 })
+    const fetched = await _fetchErc20FromNetwork({ address, networkId, setError })
     if (fetched) {
       saveErc20s([fetched])
     }
 
     setIsLoading(false)
-  }, [address, networkId, saveErc20s, web3])
+  }, [address, networkId, saveErc20s])
 
   useEffect(() => {
     // Only try to fetch it if not on global state
@@ -110,7 +105,6 @@ export function useMultipleErc20(
 
   const erc20s = useMultipleErc20sState({ networkId, addresses })
   const saveErc20s = useSaveErc20s(networkId)
-  const web3 = useWeb3()
 
   // check what on globalState has not been fetched yet
   const toFetch = useMemo(() => addresses.filter((address) => !erc20s[address]), [addresses, erc20s])
@@ -132,7 +126,6 @@ export function useMultipleErc20(
         address,
         networkId,
         setError: (msg) => setErrors((curr) => ({ ...curr, [address]: msg })),
-        web3,
       }),
     )
 
@@ -143,7 +136,7 @@ export function useMultipleErc20(
 
     setIsLoading(false)
     running.current = false
-  }, [networkId, saveErc20s, toFetch, web3])
+  }, [networkId, saveErc20s, toFetch])
 
   useEffect(() => {
     // only trigger network query if not yet running

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -6,6 +6,8 @@ import useGlobalState from 'hooks/useGlobalState'
 
 import { setNetwork } from './actions'
 import { useNetworkId } from './hooks'
+import { updateWeb3Provider } from 'api/web3'
+import { web3 } from 'apps/explorer/api'
 
 function getNetworkId(network: string | undefined): Network {
   switch (network) {
@@ -33,6 +35,7 @@ export const NetworkUpdater: React.FC = () => {
     // Update the network if it's different
     if (currentNetworkId !== networkId) {
       dispatch(setNetwork(networkId))
+      updateWeb3Provider(web3, networkId)
     }
   }, [location, currentNetworkId, dispatch])
 


### PR DESCRIPTION
# Summary

Builds on top of https://github.com/gnosis/gp-ui/pull/136 (:sweat_drops: :fallen_leaf:)

:warning: merge only after #136 

---

Updating web3 instance provider when network changes.

This PR adds 2 approaches:

1. Create a web3 instance per network
2. Use a single web3 instance, and update its provider when the network changes

Currently approach `2` is in use, although both were added.
Check their implementations for more details, respectively https://github.com/gnosis/gp-ui/blob/9570c86e3f09d3e78fd456644ed9b75f355afe68/src/api/web3/index.ts and https://github.com/gnosis/gp-ui/blob/9570c86e3f09d3e78fd456644ed9b75f355afe68/src/api/web3/hooks.ts

# Testing

Compare the same order on the:
- Previous PR: https://pr136--gpui.review.gnosisdev.com/rinkeby/orders/0x3960fcd923574dcd0c0f40f9bd20485a2c8b4f85128eedb3c3d53960691d1d7d5b0abe214ab7875562adee331deff0fe1912fe4260257f55/
![screenshot_2021-02-11_13-47-00](https://user-images.githubusercontent.com/43217/107702772-97454100-6c6f-11eb-99c6-fb8ee1e2c1e6.png)

- Current PR: https://pr137--gpui.review.gnosisdev.com/rinkeby/orders/0x3960fcd923574dcd0c0f40f9bd20485a2c8b4f85128eedb3c3d53960691d1d7d5b0abe214ab7875562adee331deff0fe1912fe4260257f55/
![screenshot_2021-02-11_13-47-07](https://user-images.githubusercontent.com/43217/107702787-99a79b00-6c6f-11eb-9854-383da5c8da0f.png)
