### PR TITLE
Checksum token images

### DIFF
--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -83,8 +83,12 @@ export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
  */
 export function getImageUrl(tokenAddress?: string): string | undefined {
   if (!tokenAddress) return undefined
-  const checksummedAddress = toChecksumAddress(tokenAddress)
-  return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${checksummedAddress}/logo.png`
+  try {
+    const checksummedAddress = toChecksumAddress(tokenAddress)
+    return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${checksummedAddress}/logo.png`
+  } catch (e) {
+    return undefined
+  }
 }
 
 export function isTokenEnabled(allowance: BN, { decimals = 18 }: TokenDetails): boolean {

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -1,5 +1,8 @@
 import BN from 'bn.js'
 import BigNumber from 'bignumber.js'
+import Web3 from 'web3'
+
+const toChecksumAddress = Web3.utils.toChecksumAddress
 
 import { TokenDetails, Unpromise } from 'types'
 import { AssertionError } from 'assert'
@@ -80,7 +83,8 @@ export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
  */
 export function getImageUrl(tokenAddress?: string): string | undefined {
   if (!tokenAddress) return undefined
-  return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${tokenAddress}/logo.png`
+  const checksummedAddress = toChecksumAddress(tokenAddress)
+  return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${checksummedAddress}/logo.png`
 }
 
 export function isTokenEnabled(allowance: BN, { decimals = 18 }: TokenDetails): boolean {

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -7,7 +7,7 @@ import { Row, RowProps } from 'apps/gp-v1/components/DepositWidget/Row'
 import { ZERO, ONE, TEN } from 'const'
 import { Network, TokenBalanceDetails } from 'types'
 import { TokenLocalState } from 'state'
-import { createFlux } from '../data'
+import { createFlux, TOKEN_1 } from '../data'
 
 const fakeRowState: Record<keyof TokenLocalState, boolean> = {
   enabling: false,
@@ -26,7 +26,7 @@ const initialTokenBalanceDetails = {
   name: 'Test token',
   symbol: 'TTT',
   decimals: 18,
-  address: '0x0',
+  address: TOKEN_1,
   exchangeBalance: ZERO,
   totalExchangeBalance: ZERO,
   pendingDeposit: createFlux(),


### PR DESCRIPTION
# Summary
Fixes Mainnet token images.

Rinekby and xDai remain unchanged.

## Before
![screenshot_2021-03-05_14-16-20](https://user-images.githubusercontent.com/43217/110179720-67e0aa80-7dbd-11eb-8329-57761c790f7d.png)
## After
![screenshot_2021-03-05_14-16-30](https://user-images.githubusercontent.com/43217/110179729-6b743180-7dbd-11eb-9648-d1330a29d2ee.png)
