### PR TITLE
Style updates to the footer.

### DIFF
--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -22,48 +22,56 @@ const FooterStyled = styled.footer`
   padding: 0 1rem;
   border-top: 0.1rem solid var(--color-border);
   flex: 1 1 auto;
-  background: ${({ theme }): string => theme.gradient1};
+  color: ${({ theme }): string => theme.textSecondary2};
+  background: ${({ theme }): string => theme.bg1};
   width: 100%;
   justify-content: space-between;
 
-  &,
-  a {
-    color: var(--color-text-secondary2);
+  & a {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s ease-in-out;
+
+    &:hover {
+      color: ${({ theme }): string => theme.white};
+    }
   }
 `
 
+const BetaWrapper = styled.div`
+  display: flex;
+  margin: 0;
+  height: 100%;
+  align-items: center;
+  padding: 0 1rem 0 0;
+  position: relative;
+  border-right: 0.1rem solid ${({ theme }): string => theme.borderPrimary};
+`
+
 const VerifiedButton = styled(BlockExplorerLink)`
-  margin: 0 auto 0 0.6rem;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 1rem;
+  border-right: 0.1rem solid ${({ theme }): string => theme.borderPrimary};
 `
 
 const VersionsWrapper = styled.div`
   display: flex;
   margin: 0 0 0 auto;
-
-  > a {
-    text-decoration: none;
-
-    &:focus,
-    &:hover {
-      text-decoration: underline;
-    }
-  }
+  align-items: center;
+  padding: 0 0 0 1rem;
+  height: 100%;
+  border-left: 0.1rem solid ${({ theme }): string => theme.borderPrimary};
 
   > a:not(:last-of-type) {
-    margin: 0 1.6rem 0 0;
+    margin: 0 1rem 0 0;
     flex-flow: row nowrap;
     display: flex;
     position: relative;
-
-    &::after {
-      content: '-';
-      position: absolute;
-      right: -1rem;
-      display: block;
-    }
   }
 `
-
 export interface FooterType {
   readonly verifiedText?: string
   readonly isBeta?: boolean
@@ -81,7 +89,7 @@ export const Footer: React.FC<FooterType> = (props) => {
 
   return (
     <FooterStyled>
-      {isBeta && 'This project is in beta. Use at your own risk.'}
+      <BetaWrapper>{isBeta && 'This project is in beta. Use at your own risk.'}</BetaWrapper>
       {contractAddress && networkId ? (
         <VerifiedButton
           type="contract"


### PR DESCRIPTION
Style the footer in a slightly different way:
<img width="1460" alt="Screen Shot 2021-02-12 at 11 53 12" src="https://user-images.githubusercontent.com/31534717/107759645-e3a08780-6d28-11eb-9dec-408062884122.png">
- Includes on hover styles.

Errors:
- Noticed an error:
> src/apps/explorer/components/OrderWidget/OrderDetails.tsx:149:34 - error TS2769: No overload matches this call.

Pending for future PR's:
- Mobile responsiveness
