### PR TITLE
212/gas fee paid row

### DIFF
--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
 
-import { formatSmart } from '@gnosis.pm/dex-js'
-
 import { Order } from 'api/operator'
 
 import { capitalize } from 'utils'
@@ -19,6 +17,7 @@ import { OrderPriceDisplay } from 'components/orders/OrderPriceDisplay'
 import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
 import { RowWithCopyButton } from 'components/orders/RowWithCopyButton'
 import { StatusLabel } from 'components/orders/StatusLabel'
+import { GasFeeDisplay } from 'components/orders/GasFeeDisplay'
 
 const Table = styled(SimpleTable)`
   border: 0.1rem solid ${({ theme }): string => theme.borderPrimary};
@@ -96,7 +95,6 @@ export function DetailsTable(props: Props): JSX.Element | null {
     sellAmount,
     executedBuyAmount,
     executedSellAmount,
-    executedFeeAmount,
     status,
     filledAmount,
     surplusAmount,
@@ -241,7 +239,9 @@ export function DetailsTable(props: Props): JSX.Element | null {
             <td>
               <HelpTooltip tooltip={tooltip.fees} /> Gas Fees paid
             </td>
-            <td>{formatSmart(executedFeeAmount.toString(), sellToken.decimals)}</td>
+            <td>
+              <GasFeeDisplay order={order} />
+            </td>
           </tr>
         </>
       }

--- a/src/components/orders/GasFeeDisplay/GasFeeDisplay.stories.tsx
+++ b/src/components/orders/GasFeeDisplay/GasFeeDisplay.stories.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import BigNumber from 'bignumber.js'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+
+import { GasFeeDisplay, Props } from '.'
+
+import { RICH_ORDER, WETH } from '../../../../test/data'
+import { ZERO_BIG_NUMBER } from 'const'
+
+export default {
+  title: 'orders/GasFeeDisplay',
+  component: GasFeeDisplay,
+  decorators: [GlobalStyles, ThemeToggler],
+  argTypes: { order: { control: null } },
+} as Meta
+
+const Template: Story<Props> = (args) => (
+  <div style={{ fontSize: '14px' }}>
+    <GasFeeDisplay {...args} />
+  </div>
+)
+
+const order = {
+  ...RICH_ORDER,
+  feeAmount: new BigNumber('200000'),
+  executedFeeAmount: ZERO_BIG_NUMBER,
+}
+
+const defaultProps: Props = { order }
+
+export const NoFee = Template.bind({})
+NoFee.args = { ...defaultProps }
+
+export const PartialFee = Template.bind({})
+PartialFee.args = { ...defaultProps, order: { ...order, executedFeeAmount: new BigNumber('100000') } }
+
+export const FullFee = Template.bind({})
+FullFee.args = { ...defaultProps, order: { ...order, executedFeeAmount: order.feeAmount } }
+
+export const TinyFee6DecimalsToken = Template.bind({})
+TinyFee6DecimalsToken.args = { ...defaultProps, order: { ...order, executedFeeAmount: new BigNumber('1') } }
+
+export const TinyFee18DecimalsToken = Template.bind({})
+TinyFee18DecimalsToken.args = {
+  ...defaultProps,
+  order: { ...order, executedFeeAmount: new BigNumber('1'), sellToken: WETH },
+}

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { formatSmart, safeTokenName } from '@gnosis.pm/dex-js'
+
+import { Order } from 'api/operator'
+
+import { ONE_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
+
+const Wrapper = styled.div`
+  & > span {
+    margin: 0 0.5rem 0 0;
+  }
+`
+
+const UsdAmount = styled.span`
+  color: ${({ theme }): string => theme.grey};
+`
+
+export type Props = { order: Order }
+
+export function GasFeeDisplay(props: Props): JSX.Element | null {
+  const {
+    order: { feeAmount, executedFeeAmount, sellToken, sellTokenAddress },
+  } = props
+
+  // TODO: fetch amount in USD
+  const executedFeeUSD = '0.99'
+  const totalFeeUSD = '0.35'
+
+  let smallLimit: string | undefined
+  // When `sellToken` is not set, default to raw amounts
+  let formattedExecutedFee: string = executedFeeAmount.toString(10)
+  let formattedTotalFee: string = feeAmount.toString(10)
+  // When `sellToken` is not set, show token address
+  let quoteSymbol: string = sellTokenAddress
+
+  if (sellToken) {
+    // Small limit === 1 token atom in relation to token units.
+    // E.g.: Token decimals: 5; 1 unit => 100000; 1 atom => 0.00001 === small limit
+    smallLimit = ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(sellToken.decimals)).toString(10)
+
+    formattedExecutedFee = formatSmart({
+      amount: executedFeeAmount.toString(10),
+      precision: sellToken.decimals,
+      decimals: sellToken.decimals,
+      smallLimit,
+    })
+    formattedTotalFee = formatSmart({
+      amount: feeAmount.toString(10),
+      precision: sellToken.decimals,
+      decimals: sellToken.decimals,
+      smallLimit,
+    })
+
+    quoteSymbol = safeTokenName(sellToken)
+  }
+
+  return (
+    <Wrapper>
+      <span>
+        {formattedExecutedFee} {quoteSymbol}
+      </span>
+      <UsdAmount>(~${totalFeeUSD})</UsdAmount>
+      <span>
+        of {formattedTotalFee} {quoteSymbol}
+      </span>
+      <UsdAmount>(~${executedFeeUSD})</UsdAmount>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
# Summary

Implements `gas fee paid` row

Closes #212 

![screenshot_2021-03-01_14-38-36](https://user-images.githubusercontent.com/43217/109568462-cf37eb00-7a9b-11eb-91f4-58567783daf7.png)

Added Storybook with edge case of tiny fee amounts displayed in full