### PR TITLE
250/hide mocked data

### DIFF
--- a/src/components/orders/AmountsDisplay/index.tsx
+++ b/src/components/orders/AmountsDisplay/index.tsx
@@ -9,7 +9,7 @@ import { HIGH_PRECISION_DECIMALS, HIGH_PRECISION_SMALL_LIMIT } from 'apps/explor
 
 import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorerLink'
 
-import { RowContents, RowTitle, StyledImg, UsdAmount, Wrapper } from './styled'
+import { RowContents, RowTitle, StyledImg, /*UsdAmount,*/ Wrapper } from './styled'
 
 type RowProps = {
   title: string
@@ -22,7 +22,7 @@ function Row(props: RowProps): JSX.Element {
   const { title, titleSuffix, amount, erc20 } = props
 
   // TODO: calculate real usd amount
-  const usdAmount = '31231.32'
+  // const usdAmount = '31231.32'
 
   // Decimals are optional on ERC20 spec. In that unlikely case, graceful fallback to raw amount
   const formattedAmount = erc20.decimals
@@ -44,7 +44,7 @@ function Row(props: RowProps): JSX.Element {
       </RowTitle>
       <RowContents>
         <span>{formattedAmount}</span>
-        <UsdAmount>(~${usdAmount})</UsdAmount>
+        {/* <UsdAmount>(~${usdAmount})</UsdAmount> */}
         {/* TODO: figure out the deal with images on networks other than Mainnet */}
         <StyledImg address={erc20.address} />
         <BlockExplorerLink identifier={erc20.address} type="token" label={tokenLabel} />

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -90,7 +90,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
     uid,
     shortId,
     owner,
-    txHash,
+    // txHash,
     kind,
     partiallyFillable,
     creationDate,
@@ -142,7 +142,8 @@ export function DetailsTable(props: Props): JSX.Element | null {
               />
             </td>
           </tr>
-          {!partiallyFillable && (
+          {/* TODO: re-enable once this data is available on the API */}
+          {/* {!partiallyFillable && (
             <tr>
               <td>
                 <HelpTooltip tooltip={tooltip.hash} /> Transaction hash
@@ -159,7 +160,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
                 )}
               </td>
             </tr>
-          )}
+          )} */}
           <tr>
             <td>
               <HelpTooltip tooltip={tooltip.status} /> Status

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -13,9 +13,9 @@ const Wrapper = styled.div`
   }
 `
 
-const UsdAmount = styled.span`
-  color: ${({ theme }): string => theme.grey};
-`
+// const UsdAmount = styled.span`
+//   color: ${({ theme }): string => theme.grey};
+// `
 
 export type Props = { order: Order }
 
@@ -25,8 +25,8 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
   } = props
 
   // TODO: fetch amount in USD
-  const executedFeeUSD = '0.99'
-  const totalFeeUSD = '0.35'
+  // const executedFeeUSD = '0.99'
+  // const totalFeeUSD = '0.35'
 
   let smallLimit: string | undefined
   // When `sellToken` is not set, default to raw amounts
@@ -61,11 +61,11 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
       <span>
         {formattedExecutedFee} {quoteSymbol}
       </span>
-      <UsdAmount>(~${totalFeeUSD})</UsdAmount>
+      {/* <UsdAmount>(~${totalFeeUSD})</UsdAmount> */}
       <span>
         of {formattedTotalFee} {quoteSymbol}
       </span>
-      <UsdAmount>(~${executedFeeUSD})</UsdAmount>
+      {/* <UsdAmount>(~${executedFeeUSD})</UsdAmount> */}
     </Wrapper>
   )
 }

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -8,7 +8,6 @@ import {
   HIGH_PRECISION_DECIMALS,
   HIGH_PRECISION_SMALL_LIMIT,
   LOW_PRECISION_DECIMALS,
-  NO_ADJUSTMENT_NEEDED_PRECISION,
   PERCENTAGE_PRECISION,
 } from 'apps/explorer/const'
 
@@ -26,10 +25,10 @@ const Surplus = styled.span`
   color: ${({ theme }): string => theme.green};
 `
 
-const UsdAmount = styled.span`
-  color: ${({ theme }): string => theme.textPrimary1};
-  opacity: 0.5;
-`
+// const UsdAmount = styled.span`
+//   color: ${({ theme }): string => theme.textPrimary1};
+//   opacity: 0.5;
+// `
 
 export type Props = { order: Order }
 
@@ -41,7 +40,7 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   const surplusToken = kind === 'buy' ? sellToken : buyToken
 
   // TODO: get USD estimation
-  const usdAmount = '55.555'
+  // const usdAmount = '55.555'
 
   if (!surplusToken || surplusAmount.isZero()) {
     return null
@@ -59,11 +58,11 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
     smallLimit: HIGH_PRECISION_SMALL_LIMIT,
   })
   const tokenSymbol = safeTokenName(surplusToken)
-  const formattedUsdAmount = formatSmart({
-    amount: usdAmount,
-    precision: NO_ADJUSTMENT_NEEDED_PRECISION,
-    decimals: LOW_PRECISION_DECIMALS,
-  })
+  // const formattedUsdAmount = formatSmart({
+  //   amount: usdAmount,
+  //   precision: NO_ADJUSTMENT_NEEDED_PRECISION,
+  //   decimals: LOW_PRECISION_DECIMALS,
+  // })
 
   return (
     <Wrapper>
@@ -71,7 +70,7 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
       <span>
         {formattedSurplusAmount} {tokenSymbol}
       </span>
-      <UsdAmount>(~${formattedUsdAmount})</UsdAmount>
+      {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}
     </Wrapper>
   )
 }


### PR DESCRIPTION
# Summary

Closes #250 

- Hiding USD amounts -- depends on new API not yet available on the backend
- Hiding transaction hash -- depends on tx hash not yet available on existing API