### PR TITLE
207/network state on storybook

### DIFF
--- a/src/components/orders/AmountsDisplay/AmountsDisplay.stories.tsx
+++ b/src/components/orders/AmountsDisplay/AmountsDisplay.stories.tsx
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0'
 
-import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+import { GlobalStyles, NetworkDecorator, ThemeToggler } from 'storybook/decorators'
 
 import { AmountsDisplay, Props } from '.'
 
@@ -12,7 +12,7 @@ import { RICH_ORDER } from '../../../../test/data'
 export default {
   title: 'orders/AmountsDisplay',
   component: AmountsDisplay,
-  decorators: [GlobalStyles, ThemeToggler],
+  decorators: [GlobalStyles, NetworkDecorator, ThemeToggler],
 } as Meta
 
 const Template: Story<Props> = (args) => (

--- a/src/components/orders/DetailsTable/DetailsTable.stories.tsx
+++ b/src/components/orders/DetailsTable/DetailsTable.stories.tsx
@@ -4,7 +4,7 @@ import { Story, Meta } from '@storybook/react/types-6-0'
 import BigNumber from 'bignumber.js'
 import { add, sub } from 'date-fns'
 
-import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+import { GlobalStyles, NetworkDecorator, ThemeToggler } from 'storybook/decorators'
 
 import { ONE_BIG_NUMBER } from 'const'
 
@@ -15,7 +15,7 @@ import { RICH_ORDER } from '../../../../test/data'
 export default {
   title: 'orders/DetailsTable',
   component: DetailsTable,
-  decorators: [GlobalStyles, ThemeToggler],
+  decorators: [GlobalStyles, NetworkDecorator, ThemeToggler],
   argTypes: { order: { control: null } },
 } as Meta
 

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -47,7 +47,7 @@ const ThemeTogglerUnwrapped: React.FC = ({ children }) => {
       </ThemeToggle>
       <br />
       <br />
-      <code>Current theme: {themeMode.toUpperCase()}</code>
+      <code style={{ fontSize: '12px' }}>Current theme: {themeMode.toUpperCase()}</code>
     </>
   )
 }

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -17,6 +17,10 @@ import { useThemeManager } from 'hooks/useThemeManager'
 
 import { withGlobalContext } from 'hooks/useGlobalState'
 import { GLOBAL_INITIAL_STATE, globalRootReducer } from 'state'
+import { reducer as networkReducer } from 'state/network'
+
+import { Network } from 'types'
+import combineReducers from 'combine-reducers'
 
 export const GlobalStyles = (DecoratedStory: () => StoryFnReactReturnType): JSX.Element => (
   <>
@@ -53,6 +57,15 @@ const WrappedThemeToggler: React.FC = withGlobalContext(ThemeTogglerUnwrapped, G
 export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => (
   <WrappedThemeToggler>{DecoratedStory()}</WrappedThemeToggler>
 )
+
+export function NetworkDecorator(DecoratedStory: () => JSX.Element): JSX.Element {
+  const Component = withGlobalContext(
+    DecoratedStory,
+    () => ({ networkId: Network.Mainnet }),
+    combineReducers({ networkId: networkReducer }),
+  )
+  return <Component />
+}
 
 export const Router = (DecoratedStory: () => JSX.Element): JSX.Element => (
   <MemoryRouter>{DecoratedStory()}</MemoryRouter>


### PR DESCRIPTION
# Summary

Closes #207 

Network state on storybook as a decorator.

Nothing fancy like a network switch. Defaults to mainnet and that's it.
Now stories that depend on the state will work properly (check `AmountsDisplay` and `DetailsTable`)