### PR TITLE
Use a different infura id for explorer

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -76,7 +76,7 @@ defaultProviderConfig:
   type: 'infura' # Choices: infura | url
   config:
     # It'll be appended to `infuraEndpoint`
-    infuraId: 607a7dfcb1ad4a0b83152e30ce20cfc5
+    infuraId: e941376b017d4dada26dc7891456fa3b
     infuraEndpoint: wss://mainnet.infura.io/ws/v3/
   #
   # Example for type `url`

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -104,7 +104,7 @@ describe('Test config defaults', () => {
     const expected: InfuraProviderConfig = {
       type: 'infura',
       config: {
-        infuraId: '607a7dfcb1ad4a0b83152e30ce20cfc5',
+        infuraId: 'e941376b017d4dada26dc7891456fa3b',
         infuraEndpoint: 'wss://mainnet.infura.io/ws/v3/',
       },
     }

--- a/webpack.gp-v1.config.js
+++ b/webpack.gp-v1.config.js
@@ -20,7 +20,16 @@ module.exports = getWebpackConfig({
       filename: 'index.html',
     },
   ],
-  config,
+  config: {
+    ...config,
+    defaultProviderConfig: {
+      type: 'infura', // Choices: infura | url
+      config: {
+        infuraId: '607a7dfcb1ad4a0b83152e30ce20cfc5',
+        infuraEndpoint: 'wss://mainnet.infura.io/ws/v3/',
+      },
+    },
+  },
   baseUrl,
   envVars: {
     BASE_URL: baseUrl,


### PR DESCRIPTION
This PR changes the infura key being used. 
Now there's one specific for the Explorer. We leave the gp-v1 just for the legacy app in it's own config. 