### PR TITLE
Adding fill progress bar.

### DIFF
--- a/src/components/common/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/common/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+import { ProgressBar, Props } from '.'
+
+export default {
+  title: 'Common/ProgressBar',
+  component: ProgressBar,
+  decorators: [GlobalStyles, ThemeToggler],
+} as Meta
+
+const Template: Story<Props> = (args) => (
+  <div>
+    <ProgressBar {...args} />
+  </div>
+)
+
+const defaultProps: Props = { percentage: '35' }
+
+export const Default = Template.bind({})
+Default.args = { ...defaultProps }

--- a/src/components/common/ProgressBar/index.tsx
+++ b/src/components/common/ProgressBar/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 export type Props = {
   percentage?: string | null
   activeColor?: string
+  showLabel?: boolean
 }
 
 const Wrapper = styled.div<Props>`
@@ -28,14 +29,22 @@ const Wrapper = styled.div<Props>`
     background-color: ${({ activeColor, theme }): string => (activeColor ? activeColor : theme.green)};
     border-radius: 16rem;
   }
+
+  > b {
+    color: ${({ activeColor, theme }): string => (activeColor ? activeColor : theme.green)};
+    margin: 0 0 0 0.7rem;
+  }
 `
 
 export function ProgressBar(props: Props): JSX.Element {
+  const { percentage, showLabel = true } = props
+
   return (
     <Wrapper {...props}>
       <div>
         <span></span>
       </div>
+      {showLabel && <b>{percentage}%</b>}
     </Wrapper>
   )
 }

--- a/src/components/common/ProgressBar/index.tsx
+++ b/src/components/common/ProgressBar/index.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import styled from 'styled-components'
 
 export type Props = {
-  percentage?: string | null
-  activeColor?: string
-  showLabel?: boolean
+  readonly percentage?: string
+  readonly activeColor?: string
+  readonly showLabel?: boolean
 }
 
 const Wrapper = styled.div<Props>`
@@ -37,7 +37,7 @@ const Wrapper = styled.div<Props>`
 `
 
 export function ProgressBar(props: Props): JSX.Element {
-  const { percentage, showLabel = true } = props
+  const { percentage = '0', showLabel = true } = props
 
   return (
     <Wrapper {...props}>

--- a/src/components/common/ProgressBar/index.tsx
+++ b/src/components/common/ProgressBar/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export type Props = {
+  percentage?: string | null
+  activeColor?: string
+}
+
+const Wrapper = styled.div<Props>`
+  display: flex;
+  align-items: center;
+
+  > div {
+    width: 16rem;
+    height: 0.6rem;
+    position: relative;
+    border-radius: 16rem;
+    background: ${({ theme }): string => theme.borderPrimary};
+  }
+
+  > div > span {
+    width: ${({ percentage }): string => percentage || '0'}%;
+    max-width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: ${({ activeColor, theme }): string => (activeColor ? activeColor : theme.green)};
+    border-radius: 16rem;
+  }
+`
+
+export function ProgressBar(props: Props): JSX.Element {
+  return (
+    <Wrapper {...props}>
+      <div>
+        <span></span>
+      </div>
+    </Wrapper>
+  )
+}

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -16,6 +16,7 @@ import { SimpleTable } from 'components/common/SimpleTable'
 import { AmountsDisplay } from 'components/orders/AmountsDisplay'
 import { DateDisplay } from 'components/orders/DateDisplay'
 import { OrderPriceDisplay } from 'components/orders/OrderPriceDisplay'
+import { FilledProgress } from 'components/orders/FilledProgress'
 import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
 import { RowWithCopyButton } from 'components/orders/RowWithCopyButton'
 import { StatusLabel } from 'components/orders/StatusLabel'
@@ -227,7 +228,9 @@ export function DetailsTable(props: Props): JSX.Element | null {
                 <td>
                   <HelpTooltip tooltip={tooltip.filled} /> Filled
                 </td>
-                <td>[------progress bar-------] 81% 2,430 DAI of 3000 DAI sold for a total of 2.842739643 ETH</td>
+                <td>
+                  <FilledProgress percentage={'34'} />
+                </td>
               </tr>
               <tr>
                 <td>

--- a/src/components/orders/FilledProgress/FilledProgress.stories.tsx
+++ b/src/components/orders/FilledProgress/FilledProgress.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+
+import { FilledProgress, Props } from '.'
+
+export default {
+  title: 'Orders/FilledProgress',
+  component: FilledProgress,
+  decorators: [GlobalStyles, ThemeToggler],
+  argTypes: { percentage: { control: null } },
+} as Meta
+
+const Template: Story<Props> = (args) => <FilledProgress {...args} />
+
+const defaultArgs: Props = {
+  percentage: '40',
+}
+
+export const Default = Template.bind({})
+Default.args = { ...defaultArgs }

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -4,7 +4,7 @@ import { media } from 'theme/styles/media'
 import { ProgressBar } from 'components/common/ProgressBar'
 
 export type Props = {
-  percentage?: string | null
+  readonly percentage?: string
 }
 
 const Wrapper = styled.div`
@@ -26,7 +26,7 @@ const Wrapper = styled.div`
 `
 
 export function FilledProgress(props: Props): JSX.Element {
-  const { percentage } = props
+  const { percentage = '0' } = props
 
   return (
     <Wrapper>

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -11,11 +11,6 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
 
-  > b {
-    color: ${({ theme }): string => theme.green};
-    margin: 0 0 0 0.7rem;
-  }
-
   > span {
     margin: 0 0 0 2rem;
     font-weight: ${({ theme }): string => theme.fontLighter};
@@ -36,7 +31,6 @@ export function FilledProgress(props: Props): JSX.Element {
   return (
     <Wrapper>
       <ProgressBar percentage={percentage} />
-      <b>{percentage}%</b>
       <span>
         <b>2,430 DAI</b> of <b>3000 DAI</b> sold for a total of <b>2.842739643 ETH</b>
       </span>

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import styled from 'styled-components'
+import { media } from 'theme/styles/media'
+import { ProgressBar } from 'components/common/ProgressBar'
+
+export type Props = {
+  percentage?: string | null
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  > b {
+    color: ${({ theme }): string => theme.green};
+    margin: 0 0 0 0.7rem;
+  }
+
+  > span {
+    margin: 0 0 0 2rem;
+    font-weight: ${({ theme }): string => theme.fontLighter};
+
+    ${media.mobile} {
+      line-height: 1.5;
+    }
+  }
+
+  > span > b {
+    font-weight: ${({ theme }): string => theme.fontMedium};
+  }
+`
+
+export function FilledProgress(props: Props): JSX.Element {
+  const { percentage } = props
+
+  return (
+    <Wrapper>
+      <ProgressBar percentage={percentage} />
+      <b>{percentage}%</b>
+      <span>
+        <b>2,430 DAI</b> of <b>3000 DAI</b> sold for a total of <b>2.842739643 ETH</b>
+      </span>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
Adds a fill progress bar for the Filled section. Created a common component 'progressBar' to be re-used:

<img width="510" alt="Screen Shot 2021-03-02 at 13 39 37" src="https://user-images.githubusercontent.com/31534717/109650724-ea6b2f00-7b5d-11eb-8bbb-82cc9fd39fa8.png">
<img width="507" alt="Screen Shot 2021-03-02 at 13 39 30" src="https://user-images.githubusercontent.com/31534717/109650728-eb9c5c00-7b5d-11eb-950a-a6afc0226910.png">

https://pr235--gpui.review.gnosisdev.com/storybook/?path=/story/common-progressbar--default
https://pr235--gpui.review.gnosisdev.com/storybook/?path=/story/orders-filledprogress--default
