### PR TITLE
169/transaction hash row

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -48,6 +48,7 @@ export type RawOrder = {
  * Some fields are kept as is.
  */
 export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature'> & {
+  txHash?: string
   shortId: string
   creationDate: Date
   expirationDate: Date

--- a/src/components/orders/DetailsTable/DetailsTable.stories.tsx
+++ b/src/components/orders/DetailsTable/DetailsTable.stories.tsx
@@ -27,6 +27,7 @@ const order = {
   sellAmount: new BigNumber('5000000000'), //5000 USDT
   creationDate: sub(new Date(), { hours: 1 }),
   expirationDate: add(new Date(), { hours: 1 }),
+  txHash: '0x489d8fd1efd43394c7c2b26216f36f1ab49b8d67623047e0fcb60efa2a2c420b',
 }
 
 const defaultProps: Props = { order }

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { formatSmart } from '@gnosis.pm/dex-js'
+import { abbreviateString, formatSmart } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
 import { capitalize } from 'utils'
 
 import { SimpleTable } from 'components/common/SimpleTable'
+
 import { StatusLabel } from 'components/orders/StatusLabel'
 import { OrderPriceDisplay } from 'components/orders/OrderPriceDisplay'
 import { DateDisplay } from 'components/orders/DateDisplay'
-import { OrderSurplusDisplay } from '../OrderSurplusDisplay'
+import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
+import { RowWithCopyButton } from 'components/orders/RowWithCopyButton'
 
 const Table = styled(SimpleTable)`
   border: 0.1rem solid ${({ theme }): string => theme.borderPrimary};
@@ -79,16 +81,26 @@ export function DetailsTable(props: Props): JSX.Element {
         <>
           <tr>
             <td>Order Id</td>
-            <td>{shortId}</td>
+            <td>
+              <RowWithCopyButton textToCopy={shortId} contentsToDisplay={shortId} />
+            </td>
           </tr>
           <tr>
             <td>From</td>
-            <td>{owner}</td>
+            <td>
+              <RowWithCopyButton textToCopy={owner} contentsToDisplay={owner} />
+            </td>
           </tr>
           {!partiallyFillable && (
             <tr>
               <td>Transaction hash</td>
-              <td>{txHash || '-'}</td>
+              <td>
+                {txHash ? (
+                  <RowWithCopyButton textToCopy={txHash} contentsToDisplay={abbreviateString(txHash, 12, 10)} />
+                ) : (
+                  '-'
+                )}
+              </td>
             </tr>
           )}
           <tr>

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -54,6 +54,7 @@ export type Props = { order: Order }
 export function DetailsTable(props: Props): JSX.Element | null {
   const { order } = props
   const {
+    uid,
     shortId,
     owner,
     txHash,
@@ -84,7 +85,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
           <tr>
             <td>Order Id</td>
             <td>
-              <RowWithCopyButton textToCopy={shortId} contentsToDisplay={shortId} />
+              <RowWithCopyButton textToCopy={uid} contentsToDisplay={shortId} />
             </td>
           </tr>
           <tr>

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -49,7 +49,7 @@ const Table = styled(SimpleTable)`
 
 export type Props = { order: Order }
 
-export function DetailsTable(props: Props): JSX.Element {
+export function DetailsTable(props: Props): JSX.Element | null {
   const { order } = props
   const {
     shortId,
@@ -72,7 +72,7 @@ export function DetailsTable(props: Props): JSX.Element {
   } = order
 
   if (!buyToken || !sellToken) {
-    return <div>Not sell or buy tokens loaded</div>
+    return null
   }
 
   return (

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -52,6 +52,7 @@ export function DetailsTable(props: Props): JSX.Element {
   const {
     shortId,
     owner,
+    txHash,
     kind,
     partiallyFillable,
     creationDate,
@@ -84,6 +85,12 @@ export function DetailsTable(props: Props): JSX.Element {
             <td>From</td>
             <td>{owner}</td>
           </tr>
+          {!partiallyFillable && (
+            <tr>
+              <td>Transaction hash</td>
+              <td>{txHash || '-'}</td>
+            </tr>
+          )}
           <tr>
             <td>Status</td>
             <td>

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { abbreviateString, formatSmart } from '@gnosis.pm/dex-js'
+import { formatSmart } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
 import { capitalize } from 'utils'
+
+import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorerLink'
 
 import { SimpleTable } from 'components/common/SimpleTable'
 
@@ -88,7 +90,10 @@ export function DetailsTable(props: Props): JSX.Element | null {
           <tr>
             <td>From</td>
             <td>
-              <RowWithCopyButton textToCopy={owner} contentsToDisplay={owner} />
+              <RowWithCopyButton
+                textToCopy={owner}
+                contentsToDisplay={<BlockExplorerLink identifier={owner} type="address" label={owner} />}
+              />
             </td>
           </tr>
           {!partiallyFillable && (
@@ -96,7 +101,10 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <td>Transaction hash</td>
               <td>
                 {txHash ? (
-                  <RowWithCopyButton textToCopy={txHash} contentsToDisplay={abbreviateString(txHash, 12, 10)} />
+                  <RowWithCopyButton
+                    textToCopy={txHash}
+                    contentsToDisplay={<BlockExplorerLink identifier={txHash} type="tx" label={txHash} />}
+                  />
                 ) : (
                   '-'
                 )}

--- a/src/components/orders/RowWithCopyButton/index.tsx
+++ b/src/components/orders/RowWithCopyButton/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { CopyButton } from 'components/common/CopyButton'
+
+const Wrapper = styled.span`
+  display: flex;
+  flex-wrap: no;
+
+  & > :first-child {
+    margin-right: 0.5rem;
+  }
+`
+
+type Props = {
+  textToCopy: string
+  contentsToDisplay: string | JSX.Element
+}
+
+export function RowWithCopyButton(props: Props): JSX.Element {
+  const { textToCopy, contentsToDisplay } = props
+
+  // Wrap contents in a <span> if it's a raw string for proper CSS spacing
+  const contentsComponent = typeof contentsToDisplay === 'string' ? <span>{contentsToDisplay}</span> : contentsToDisplay
+
+  return (
+    <Wrapper>
+      {contentsComponent} <CopyButton text={textToCopy} />
+    </Wrapper>
+  )
+}

--- a/src/theme/styles/colours.ts
+++ b/src/theme/styles/colours.ts
@@ -49,6 +49,7 @@ export interface Colors {
   blue1: Color
   blue2: Color
   blue3?: Color
+  orange1: Color
 }
 
 export const BASE_COLOURS = {
@@ -65,6 +66,7 @@ export const BASE_COLOURS = {
   yellow2: '#f1851d',
   blue1: '#2172E5',
   blue2: '#3F77FF',
+  orange1: '#D96D49',
 
   // labels
   labelTextExpired: '#DB843A',
@@ -78,7 +80,7 @@ export const LIGHT_COLOURS = {
   textPrimary1: '#FFF',
   textSecondary1: '#EDEDED',
   textSecondary2: '#9797B8',
-  textActive1: '',
+  textActive1: '#D96D49',
   textDisabled: '#31323E',
 
   icon: '#657795B3',
@@ -107,7 +109,7 @@ export const DARK_COLOURS = {
   textPrimary1: '#FFF',
   textSecondary1: '#EDEDED',
   textSecondary2: '#9797B8',
-  textActive1: '',
+  textActive1: '#D96D49',
   textDisabled: '#31323E',
 
   icon: '#8D8DA980',

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -199,8 +199,12 @@ export function transformOrder(rawOrder: RawOrder): Order {
   const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(rawOrder)
   const { amount: surplusAmount, percentage: surplusPercentage } = getOrderSurplus(rawOrder)
 
+  // TODO: fill in tx hash for fill or kill orders when available from the api
+  const txHash = '0x489d8fd1efd43394c7c2b26216f36f1ab49b8d67623047e0fcb60efa2a2c420b'
+
   return {
     ...rest,
+    txHash,
     shortId,
     creationDate: new Date(creationDate),
     expirationDate: new Date(validTo * 1000),


### PR DESCRIPTION
# Summary

Closes #169

~Waterfalls into https://github.com/gnosis/gp-ui/pull/183~

# Testing

https://pr185--gpui.review.gnosisdev.com/rinkeby/orders/0xa6223509c0a41f992995d8781c3452ae8e2f55640b21d057fc02c7fb5a1674b35b0abe214ab7875562adee331deff0fe1912fe4260246928/


## Notes
- `txHash` is using a fake value. Data not yet available from the API
- ~Block explorer link to be added once https://github.com/gnosis/gp-ui/pull/184 is merged~ added
- ~Copy button not yet implemented, will come as a separated PR~ added

~So this PR just adds a row with fake data :sweat_smile:~ a bit more stuff now

Also:

- Added block explorer link to `From` row
- Added copy button to all 3 rows
- Set design color to links

![screenshot_2021-02-23_14-32-54](https://user-images.githubusercontent.com/43217/108917033-f6964000-75e3-11eb-8aa3-c7165ac50dc7.png)
 