### PR TITLE
178/update order statuses

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -64,6 +64,7 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   executedFeeAmount: BigNumber
   cancelled: boolean
   status: OrderStatus
+  partiallyFilled: boolean
   filledAmount: BigNumber
   filledPercentage: BigNumber
   surplusAmount: BigNumber

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -19,7 +19,7 @@ export interface FeeInformation {
 
 export type OrderKind = 'sell' | 'buy'
 
-export type OrderStatus = 'open' | 'filled' | 'expired' | 'partially filled'
+export type OrderStatus = 'open' | 'filled' | 'canceled' | 'expired'
 
 // Raw API response
 export type RawOrder = {

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -97,6 +97,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
     executedBuyAmount,
     executedSellAmount,
     status,
+    partiallyFilled,
     filledAmount,
     surplusAmount,
     buyToken,
@@ -152,7 +153,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.status} /> Status
             </td>
             <td>
-              <StatusLabel status={status} />
+              <StatusLabel status={status} partiallyFilled={partiallyFilled} />
             </td>
           </tr>
           <tr>

--- a/src/components/orders/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/orders/StatusLabel/StatusLabel.stories.tsx
@@ -14,12 +14,14 @@ export default {
 
 const Template: Story<Props> = (args) => <StatusLabel {...args} />
 
+export const Filled = Template.bind({})
+Filled.args = { status: 'filled' }
+
 export const Expired = Template.bind({})
 Expired.args = { status: 'expired' }
 
-export const Filled = Template.bind({})
-Filled.args = { status: 'filled' }
-export const PartiallyFilled = Template.bind({})
-PartiallyFilled.args = { status: 'partially filled' }
+export const Canceled = Template.bind({})
+Canceled.args = { status: 'canceled' }
+
 export const Open = Template.bind({})
 Open.args = { status: 'open' }

--- a/src/components/orders/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/orders/StatusLabel/StatusLabel.stories.tsx
@@ -25,3 +25,10 @@ Canceled.args = { status: 'canceled' }
 
 export const Open = Template.bind({})
 Open.args = { status: 'open' }
+
+export const OpenPartiallyFilled = Template.bind({})
+OpenPartiallyFilled.args = { status: 'open', partiallyFilled: true }
+export const ExpiredPartiallyFilled = Template.bind({})
+ExpiredPartiallyFilled.args = { status: 'expired', partiallyFilled: true }
+export const CanceledPartiallyFilled = Template.bind({})
+CanceledPartiallyFilled.args = { status: 'canceled', partiallyFilled: true }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { DefaultTheme } from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCheckCircle, faClock, faDotCircle, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faCheckCircle, faClock, faDotCircle, faTimesCircle, IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
 import { OrderStatus } from 'api/operator'
 
@@ -12,11 +12,11 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
 
   switch (status) {
     case 'expired':
+    case 'canceled':
       text = theme.orange
       background = theme.orangeOpacity
       break
     case 'filled':
-    case 'partially filled':
       text = theme.green
       background = theme.greenOpacity
       break
@@ -53,8 +53,9 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
     case 'expired':
       return faClock
     case 'filled':
-    case 'partially filled':
       return faCheckCircle
+    case 'canceled':
+      return faTimesCircle
     case 'open':
       return faDotCircle
   }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -5,7 +5,7 @@ import { faCheckCircle, faClock, faDotCircle, faTimesCircle, IconDefinition } fr
 
 import { OrderStatus } from 'api/operator'
 
-export type Props = { status: OrderStatus }
+type DisplayProps = { status: OrderStatus }
 
 function setStatusColors({ theme, status }: { theme: DefaultTheme; status: OrderStatus }): string {
   let background, text
@@ -32,8 +32,13 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
     `
 }
 
-const Wrapper = styled.div<Props>`
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
   font-size: ${({ theme }): string => theme.fontSizeDefault};
+`
+
+const Label = styled.div<DisplayProps>`
   font-weight: ${({ theme }): string => theme.fontBold};
   text-transform: capitalize;
   border-radius: 0.4rem;
@@ -46,6 +51,12 @@ const Wrapper = styled.div<Props>`
 
 const StyledFAIcon = styled(FontAwesomeIcon)`
   margin: 0 0.75rem 0 0;
+`
+
+const PartialFill = styled.div`
+  margin-left: 1rem;
+  font-size: 0.85em; /* Intentional use of "em" to be relative to parent's font size */
+  color: ${({ theme }): string => theme.textPrimary1};
 `
 
 function getStatusIcon(status: OrderStatus): IconDefinition {
@@ -61,19 +72,24 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
   }
 }
 
-function StatusIcon({ status }: Props): JSX.Element {
+function StatusIcon({ status }: DisplayProps): JSX.Element {
   const icon = getStatusIcon(status)
 
   return <StyledFAIcon icon={icon} />
 }
 
+export type Props = DisplayProps & { partiallyFilled: boolean }
+
 export function StatusLabel(props: Props): JSX.Element {
-  const { status } = props
+  const { status, partiallyFilled } = props
 
   return (
-    <Wrapper status={status}>
-      <StatusIcon status={status} />
-      {status}
+    <Wrapper>
+      <Label status={status}>
+        <StatusIcon status={status} />
+        {status}
+      </Label>
+      {partiallyFilled && <PartialFill>(partial fill)</PartialFill>}
     </Wrapper>
   )
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -194,6 +194,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
   const shortId = getShortOrderId(rawOrder.uid)
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(rawOrder)
   const status = getOrderStatus(rawOrder)
+  const partiallyFilled = isOrderPartiallyFilled(rawOrder)
   const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(rawOrder)
   const { amount: surplusAmount, percentage: surplusPercentage } = getOrderSurplus(rawOrder)
 
@@ -216,6 +217,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
     executedFeeAmount: new BigNumber(executedFeeAmount),
     cancelled: invalidated,
     status,
+    partiallyFilled,
     filledAmount,
     filledPercentage,
     surplusAmount,

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -38,12 +38,10 @@ function isOrderPartiallyFilled(order: RawOrder): boolean {
 export function getOrderStatus(order: RawOrder): OrderStatus {
   if (isOrderFilled(order)) {
     return 'filled'
+  } else if (order.invalidated) {
+    return 'canceled'
   } else if (isOrderExpired(order)) {
-    if (isOrderPartiallyFilled(order)) {
-      return 'partially filled'
-    } else {
-      return 'expired'
-    }
+    return 'expired'
   } else {
     return 'open'
   }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -28,6 +28,9 @@ function isOrderExpired(order: RawOrder): boolean {
 }
 
 function isOrderPartiallyFilled(order: RawOrder): boolean {
+  if (isOrderFilled(order)) {
+    return false
+  }
   if (order.kind === 'buy') {
     return order.executedBuyAmount !== '0'
   } else {

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -42,6 +42,7 @@ export const RICH_ORDER: Order = {
   executedFeeAmount: new BigNumber(RAW_ORDER.executedFeeAmount),
   cancelled: RAW_ORDER.invalidated,
   status: 'open',
+  partiallyFilled: false,
   filledAmount: ZERO_BIG_NUMBER,
   filledPercentage: ZERO_BIG_NUMBER,
   buyToken: WETH,

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -113,6 +113,25 @@ describe('Filled status', () => {
   })
 })
 
+describe('Canceled status', () => {
+  test('Buy order', () => {
+    const order: RawOrder = {
+      ...RAW_ORDER,
+      kind: 'buy',
+      invalidated: true,
+    }
+    expect(getOrderStatus(order)).toEqual('canceled')
+  })
+  test('Sell order', () => {
+    const order: RawOrder = {
+      ...RAW_ORDER,
+      kind: 'sell',
+      invalidated: true,
+    }
+    expect(getOrderStatus(order)).toEqual('canceled')
+  })
+})
+
 describe('Expired status', () => {
   describe('Buy order', () => {
     test('Expired', () => {

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -113,68 +113,6 @@ describe('Filled status', () => {
   })
 })
 
-describe('Partially filled status', () => {
-  describe('Buy order', () => {
-    test('Partially filled, on the border to be considered filled', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9998' }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-    test('Partially filled', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '11' }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-    test('Partially filled, sell amount does not affect output', () => {
-      const order: RawOrder = {
-        ...RAW_ORDER,
-        kind: 'buy',
-        buyAmount: '10000',
-        executedBuyAmount: '11',
-        sellAmount: '10000',
-        executedSellAmount: '123',
-      }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-  })
-  describe('Sell order', () => {
-    test('Partially filled, on the border to be considered filled', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9998' }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-    test('Partially filled, with fee, on the border to be considered filled', () => {
-      const order: RawOrder = {
-        ...RAW_ORDER,
-        kind: 'sell',
-        sellAmount: '9000',
-        executedSellAmount: '9996',
-        executedFeeAmount: '998',
-      }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-    test('Partially filled', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '11' }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-    test('Partially filled, buy amount does not affect output', () => {
-      const order: RawOrder = {
-        ...RAW_ORDER,
-        kind: 'sell',
-        sellAmount: '10000',
-        executedSellAmount: '11',
-        buyAmount: '10000',
-        executedBuyAmount: '20',
-      }
-
-      expect(getOrderStatus(order)).toEqual('partially filled')
-    })
-  })
-})
-
 describe('Expired status', () => {
   describe('Buy order', () => {
     test('Expired', () => {

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -118,6 +118,7 @@ describe('Canceled status', () => {
     const order: RawOrder = {
       ...RAW_ORDER,
       kind: 'buy',
+      buyAmount: '10000',
       invalidated: true,
     }
     expect(getOrderStatus(order)).toEqual('canceled')
@@ -126,6 +127,7 @@ describe('Canceled status', () => {
     const order: RawOrder = {
       ...RAW_ORDER,
       kind: 'sell',
+      sellAmount: '10000',
       invalidated: true,
     }
     expect(getOrderStatus(order)).toEqual('canceled')

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -132,6 +132,16 @@ describe('Canceled status', () => {
     }
     expect(getOrderStatus(order)).toEqual('canceled')
   })
+  test('Expired and invalidated', () => {
+    const order: RawOrder = {
+      ...RAW_ORDER,
+      kind: 'sell',
+      sellAmount: '10000',
+      invalidated: true,
+      validTo: _getPastTimestamp(),
+    }
+    expect(getOrderStatus(order)).toEqual('canceled')
+  })
 })
 
 describe('Expired status', () => {


### PR DESCRIPTION
# Summary

Closes #178 

Removed `partially filled` and added `canceled` order status
Now displaying `(partial fill)` on `expired`, `canceled` and `open` orders

![screenshot_2021-02-26_13-33-54](https://user-images.githubusercontent.com/43217/109357556-3e60d580-7837-11eb-9c78-155718de03ef.png)
