### PR TITLE
92/final order widget refactor

### DIFF
--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -5,12 +5,12 @@ import { useOrderAndErc20s } from 'hooks/useOperatorOrder'
 
 import { ORDER_QUERY_INTERVAL } from 'apps/explorer/const'
 
-import { OrderWidgetView } from './view'
+import { OrderDetails } from 'components/orders/OrderDetails'
 
 export const OrderWidget: React.FC = () => {
   const { orderId } = useParams<{ orderId: string }>()
 
   const { order, isLoading, errors } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
 
-  return <OrderWidgetView order={order} isLoading={isLoading} errors={errors} />
+  return <OrderDetails order={order} isLoading={isLoading} errors={errors} />
 }

--- a/src/apps/explorer/components/OrderWidget/view.tsx
+++ b/src/apps/explorer/components/OrderWidget/view.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { Order } from 'api/operator'
 
-import { OrderDetails } from 'components/orders/OrderDetails'
+import { DetailsTable } from 'components/orders/DetailsTable'
 
 const Wrapper = styled.div`
   padding: 1.6rem 0;
@@ -24,7 +24,7 @@ export const OrderWidgetView: React.FC<Props> = (props) => {
     <Wrapper>
       <h2>Order details</h2>
       {/* TODO: create common loading indicator */}
-      {order?.buyToken && order?.sellToken && <OrderDetails order={order} />}
+      {order?.buyToken && order?.sellToken && <DetailsTable order={order} />}
       {!order && !isLoading && <p>Order not found</p>}
       {!isLoading && order && (!order?.buyToken || !order?.sellToken) && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}

--- a/src/components/orders/DetailsTable/DetailsTable.stories.tsx
+++ b/src/components/orders/DetailsTable/DetailsTable.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+import BigNumber from 'bignumber.js'
+import { add, sub } from 'date-fns'
+
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+
+import { ONE_BIG_NUMBER } from 'const'
+
+import { DetailsTable, Props } from '.'
+
+import { RICH_ORDER } from '../../../../test/data'
+
+export default {
+  title: 'orders/DetailsTable',
+  component: DetailsTable,
+  decorators: [GlobalStyles, ThemeToggler],
+  argTypes: { order: { control: null } },
+} as Meta
+
+const Template: Story<Props> = (args) => <DetailsTable {...args} />
+
+const order = {
+  ...RICH_ORDER,
+  buyAmount: new BigNumber('1000000000000000000'), // 1WETH
+  sellAmount: new BigNumber('5000000000'), //5000 USDT
+  creationDate: sub(new Date(), { hours: 1 }),
+  expirationDate: add(new Date(), { hours: 1 }),
+}
+
+const defaultProps: Props = { order }
+
+export const DefaultFillOrKill = Template.bind({})
+DefaultFillOrKill.args = { ...defaultProps }
+
+export const FilledFillOrKill = Template.bind({})
+FilledFillOrKill.args = {
+  ...defaultProps,
+  order: {
+    ...order,
+    status: 'filled',
+    executedBuyAmount: order.buyAmount,
+    executedSellAmount: order.sellAmount,
+    filledAmount: order.sellAmount,
+    filledPercentage: ONE_BIG_NUMBER,
+  },
+}
+
+export const DefaultPartiallyFillable = Template.bind({})
+DefaultPartiallyFillable.args = { ...defaultProps, order: { ...order, partiallyFillable: true } }
+
+export const FilledPartiallyFillable = Template.bind({})
+FilledPartiallyFillable.args = {
+  ...defaultProps,
+  order: {
+    ...order,
+    partiallyFillable: true,
+    status: 'filled',
+    executedBuyAmount: order.buyAmount,
+    executedSellAmount: order.sellAmount,
+    filledAmount: order.sellAmount,
+    filledPercentage: ONE_BIG_NUMBER,
+  },
+}

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -46,7 +46,7 @@ const Table = styled(SimpleTable)`
 
 export type Props = { order: Order }
 
-export function OrderDetails(props: Props): JSX.Element {
+export function DetailsTable(props: Props): JSX.Element {
   const { order } = props
   const {
     shortId,

--- a/src/components/orders/OrderDetails/OrderDetails.stories.tsx
+++ b/src/components/orders/OrderDetails/OrderDetails.stories.tsx
@@ -4,18 +4,18 @@ import { Story, Meta } from '@storybook/react/types-6-0'
 
 import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
 
-import { OrderWidgetView, Props } from './view'
+import { OrderDetails, Props } from '.'
 
-import { RICH_ORDER } from '../../../../../test/data'
+import { RICH_ORDER } from '../../../../test/data'
 
 export default {
-  title: 'Explorer/OrderWidget',
-  component: OrderWidgetView,
+  title: 'orders/OrderDetails',
+  component: OrderDetails,
   decorators: [GlobalStyles, ThemeToggler],
   //   argTypes: { header: { control: null }, children: { control: null } },
 } as Meta
 
-const Template: Story<Props> = (args) => <OrderWidgetView {...args} />
+const Template: Story<Props> = (args) => <OrderDetails {...args} />
 
 const defaultProps: Props = { order: null, isLoading: false, errors: {} }
 

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -17,7 +17,7 @@ export type Props = {
   errors: Record<string, string>
 }
 
-export const OrderWidgetView: React.FC<Props> = (props) => {
+export const OrderDetails: React.FC<Props> = (props) => {
   const { order, isLoading, errors } = props
 
   return (

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -23,14 +23,16 @@ export const OrderDetails: React.FC<Props> = (props) => {
   return (
     <Wrapper>
       <h2>Order details</h2>
-      {/* TODO: create common loading indicator */}
+      {/* TODO: add tabs (overview/fills) */}
       {order?.buyToken && order?.sellToken && <DetailsTable order={order} />}
+      {/* TODO: add fills tab for partiallyFillable orders */}
       {!order && !isLoading && <p>Order not found</p>}
       {!isLoading && order && (!order?.buyToken || !order?.sellToken) && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}
       {Object.keys(errors).map((key) => (
         <p key={key}>{errors[key]}</p>
       ))}
+      {/* TODO: create common loading indicator */}
       {isLoading && <FontAwesomeIcon icon={faSpinner} spin size="3x" />}
     </Wrapper>
   )


### PR DESCRIPTION
Closes #92 

Final step in this refactoring
![screenshot_2021-02-19_13-16-24](https://user-images.githubusercontent.com/43217/108562378-9be3a800-72b4-11eb-9835-ea57bd87a305.png)


- Renamed former `OrderDetails` to `DetailsTable`
- Moved `OrderWidgetView` to `components/orders` folder
- Renamed `OrderWidgetView` to `OrderDetails`
- Added storybook stories for `OrderDetails`
![screenshot_2021-02-19_13-15-01](https://user-images.githubusercontent.com/43217/108562233-68088280-72b4-11eb-85b2-41f736d12149.png)
