### PR TITLE
92/use order and erc20s hook

### DIFF
--- a/src/api/operator/operatorMock.ts
+++ b/src/api/operator/operatorMock.ts
@@ -1,12 +1,12 @@
 import { GetOrderParams, GetOrdersParams, RawOrder } from './types'
 
-import { ORDER } from '../../../test/data'
+import { RAW_ORDER } from '../../../test/data'
 
 export async function getOrder(params: GetOrderParams): Promise<RawOrder> {
   const { orderId } = params
 
   return {
-    ...ORDER,
+    ...RAW_ORDER,
     uid: orderId,
   }
 }

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -57,7 +57,7 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   feeAmount: BigNumber
   executedFeeAmount: BigNumber
   cancelled: boolean
-  // status: OrderStatus // better not have the status because it depends on `expirationDate`
+  status: OrderStatus
   filledAmount: BigNumber
   filledPercentage: BigNumber
   // limitPrice: BigNumber  // cant have prices because they depend on token decimals

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -1,3 +1,5 @@
+import BigNumber from 'bignumber.js'
+
 import { Network } from 'types'
 
 export type OrderID = string
@@ -36,6 +38,30 @@ export type RawOrder = {
   kind: OrderKind
   partiallyFillable: boolean
   signature: string
+}
+
+/**
+ * Enriched Order type.
+ * Applies some transformations on the raw api data.
+ * Some fields are kept as is.
+ */
+export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature'> & {
+  creationDate: Date
+  expirationDate: Date
+  buyTokenAddress: string
+  sellTokenAddress: string
+  buyAmount: BigNumber
+  sellAmount: BigNumber
+  executedBuyAmount: BigNumber
+  executedSellAmount: BigNumber
+  feeAmount: BigNumber
+  executedFeeAmount: BigNumber
+  cancelled: boolean
+  // status: OrderStatus // better not have the status because it depends on `expirationDate`
+  filledAmount: BigNumber
+  filledPercentage: BigNumber
+  // limitPrice: BigNumber  // cant have prices because they depend on token decimals
+  // executedPrice: BigNumber
 }
 
 type WithNetworkId = { networkId: Network }

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -60,8 +60,6 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   status: OrderStatus
   filledAmount: BigNumber
   filledPercentage: BigNumber
-  // limitPrice: BigNumber  // cant have prices because they depend on token decimals
-  // executedPrice: BigNumber
 }
 
 type WithNetworkId = { networkId: Network }

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js'
 
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+
 import { Network } from 'types'
 
 export type OrderID = string
@@ -49,7 +51,9 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   creationDate: Date
   expirationDate: Date
   buyTokenAddress: string
+  buyToken?: TokenErc20 | null // undefined when not set, null when not found
   sellTokenAddress: string
+  sellToken?: TokenErc20 | null
   buyAmount: BigNumber
   sellAmount: BigNumber
   executedBuyAmount: BigNumber

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -163,6 +163,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
     ...rest
   } = rawOrder
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(rawOrder)
+  const status = getOrderStatus(rawOrder)
   const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(rawOrder)
 
   return {
@@ -178,6 +179,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
     feeAmount: new BigNumber(feeAmount),
     executedFeeAmount: new BigNumber(executedFeeAmount),
     cancelled: invalidated,
+    status,
     filledAmount,
     filledPercentage,
   }

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -5,7 +5,7 @@ import { calculatePrice, invertPrice } from '@gnosis.pm/dex-js'
 
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
-import { OrderStatus, RawOrder } from './types'
+import { Order, OrderStatus, RawOrder } from './types'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount
@@ -142,4 +142,43 @@ export function getOrderExecutedPrice({
   })
 
   return inverted ? invertPrice(price) : price
+}
+
+/**
+ * Transforms a RawOrder into an Order object
+ *
+ * @param rawOrder RawOrder object
+ */
+export function transformOrder(rawOrder: RawOrder): Order {
+  const {
+    creationDate,
+    validTo,
+    buyToken,
+    sellToken,
+    buyAmount,
+    sellAmount,
+    feeAmount,
+    executedFeeAmount,
+    invalidated,
+    ...rest
+  } = rawOrder
+  const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(rawOrder)
+  const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(rawOrder)
+
+  return {
+    ...rest,
+    creationDate: new Date(creationDate),
+    expirationDate: new Date(validTo * 1000),
+    buyTokenAddress: buyToken,
+    sellTokenAddress: sellToken,
+    buyAmount: new BigNumber(buyAmount),
+    sellAmount: new BigNumber(sellAmount),
+    executedBuyAmount,
+    executedSellAmount,
+    feeAmount: new BigNumber(feeAmount),
+    executedFeeAmount: new BigNumber(executedFeeAmount),
+    cancelled: invalidated,
+    filledAmount,
+    filledPercentage,
+  }
 }

--- a/src/apps/explorer/components/OrderWidget/OrderWidget.stories.tsx
+++ b/src/apps/explorer/components/OrderWidget/OrderWidget.stories.tsx
@@ -6,7 +6,7 @@ import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
 
 import { OrderWidgetView, Props } from './view'
 
-import { ORDER } from '../../../../../test/data'
+import { RICH_ORDER } from '../../../../../test/data'
 
 export default {
   title: 'Explorer/OrderWidget',
@@ -17,13 +17,16 @@ export default {
 
 const Template: Story<Props> = (args) => <OrderWidgetView {...args} />
 
-const defaultProps: Props = { order: null, isLoading: false }
+const defaultProps: Props = { order: null, isLoading: false, errors: {} }
 
 export const OrderFound = Template.bind({})
-OrderFound.args = { ...defaultProps, order: ORDER }
+OrderFound.args = { ...defaultProps, order: RICH_ORDER }
 
 export const OrderLoading = Template.bind({})
 OrderLoading.args = { ...defaultProps, isLoading: true }
 
 export const OrderNotFound = Template.bind({})
 OrderNotFound.args = { ...defaultProps }
+
+export const WithErrors = Template.bind({})
+WithErrors.args = { ...defaultProps, errors: { error1: 'Failed something something', error2: 'Something else failed' } }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 import { useParams } from 'react-router'
 
 import { useOrderAndErc20s } from 'hooks/useOperatorOrder'
+
+import { ORDER_QUERY_INTERVAL } from 'apps/explorer/const'
+
 import { OrderWidgetView } from './view'
 
 export const OrderWidget: React.FC = () => {
   const { orderId } = useParams<{ orderId: string }>()
 
-  const { order, buyToken, sellToken, isLoading, error } = useOrderAndErc20s(orderId)
+  const { order, buyToken, sellToken, isLoading, error } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
 
   return (
     <OrderWidgetView

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -10,15 +10,7 @@ import { OrderWidgetView } from './view'
 export const OrderWidget: React.FC = () => {
   const { orderId } = useParams<{ orderId: string }>()
 
-  const { order, buyToken, sellToken, isLoading, error } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
+  const { order, isLoading, error } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
 
-  return (
-    <OrderWidgetView
-      order={order}
-      isLoading={isLoading}
-      error={error}
-      buyToken={buyToken || undefined}
-      sellToken={sellToken || undefined}
-    />
-  )
+  return <OrderWidgetView order={order} isLoading={isLoading} error={error} />
 }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -1,62 +1,21 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React from 'react'
 import { useParams } from 'react-router'
 
-import { getOrder, RawOrder } from 'api/operator'
-
+import { useOrderAndErc20s } from 'hooks/useOperatorOrder'
 import { OrderWidgetView } from './view'
-import { useMultipleErc20 } from 'hooks/useErc20'
-import { useNetworkId } from 'state/network'
-import { Network } from 'types'
 
 export const OrderWidget: React.FC = () => {
-  // TODO: move order loading to a hook
-  const networkId = useNetworkId()
-  const [order, setOrder] = useState<RawOrder | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState('')
-  // TODO: load fills from a hook
-
   const { orderId } = useParams<{ orderId: string }>()
 
-  useEffect(() => {
-    // TODO: get network from a hook or something
-    setIsLoading(true)
-
-    if (!networkId) {
-      return
-    }
-
-    getOrder({ networkId, orderId })
-      .then((order) => {
-        console.log(`got order ${order} for network ${networkId}`)
-        setOrder(order)
-        setError('')
-      })
-      .catch((e) => setError(e.message))
-      .finally(() => setIsLoading(false))
-  }, [networkId, orderId])
-
-  // TODO: this is just for testing. The hooks will not be here
-  const networkIdOrDefault = networkId ?? Network.Mainnet
-
-  const { isLoading: isErc20sLoading, value: erc20s } = useMultipleErc20({
-    addresses: [order?.buyToken || '', order?.sellToken || ''].filter(Boolean),
-    networkId: networkIdOrDefault,
-  })
-  const [buyToken, sellToken] = useMemo(() => {
-    const buyToken = erc20s[order?.buyToken || ''] || undefined
-    const sellToken = erc20s[order?.sellToken || ''] || undefined
-
-    return [buyToken, sellToken]
-  }, [order?.buyToken, order?.sellToken, erc20s])
+  const { order, buyToken, sellToken, isLoading, error } = useOrderAndErc20s(orderId)
 
   return (
     <OrderWidgetView
       order={order}
-      isLoading={isLoading || isErc20sLoading}
+      isLoading={isLoading}
       error={error}
-      buyToken={buyToken}
-      sellToken={sellToken}
+      buyToken={buyToken || undefined}
+      sellToken={sellToken || undefined}
     />
   )
 }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -10,7 +10,7 @@ import { OrderWidgetView } from './view'
 export const OrderWidget: React.FC = () => {
   const { orderId } = useParams<{ orderId: string }>()
 
-  const { order, isLoading, error } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
+  const { order, isLoading, errors } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
 
-  return <OrderWidgetView order={order} isLoading={isLoading} error={error} />
+  return <OrderWidgetView order={order} isLoading={isLoading} errors={errors} />
 }

--- a/src/apps/explorer/components/OrderWidget/view.tsx
+++ b/src/apps/explorer/components/OrderWidget/view.tsx
@@ -28,13 +28,12 @@ export const OrderWidgetView: React.FC<Props> = (props) => {
     <Wrapper>
       <h2>Order details</h2>
       {/* TODO: create common loading indicator */}
-      {isLoading && <FontAwesomeIcon icon={faSpinner} spin size="5x" />}
-      {order && !isLoading && buyToken && sellToken && (
-        <OrderDetails order={order} buyToken={buyToken} sellToken={sellToken} />
-      )}
+      {order && buyToken && sellToken && <OrderDetails order={order} buyToken={buyToken} sellToken={sellToken} />}
       {!order && !isLoading && <p>Order not found</p>}
+      {!isLoading && (!buyToken || !sellToken) && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}
       {error && <p>{error}</p>}
+      {isLoading && <FontAwesomeIcon icon={faSpinner} spin size="3x" />}
     </Wrapper>
   )
 }

--- a/src/apps/explorer/components/OrderWidget/view.tsx
+++ b/src/apps/explorer/components/OrderWidget/view.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 
-import { RawOrder } from 'api/operator'
+import { Order } from 'api/operator'
 
 import { OrderDetails } from 'components/orders/OrderDetails'
 
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 `
 
 export type Props = {
-  order: RawOrder | null
+  order: Order | null
   isLoading: boolean
   error?: string
   buyToken?: TokenErc20

--- a/src/apps/explorer/components/OrderWidget/view.tsx
+++ b/src/apps/explorer/components/OrderWidget/view.tsx
@@ -3,8 +3,6 @@ import styled from 'styled-components'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import { TokenErc20 } from '@gnosis.pm/dex-js'
-
 import { Order } from 'api/operator'
 
 import { OrderDetails } from 'components/orders/OrderDetails'
@@ -17,20 +15,18 @@ export type Props = {
   order: Order | null
   isLoading: boolean
   error?: string
-  buyToken?: TokenErc20
-  sellToken?: TokenErc20
 }
 
 export const OrderWidgetView: React.FC<Props> = (props) => {
-  const { order, isLoading, error, buyToken, sellToken } = props
+  const { order, isLoading, error } = props
 
   return (
     <Wrapper>
       <h2>Order details</h2>
       {/* TODO: create common loading indicator */}
-      {order && buyToken && sellToken && <OrderDetails order={order} buyToken={buyToken} sellToken={sellToken} />}
+      {order?.buyToken && order?.sellToken && <OrderDetails order={order} />}
       {!order && !isLoading && <p>Order not found</p>}
-      {!isLoading && (!buyToken || !sellToken) && <p>Not able to load tokens</p>}
+      {!isLoading && (!order?.buyToken || !order?.sellToken) && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}
       {error && <p>{error}</p>}
       {isLoading && <FontAwesomeIcon icon={faSpinner} spin size="3x" />}

--- a/src/apps/explorer/components/OrderWidget/view.tsx
+++ b/src/apps/explorer/components/OrderWidget/view.tsx
@@ -14,11 +14,11 @@ const Wrapper = styled.div`
 export type Props = {
   order: Order | null
   isLoading: boolean
-  error?: string
+  errors: Record<string, string>
 }
 
 export const OrderWidgetView: React.FC<Props> = (props) => {
-  const { order, isLoading, error } = props
+  const { order, isLoading, errors } = props
 
   return (
     <Wrapper>
@@ -26,9 +26,11 @@ export const OrderWidgetView: React.FC<Props> = (props) => {
       {/* TODO: create common loading indicator */}
       {order?.buyToken && order?.sellToken && <OrderDetails order={order} />}
       {!order && !isLoading && <p>Order not found</p>}
-      {!isLoading && (!order?.buyToken || !order?.sellToken) && <p>Not able to load tokens</p>}
+      {!isLoading && order && (!order?.buyToken || !order?.sellToken) && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}
-      {error && <p>{error}</p>}
+      {Object.keys(errors).map((key) => (
+        <p key={key}>{errors[key]}</p>
+      ))}
       {isLoading && <FontAwesomeIcon icon={faSpinner} spin size="3x" />}
     </Wrapper>
   )

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -1,0 +1,2 @@
+/** Explorer app constants */
+export const ORDER_QUERY_INTERVAL = 10000 // in ms

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { formatSmart, TokenErc20 } from '@gnosis.pm/dex-js'
 
-import { getOrderExecutedAmounts, getOrderFilledAmount, getOrderStatus, RawOrder } from 'api/operator'
+import { Order } from 'api/operator'
 
 import { SimpleTable } from 'components/common/SimpleTable'
 import { StatusLabel } from 'components/orders/StatusLabel'
@@ -41,18 +41,30 @@ const Table = styled(SimpleTable)`
   }
 `
 
-// TODO: either use a RichOrder object or transform it here
-// TODO: for that we'll need token info (decimals, symbol)
-export type Props = { order: RawOrder; buyToken: TokenErc20; sellToken: TokenErc20 }
+export type Props = { order: Order; buyToken: TokenErc20; sellToken: TokenErc20 }
 
 export function OrderDetails(props: Props): JSX.Element {
   const { order, buyToken, sellToken } = props
-  const { uid, owner, kind, partiallyFillable, creationDate, validTo, buyAmount, sellAmount, executedFeeAmount } = order
+  const {
+    uid,
+    owner,
+    kind,
+    partiallyFillable,
+    creationDate,
+    expirationDate,
+    buyAmount,
+    sellAmount,
+    executedBuyAmount,
+    executedSellAmount,
+    executedFeeAmount,
+    filledAmount,
+    filledPercentage,
+  } = order
 
-  const status = useMemo(() => getOrderStatus(order), [order])
-
-  const { amount: filledAmount, percentage: filledPercentage } = useMemo(() => getOrderFilledAmount(order), [order])
-  const { executedBuyAmount, executedSellAmount } = useMemo(() => getOrderExecutedAmounts(order), [order])
+  // TODO: refactor getOrderStatus (there are new states)
+  // TODO: update order every x seconds until it expires. Setup an interval?
+  // const status = useMemo(() => getOrderStatus(order), [order])
+  const status = 'open'
 
   return (
     <Table
@@ -74,11 +86,11 @@ export function OrderDetails(props: Props): JSX.Element {
           </tr>
           <tr>
             <td>Submission Time</td>
-            <td>{creationDate}</td>
+            <td>{creationDate.toISOString()}</td>
           </tr>
           <tr>
             <td>Expiration Time</td>
-            <td>{new Date(validTo * 1000).toISOString()}</td>
+            <td>{expirationDate.toISOString()}</td>
           </tr>
           <tr>
             <td>Type</td>
@@ -91,11 +103,11 @@ export function OrderDetails(props: Props): JSX.Element {
           </tr>
           <tr>
             <td>Sell amount</td>
-            <td>{`${formatSmart(sellAmount, sellToken.decimals)} ${sellToken.symbol}`}</td>
+            <td>{`${formatSmart(sellAmount.toString(), sellToken.decimals)} ${sellToken.symbol}`}</td>
           </tr>
           <tr>
             <td>Buy amount</td>
-            <td>{`${formatSmart(buyAmount, buyToken.decimals)} ${buyToken.symbol}`}</td>
+            <td>{`${formatSmart(buyAmount.toString(), buyToken.decimals)} ${buyToken.symbol}`}</td>
           </tr>
           <tr>
             <td>Limit Price</td>
@@ -127,7 +139,7 @@ export function OrderDetails(props: Props): JSX.Element {
               </tr>
               <tr>
                 <td>Gas Fees paid</td>
-                <td>{formatSmart(executedFeeAmount, sellToken.decimals)}</td>
+                <td>{formatSmart(executedFeeAmount.toString(), sellToken.decimals)}</td>
               </tr>
             </>
           )}

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -57,14 +57,10 @@ export function OrderDetails(props: Props): JSX.Element {
     executedBuyAmount,
     executedSellAmount,
     executedFeeAmount,
+    status,
     filledAmount,
     filledPercentage,
   } = order
-
-  // TODO: refactor getOrderStatus (there are new states)
-  // TODO: update order every x seconds until it expires. Setup an interval?
-  // const status = useMemo(() => getOrderStatus(order), [order])
-  const status = 'open'
 
   return (
     <Table

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { formatSmart, TokenErc20 } from '@gnosis.pm/dex-js'
+import { formatSmart } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
@@ -41,10 +41,10 @@ const Table = styled(SimpleTable)`
   }
 `
 
-export type Props = { order: Order; buyToken: TokenErc20; sellToken: TokenErc20 }
+export type Props = { order: Order }
 
 export function OrderDetails(props: Props): JSX.Element {
-  const { order, buyToken, sellToken } = props
+  const { order } = props
   const {
     uid,
     owner,
@@ -60,7 +60,13 @@ export function OrderDetails(props: Props): JSX.Element {
     status,
     filledAmount,
     filledPercentage,
+    buyToken,
+    sellToken,
   } = order
+
+  if (!buyToken || !sellToken) {
+    return <div>Not sell or buy tokens loaded</div>
+  }
 
   return (
     <Table

--- a/src/hooks/useOperatorOrder.ts
+++ b/src/hooks/useOperatorOrder.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+
+import { Order, transformOrder } from 'api/operator'
+import { getOrder } from 'api/operator/operatorApi'
+
+import { useNetworkId } from 'state/network'
+import { useMultipleErc20 } from './useErc20'
+
+export function useOrder(orderId: string): { order: Order | null; error?: string; isLoading: boolean } {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [order, setOrder] = useState<Order | null>(null)
+
+  const networkId = useNetworkId()
+
+  useEffect(() => {
+    async function fetchOrder(): Promise<void> {
+      if (!networkId) return
+
+      setIsLoading(true)
+      setError('')
+
+      try {
+        const rawOrder = await getOrder({ networkId, orderId })
+        if (rawOrder) {
+          setOrder(transformOrder(rawOrder))
+        }
+      } catch (e) {
+        const msg = `Failed to fetch order: ${orderId}`
+        console.error(msg, e.message)
+        setError(msg)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchOrder()
+  }, [networkId, orderId])
+
+  return { order, isLoading, error }
+}
+
+type Result = {
+  order: Order | null
+  buyToken: TokenErc20 | null
+  sellToken: TokenErc20 | null
+  isLoading: boolean
+  error?: string
+}
+
+/**
+ * Aggregates the fetching of the order and related erc20s
+ *
+ * @param orderId The order id
+ */
+export function useOrderAndErc20s(orderId: string): Result {
+  const networkId = useNetworkId() || undefined
+
+  const { order, isLoading: isOrderLoading, error: orderError } = useOrder(orderId)
+  const addresses = order ? [order.buyTokenAddress, order.sellTokenAddress] : []
+
+  // TODO: consume errors obj
+  const { value, isLoading: areErc20Loading /*, error: erc20Errors*/ } = useMultipleErc20({ networkId, addresses })
+
+  const buyToken = value && value[order?.buyTokenAddress || '']
+  const sellToken = value && value[order?.sellTokenAddress || '']
+
+  return { order, buyToken, sellToken, isLoading: isOrderLoading || areErc20Loading, error: orderError }
+}

--- a/src/hooks/useOperatorOrder.ts
+++ b/src/hooks/useOperatorOrder.ts
@@ -8,10 +8,20 @@ import { getOrder } from 'api/operator/operatorApi'
 import { useNetworkId } from 'state/network'
 import { useMultipleErc20 } from './useErc20'
 
-export function useOrder(orderId: string): { order: Order | null; error?: string; isLoading: boolean } {
+type UseOrderResult = {
+  order: Order | null
+  error?: string
+  isLoading: boolean
+  forceUpdate: () => void
+}
+
+export function useOrder(orderId: string): UseOrderResult {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [order, setOrder] = useState<Order | null>(null)
+  // Hack to force component to update itself on demand
+  const [forcedUpdate, setForcedUpdate] = useState({})
+  const forceUpdate = (): void => setForcedUpdate({})
 
   const networkId = useNetworkId()
 
@@ -37,12 +47,12 @@ export function useOrder(orderId: string): { order: Order | null; error?: string
     }
 
     fetchOrder()
-  }, [networkId, orderId])
+  }, [networkId, orderId, forcedUpdate])
 
-  return { order, isLoading, error }
+  return { order, isLoading, error, forceUpdate }
 }
 
-type Result = {
+type UseOrderAndErc20sResult = {
   order: Order | null
   buyToken: TokenErc20 | null
   sellToken: TokenErc20 | null
@@ -52,13 +62,15 @@ type Result = {
 
 /**
  * Aggregates the fetching of the order and related erc20s
+ * Optionally sets an interval of how often to update Open orders
  *
  * @param orderId The order id
+ * @param updateInterval [Optional] How often should try to update the order
  */
-export function useOrderAndErc20s(orderId: string): Result {
+export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrderAndErc20sResult {
   const networkId = useNetworkId() || undefined
 
-  const { order, isLoading: isOrderLoading, error: orderError } = useOrder(orderId)
+  const { order, isLoading: isOrderLoading, error: orderError, forceUpdate } = useOrder(orderId)
   const addresses = order ? [order.buyTokenAddress, order.sellTokenAddress] : []
 
   // TODO: consume errors obj
@@ -66,6 +78,22 @@ export function useOrderAndErc20s(orderId: string): Result {
 
   const buyToken = value && value[order?.buyTokenAddress || '']
   const sellToken = value && value[order?.sellTokenAddress || '']
+
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout | null = null
+
+    // Only start the interval when:
+    // 1. Hook is configured to do so (`updateInterval` > 0)
+    // 2. Order exists
+    // 3. Order is not expired
+    if (updateInterval && order && order.expirationDate.getTime() > Date.now()) {
+      intervalId = setInterval(forceUpdate, updateInterval)
+    }
+
+    return (): void => {
+      intervalId && clearInterval(intervalId)
+    }
+  }, [forceUpdate, order, updateInterval])
 
   return { order, buyToken, sellToken, isLoading: isOrderLoading || areErc20Loading, error: orderError }
 }

--- a/src/hooks/useOperatorOrder.ts
+++ b/src/hooks/useOperatorOrder.ts
@@ -53,7 +53,7 @@ export function useOrder(orderId: string): UseOrderResult {
 type UseOrderAndErc20sResult = {
   order: Order | null
   isLoading: boolean
-  error?: string
+  errors: Record<string, string>
 }
 
 /**
@@ -70,7 +70,12 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
   const addresses = order ? [order.buyTokenAddress, order.sellTokenAddress] : []
 
   // TODO: consume errors obj
-  const { value, isLoading: areErc20Loading /*, error: erc20Errors*/ } = useMultipleErc20({ networkId, addresses })
+  const { value, isLoading: areErc20Loading, error: erc20Errors } = useMultipleErc20({ networkId, addresses })
+
+  const errors = { ...erc20Errors }
+  if (orderError) {
+    errors[orderId] = orderError
+  }
 
   if (order && value) {
     order.buyToken = value[order?.buyTokenAddress || '']
@@ -93,5 +98,5 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
     }
   }, [forceUpdate, order, updateInterval])
 
-  return { order, isLoading: isOrderLoading || areErc20Loading, error: orderError }
+  return { order, isLoading: isOrderLoading || areErc20Loading, errors }
 }

--- a/src/hooks/useOperatorOrder.ts
+++ b/src/hooks/useOperatorOrder.ts
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react'
 
-import { TokenErc20 } from '@gnosis.pm/dex-js'
-
 import { Order, transformOrder } from 'api/operator'
 import { getOrder } from 'api/operator/operatorApi'
 
@@ -54,8 +52,6 @@ export function useOrder(orderId: string): UseOrderResult {
 
 type UseOrderAndErc20sResult = {
   order: Order | null
-  buyToken: TokenErc20 | null
-  sellToken: TokenErc20 | null
   isLoading: boolean
   error?: string
 }
@@ -76,8 +72,10 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
   // TODO: consume errors obj
   const { value, isLoading: areErc20Loading /*, error: erc20Errors*/ } = useMultipleErc20({ networkId, addresses })
 
-  const buyToken = value && value[order?.buyTokenAddress || '']
-  const sellToken = value && value[order?.sellTokenAddress || '']
+  if (order && value) {
+    order.buyToken = value[order?.buyTokenAddress || '']
+    order.sellToken = value[order?.sellTokenAddress || '']
+  }
 
   useEffect(() => {
     let intervalId: NodeJS.Timeout | null = null
@@ -95,5 +93,5 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
     }
   }, [forceUpdate, order, updateInterval])
 
-  return { order, buyToken, sellToken, isLoading: isOrderLoading || areErc20Loading, error: orderError }
+  return { order, isLoading: isOrderLoading || areErc20Loading, error: orderError }
 }

--- a/test/api/OperatorApi/orderFilledAmount.test.ts
+++ b/test/api/OperatorApi/orderFilledAmount.test.ts
@@ -5,7 +5,7 @@ import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER, ZERO_BIG_NUMBER
 import { RawOrder } from 'api/operator'
 import { getOrderFilledAmount } from 'api/operator/utils'
 
-import { ORDER } from '../../../test/data'
+import { RAW_ORDER } from '../../../test/data'
 
 const TEN_PERCENT = new BigNumber('0.1')
 const ONE_HUNDRED_PERCENT = ONE_BIG_NUMBER
@@ -13,7 +13,7 @@ const ONE_HUNDRED_PERCENT = ONE_BIG_NUMBER
 describe('Order not filled', () => {
   describe('Buy order', () => {
     test('0% filled', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '0' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '0' }
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
     })
@@ -21,7 +21,7 @@ describe('Order not filled', () => {
   describe('Sell order', () => {
     test('0% filled', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '0',
@@ -36,7 +36,7 @@ describe('Order not filled', () => {
 describe('Order partially filled', () => {
   describe('Buy order', () => {
     test('10% filled', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '10' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '10' }
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
     })
@@ -44,7 +44,7 @@ describe('Order partially filled', () => {
   describe('Sell order', () => {
     test('10% filled, without fee', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '10',
@@ -55,7 +55,7 @@ describe('Order partially filled', () => {
     })
     test('10% filled, with fee', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '11',
@@ -71,7 +71,7 @@ describe('Order filled', () => {
   describe('Buy order', () => {
     test('100% filled, no surplus', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
@@ -83,7 +83,7 @@ describe('Order filled', () => {
     })
     test('100% filled, with surplus', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
@@ -97,7 +97,7 @@ describe('Order filled', () => {
   describe('Sell order', () => {
     test('100% filled, no surplus, no fee', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '100',
@@ -110,7 +110,7 @@ describe('Order filled', () => {
     })
     test('100% filled, with fee', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '110',
@@ -123,7 +123,7 @@ describe('Order filled', () => {
     })
     test('100% filled, with surplus', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '100',

--- a/test/api/OperatorApi/orderPrice.test.ts
+++ b/test/api/OperatorApi/orderPrice.test.ts
@@ -5,7 +5,7 @@ import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, TEN_BIG_NUMBER, ZERO_BIG_NUMBER
 import { RawOrder } from 'api/operator'
 import { getOrderExecutedPrice, getOrderLimitPrice, GetOrderPriceParams } from 'api/operator/utils'
 
-import { ORDER } from '../../data'
+import { RAW_ORDER } from '../../data'
 
 const ZERO_DOT_ONE = new BigNumber('0.1')
 
@@ -43,13 +43,13 @@ function _assertOrderPriceWithoutFills(_order: RawOrder): void {
 
 describe('Limit price', () => {
   describe('Buy order', () => {
-    const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
+    const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '1000', sellAmount: '100' }
 
     _assertOrderPrice(order, getOrderLimitPrice)
   })
 
   describe('Sell order', () => {
-    const order: RawOrder = { ...ORDER, kind: 'sell', buyAmount: '1000', sellAmount: '100' }
+    const order: RawOrder = { ...RAW_ORDER, kind: 'sell', buyAmount: '1000', sellAmount: '100' }
 
     _assertOrderPrice(order, getOrderLimitPrice)
   })
@@ -58,7 +58,7 @@ describe('Limit price', () => {
 describe('Executed price', () => {
   describe('Buy order', () => {
     const order: RawOrder = {
-      ...ORDER,
+      ...RAW_ORDER,
       kind: 'buy',
       executedBuyAmount: '1000',
       executedSellAmount: '110',
@@ -75,7 +75,7 @@ describe('Executed price', () => {
 
   describe('Sell order', () => {
     const order: RawOrder = {
-      ...ORDER,
+      ...RAW_ORDER,
       kind: 'sell',
       executedBuyAmount: '1000',
       executedSellAmount: '110',

--- a/test/api/OperatorApi/orderStatus.test.ts
+++ b/test/api/OperatorApi/orderStatus.test.ts
@@ -1,7 +1,7 @@
 import { RawOrder } from 'api/operator'
 import { getOrderStatus } from 'api/operator/utils'
 
-import { ORDER } from '../../data'
+import { RAW_ORDER } from '../../data'
 import { mockTimes, DATE } from '../../testHelpers'
 
 function _getCurrentTimestamp(): number {
@@ -18,18 +18,18 @@ beforeEach(mockTimes)
 describe('Filled status', () => {
   describe('Buy order', () => {
     test('Filled, within epsilon', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9999' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9999' }
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, exact amount', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '100' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '100' }
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, not yet expired', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
@@ -40,7 +40,7 @@ describe('Filled status', () => {
     })
     test('Filled, sell amount does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
@@ -52,7 +52,7 @@ describe('Filled status', () => {
     })
     test('Filled, fee does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
@@ -66,18 +66,18 @@ describe('Filled status', () => {
   })
   describe('Sell order', () => {
     test('Filled, within epsilon', () => {
-      const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9999' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9999' }
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, exact amount', () => {
-      const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '100', executedSellAmount: '100' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '100', executedSellAmount: '100' }
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, not yet expired', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '100',
@@ -88,7 +88,7 @@ describe('Filled status', () => {
     })
     test('Filled, with fee', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '90',
         executedSellAmount: '100',
@@ -99,7 +99,7 @@ describe('Filled status', () => {
     })
     test('Filled, buy amount does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '100',
@@ -115,18 +115,18 @@ describe('Filled status', () => {
 describe('Partially filled status', () => {
   describe('Buy order', () => {
     test('Partially filled, on the border to be considered filled', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9998' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9998' }
 
       expect(getOrderStatus(order)).toEqual('partially filled')
     })
     test('Partially filled', () => {
-      const order: RawOrder = { ...ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '11' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '11' }
 
       expect(getOrderStatus(order)).toEqual('partially filled')
     })
     test('Partially filled, sell amount does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '11',
@@ -139,13 +139,13 @@ describe('Partially filled status', () => {
   })
   describe('Sell order', () => {
     test('Partially filled, on the border to be considered filled', () => {
-      const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9998' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9998' }
 
       expect(getOrderStatus(order)).toEqual('partially filled')
     })
     test('Partially filled, with fee, on the border to be considered filled', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '9000',
         executedSellAmount: '9996',
@@ -155,13 +155,13 @@ describe('Partially filled status', () => {
       expect(getOrderStatus(order)).toEqual('partially filled')
     })
     test('Partially filled', () => {
-      const order: RawOrder = { ...ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '11' }
+      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '11' }
 
       expect(getOrderStatus(order)).toEqual('partially filled')
     })
     test('Partially filled, buy amount does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '11',
@@ -178,7 +178,7 @@ describe('Expired status', () => {
   describe('Buy order', () => {
     test('Expired', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '0',
@@ -190,7 +190,7 @@ describe('Expired status', () => {
   describe('Sell order', () => {
     test('Expired', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '0',
@@ -205,7 +205,7 @@ describe('Open status', () => {
   describe('Buy order', () => {
     test('Open, no fills', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '0',
@@ -215,7 +215,7 @@ describe('Open status', () => {
     })
     test('Open, with partial fills', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '10',
@@ -225,7 +225,7 @@ describe('Open status', () => {
     })
     test('Open, sell amount does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '10',
@@ -239,7 +239,7 @@ describe('Open status', () => {
   describe('Sell order', () => {
     test('Open, no fills', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '0',
@@ -249,7 +249,7 @@ describe('Open status', () => {
     })
     test('Open, with partial fills', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '10',
@@ -259,7 +259,7 @@ describe('Open status', () => {
     })
     test('Open, buy amount does not affect output', () => {
       const order: RawOrder = {
-        ...ORDER,
+        ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '10',

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -1,8 +1,8 @@
-import { RawOrder } from 'api/operator'
+import { Order, RawOrder, transformOrder } from 'api/operator'
 
-import { FEE_TOKEN } from './basic'
+import { USDT, WETH } from './erc20s'
 
-export const ORDER: RawOrder = {
+export const RAW_ORDER: RawOrder = {
   creationDate: '2021-01-20T23:15:07.892538607Z',
   owner: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
   uid: 'asdasdasd',
@@ -13,8 +13,8 @@ export const ORDER: RawOrder = {
   feeAmount: '0',
   executedFeeAmount: '0',
   invalidated: false,
-  sellToken: '0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d',
-  buyToken: FEE_TOKEN,
+  sellToken: WETH.address,
+  buyToken: USDT.address,
   validTo: 0,
   appData: 0,
   kind: 'sell',
@@ -22,3 +22,5 @@ export const ORDER: RawOrder = {
   signature:
     '0x04dca25f59e9ac744c4093530a38f1719c4e0b1ce8e4b68c8018b6b05fd4a6944e1dcf2a009df2d5932f7c034b4a24da0999f9309dd5108d51d54236b605ed991c',
 }
+
+export const RICH_ORDER: Order = { ...transformOrder(RAW_ORDER), buyToken: WETH, sellToken: USDT }

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -1,4 +1,8 @@
-import { Order, RawOrder, transformOrder } from 'api/operator'
+import BigNumber from 'bignumber.js'
+
+import { Order, RawOrder } from 'api/operator'
+
+import { ZERO_BIG_NUMBER } from 'const'
 
 import { USDT, WETH } from './erc20s'
 
@@ -23,4 +27,22 @@ export const RAW_ORDER: RawOrder = {
     '0x04dca25f59e9ac744c4093530a38f1719c4e0b1ce8e4b68c8018b6b05fd4a6944e1dcf2a009df2d5932f7c034b4a24da0999f9309dd5108d51d54236b605ed991c',
 }
 
-export const RICH_ORDER: Order = { ...transformOrder(RAW_ORDER), buyToken: WETH, sellToken: USDT }
+export const RICH_ORDER: Order = {
+  ...RAW_ORDER,
+  creationDate: new Date(RAW_ORDER.creationDate),
+  expirationDate: new Date(RAW_ORDER.validTo * 1000),
+  buyTokenAddress: RAW_ORDER.buyToken,
+  sellTokenAddress: RAW_ORDER.sellToken,
+  buyAmount: new BigNumber(RAW_ORDER.buyAmount),
+  sellAmount: new BigNumber(RAW_ORDER.sellAmount),
+  executedBuyAmount: ZERO_BIG_NUMBER,
+  executedSellAmount: ZERO_BIG_NUMBER,
+  feeAmount: new BigNumber(RAW_ORDER.feeAmount),
+  executedFeeAmount: new BigNumber(RAW_ORDER.executedFeeAmount),
+  cancelled: RAW_ORDER.invalidated,
+  status: 'open',
+  filledAmount: ZERO_BIG_NUMBER,
+  filledPercentage: ZERO_BIG_NUMBER,
+  buyToken: WETH,
+  sellToken: USDT,
+}


### PR DESCRIPTION
# Summary

Part of #92
Waterfalls into https://github.com/gnosis/gp-ui/pull/146/files
Follow up to https://github.com/gnosis/gp-ui/pull/146#discussion_r576417353

New order type, transforming between `RawOrder` and `Order` (the new type) and new hook vastly improving `OrderWidget`.

Still more refactor to be done. We'll get there.