### PR TITLE
Misc order details changes

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -48,6 +48,7 @@ export type RawOrder = {
  * Some fields are kept as is.
  */
 export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature'> & {
+  shortId: string
   creationDate: Date
   expirationDate: Date
   buyTokenAddress: string

--- a/src/api/operator/utils.ts
+++ b/src/api/operator/utils.ts
@@ -144,6 +144,10 @@ export function getOrderExecutedPrice({
   return inverted ? invertPrice(price) : price
 }
 
+function getShortOrderId(orderId: string, length = 8): string {
+  return orderId.replace(/^0x/, '').slice(0, length)
+}
+
 /**
  * Transforms a RawOrder into an Order object
  *
@@ -162,12 +166,14 @@ export function transformOrder(rawOrder: RawOrder): Order {
     invalidated,
     ...rest
   } = rawOrder
+  const shortId = getShortOrderId(rawOrder.uid)
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(rawOrder)
   const status = getOrderStatus(rawOrder)
   const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(rawOrder)
 
   return {
     ...rest,
+    shortId,
     creationDate: new Date(creationDate),
     expirationDate: new Date(validTo * 1000),
     buyTokenAddress: buyToken,

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -130,6 +130,22 @@ export function OrderDetails(props: Props): JSX.Element {
           {!partiallyFillable && (
             <>
               <tr>
+                <td>Execution price</td>
+                <td>
+                  {!filledAmount.isZero() ? (
+                    <OrderPriceDisplay
+                      buyAmount={executedBuyAmount}
+                      buyToken={buyToken}
+                      sellAmount={executedSellAmount}
+                      sellToken={sellToken}
+                      showInvertButton
+                    />
+                  ) : (
+                    '-'
+                  )}
+                </td>
+              </tr>
+              <tr>
                 <td>Filled</td>
                 <td>
                   {kind === 'sell'

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -5,6 +5,8 @@ import { formatSmart } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
+import { capitalize } from 'utils'
+
 import { SimpleTable } from 'components/common/SimpleTable'
 import { StatusLabel } from 'components/orders/StatusLabel'
 import { OrderPriceDisplay } from 'components/orders/OrderPriceDisplay'
@@ -102,10 +104,7 @@ export function OrderDetails(props: Props): JSX.Element {
           <tr>
             <td>Type</td>
             <td>
-              {kind === 'sell'
-                ? `Sell ${sellToken.symbol} for ${buyToken.symbol}`
-                : `Buy ${buyToken.symbol} for ${sellToken.symbol}`}
-              {partiallyFillable && ' (fill or kill)'}
+              {capitalize(kind)} order {!partiallyFillable && '(Fill or Kill)'}
             </td>
           </tr>
           <tr>

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -49,7 +49,7 @@ export type Props = { order: Order }
 export function OrderDetails(props: Props): JSX.Element {
   const { order } = props
   const {
-    uid,
+    shortId,
     owner,
     kind,
     partiallyFillable,
@@ -77,7 +77,7 @@ export function OrderDetails(props: Props): JSX.Element {
         <>
           <tr>
             <td>Order Id</td>
-            <td>{uid}</td>
+            <td>{shortId}</td>
           </tr>
           <tr>
             <td>From</td>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -200,3 +200,10 @@ export function formatPriceWithFloor(price: BigNumber): string {
   const displayPrice = amountToPrecisionDown(price, DEFAULT_DECIMALS).toString(10)
   return price.gt(LOW_PRICE_FLOOR) ? displayPrice : '< ' + LOW_PRICE_FLOOR.toString(10)
 }
+
+export function capitalize(sentence: string): string {
+  return sentence
+    .split(' ')
+    .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -29,6 +29,7 @@ export const RAW_ORDER: RawOrder = {
 
 export const RICH_ORDER: Order = {
   ...RAW_ORDER,
+  shortId: 'adef89ade',
   creationDate: new Date(RAW_ORDER.creationDate),
   expirationDate: new Date(RAW_ORDER.validTo * 1000),
   buyTokenAddress: RAW_ORDER.buyToken,

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -9,7 +9,7 @@ import { USDT, WETH } from './erc20s'
 export const RAW_ORDER: RawOrder = {
   creationDate: '2021-01-20T23:15:07.892538607Z',
   owner: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
-  uid: 'asdasdasd',
+  uid: '0xadef89adea9e8d7f987e98f79a87efde5f7e65df65e76d5f67e5d76f5edf',
   buyAmount: '0',
   executedBuyAmount: '0',
   sellAmount: '0',
@@ -29,7 +29,7 @@ export const RAW_ORDER: RawOrder = {
 
 export const RICH_ORDER: Order = {
   ...RAW_ORDER,
-  shortId: 'adef89ade',
+  shortId: 'adef89ad',
   creationDate: new Date(RAW_ORDER.creationDate),
   expirationDate: new Date(RAW_ORDER.validTo * 1000),
   buyTokenAddress: RAW_ORDER.buyToken,


### PR DESCRIPTION
# Summary

Waterfalls into https://github.com/gnosis/gp-ui/pull/162

Misc changes to details page I was already working on and are too small to deserve an issue on their own:
- Updated Type row
![screenshot_2021-02-18_16-57-03](https://user-images.githubusercontent.com/43217/108441612-54084680-720a-11eb-8c8d-e5bacec80b5b.png)
- Displaying a short id instead of the full uid
![screenshot_2021-02-18_16-56-56](https://user-images.githubusercontent.com/43217/108441619-59659100-720a-11eb-8065-91f0ca07a4c3.png)
- Added Execution price row to fill or kill orders (`-` when not filled)
![screenshot_2021-02-18_16-57-10](https://user-images.githubusercontent.com/43217/108441605-510d5600-720a-11eb-91eb-ff82e86d372b.png)


