### PR TITLE
Add support to URLs with mainnet network

### DIFF
--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -48,9 +48,7 @@ export function StateUpdaters(): JSX.Element {
 
 /** App content */
 const AppContent = (): JSX.Element => {
-  const { path, url } = useRouteMatch()
-
-  console.log({ path, url })
+  const { path } = useRouteMatch()
 
   const pathPrefix = path == '/' ? '' : path
 

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -67,10 +67,8 @@ const AppContent = (): JSX.Element => {
 
 /** Redirects to the canonnical URL for mainnet */
 const RedirectMainnet = (): JSX.Element => {
-  const { path, url, params } = useRouteMatch()
-  const { hash, pathname, search, state, key } = useLocation()
+  const { pathname } = useLocation()
 
-  console.log('path', path, url, params, { hash, pathname, search, state, key })
   const pathMatchArray = pathname.match('/mainnet(.*)')
   const newPath = pathMatchArray && pathMatchArray.length > 0 ? pathMatchArray[1] : '/'
 

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter, HashRouter, Route, Switch, useRouteMatch } from 'react-router-dom'
+import { BrowserRouter, HashRouter, Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 import { hot } from 'react-hot-loader/root'
 
 import { withGlobalContext } from 'hooks/useGlobalState'
@@ -65,6 +65,18 @@ const AppContent = (): JSX.Element => {
   )
 }
 
+/** Redirects to the canonnical URL for mainnet */
+const RedirectMainnet = (): JSX.Element => {
+  const { path, url, params } = useRouteMatch()
+  const { hash, pathname, search, state, key } = useLocation()
+
+  console.log('path', path, url, params, { hash, pathname, search, state, key })
+  const pathMatchArray = pathname.match('/mainnet(.*)')
+  const newPath = pathMatchArray && pathMatchArray.length > 0 ? pathMatchArray[1] : '/'
+
+  return <Redirect push={false} to={newPath} />
+}
+
 /**
  * Render Explorer App
  */
@@ -77,6 +89,7 @@ export const ExplorerApp: React.FC = () => {
       <Router basename={process.env.BASE_URL}>
         <StateUpdaters />
         <Switch>
+          <Route path="/mainnet" component={RedirectMainnet} />
           <Route path={['/xdai', '/rinkeby', '/']} component={AppContent} />
         </Switch>
       </Router>


### PR DESCRIPTION
addressing feedback from @W3stside on our way of handling the networks.

This PR adds a redirect for URLs of the shape `/mainnet/<path>` to `/<path>` (it's canonical form)

Note that an user might decide to change `/xdai/<path>` to `/mainet/<path>` expecting it to work. 
Before this PR it would give a 404, now it will understand where the user is trying to go, and take him there

test URL:
http://localhost:8080/mainnet/orders/0x203ab964d93ed04257dc6580f6b02f69a3e120104d9618efb28b952aaf00ae47424a46612794dbb8000194937834250dc723ffa5602a6c7c
