### PR TITLE
Fix non-boolean attribute warning for CopyButton

### DIFF
--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -7,7 +7,13 @@ import CopyToClipboard from 'react-copy-to-clipboard'
 
 import { DISPLAY_TEXT_COPIED_CHECK } from 'apps/explorer/const'
 
-const Icon = styled(FontAwesomeIcon)<{ copied: boolean }>`
+// Why is `copied` not a boolean?
+//   Because it's passed down to parent component (`FontAwesomeIcon`) and
+// since it's not consumed in the component, it's passed down to the HTML.
+//   Which does not like to receive boolean values, with an error like:
+// "Warning: Received `false` for a non-boolean attribute `copied`"
+//   Effectively though, it's treated as a boolean, thus the value doesn't matter
+const Icon = styled(FontAwesomeIcon)<{ copied?: string }>`
   color: ${({ theme, copied }): string => (copied ? theme.green : theme.grey)};
   transition: color 0.2s ease-in;
   cursor: ${({ copied }): string => (copied ? 'reset' : 'pointer')};
@@ -54,7 +60,7 @@ export function CopyButton(props: Props): JSX.Element {
   return (
     <CopyToClipboard text={text} onCopy={onCopy}>
       <span>
-        <Icon icon={copied ? faCheck : faCopy} copied={copied} /> {copied && <span>Copied</span>}
+        <Icon icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} /> {copied && <span>Copied</span>}
       </span>
     </CopyToClipboard>
   )


### PR DESCRIPTION
# Summary

Fixes non-boolean HTML error/warning:
![screenshot_2021-02-26_09-54-13](https://user-images.githubusercontent.com/43217/109336639-8c1a1580-7818-11eb-8f69-8f80362bce60.png)

# Testing
1. Open the order details page
2. Open the console
3. Verify the error mentioned above is not there
