### PR TITLE
Was using wrong amounts to show the filled amount

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -38,8 +38,8 @@ export function FilledProgress(props: Props): JSX.Element {
       filledAmount,
       filledPercentage,
       kind,
-      buyAmount,
-      sellAmount,
+      executedBuyAmount,
+      executedSellAmount,
       buyToken,
       sellToken,
       buyTokenAddress,
@@ -58,18 +58,18 @@ export function FilledProgress(props: Props): JSX.Element {
   if (kind === 'sell') {
     mainToken = sellToken
     mainAddress = sellTokenAddress
-    mainAmount = sellAmount
+    mainAmount = executedSellAmount
     swappedToken = buyToken
     swappedAddress = buyTokenAddress
-    swappedAmount = buyAmount
+    swappedAmount = executedBuyAmount
     action = 'sold'
   } else {
     mainToken = buyToken
     mainAddress = buyTokenAddress
-    mainAmount = buyAmount
+    mainAmount = executedBuyAmount
     swappedToken = sellToken
     swappedAddress = sellTokenAddress
-    swappedAmount = sellAmount
+    swappedAmount = executedSellAmount
     action = 'bought'
   }
 


### PR DESCRIPTION
I noticed there was a surplus, but didn't seem like what was bought/sold had any surplus

Pay attention to the `Filled` row total on both cases:

## Before
![screenshot_2021-03-05_13-57-57](https://user-images.githubusercontent.com/43217/110178174-edaf2680-7dba-11eb-8175-4c0834c344a5.png)
## After
![screenshot_2021-03-05_13-58-49](https://user-images.githubusercontent.com/43217/110178184-f142ad80-7dba-11eb-91e0-d575afc87771.png)

The second one shows the buy amount + surplus
