### PR TITLE
Pr244/comments

### DIFF
--- a/src/components/orders/AmountsDisplay/index.tsx
+++ b/src/components/orders/AmountsDisplay/index.tsx
@@ -5,7 +5,7 @@ import { formatSmart, TokenErc20 } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
-import { getSmallLimit } from 'utils'
+import { getMinimumRepresentableValue } from 'utils'
 
 import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorerLink'
 
@@ -30,7 +30,7 @@ function Row(props: RowProps): JSX.Element {
         amount: amount.toString(10),
         precision: erc20.decimals,
         decimals: erc20.decimals,
-        smallLimit: getSmallLimit(erc20.decimals),
+        smallLimit: getMinimumRepresentableValue(erc20.decimals),
       })
     : amount.toString(10)
   // Name and symbol are optional on ERC20 spec. Fallback to address when no name,

--- a/src/components/orders/AmountsDisplay/index.tsx
+++ b/src/components/orders/AmountsDisplay/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import BigNumber from 'bignumber.js'
 
-import { formatSmart, TokenErc20 } from '@gnosis.pm/dex-js'
+import { TokenErc20 } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
-import { getMinimumRepresentableValue } from 'utils'
+import { formatSmartMaxPrecision } from 'utils'
 
 import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorerLink'
 
@@ -25,14 +25,7 @@ function Row(props: RowProps): JSX.Element {
   // const usdAmount = '31231.32'
 
   // Decimals are optional on ERC20 spec. In that unlikely case, graceful fallback to raw amount
-  const formattedAmount = erc20.decimals
-    ? formatSmart({
-        amount: amount.toString(10),
-        precision: erc20.decimals,
-        decimals: erc20.decimals,
-        smallLimit: getMinimumRepresentableValue(erc20.decimals),
-      })
-    : amount.toString(10)
+  const formattedAmount = erc20.decimals ? formatSmartMaxPrecision(amount, erc20) : amount.toString(10)
   // Name and symbol are optional on ERC20 spec. Fallback to address when no name,
   // and show no symbol when that's not set
   const tokenLabel = `${erc20.name || erc20.address}${erc20.symbol ? ` (${erc20.symbol})` : ''}`

--- a/src/components/orders/AmountsDisplay/index.tsx
+++ b/src/components/orders/AmountsDisplay/index.tsx
@@ -5,7 +5,7 @@ import { formatSmart, TokenErc20 } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
-import { HIGH_PRECISION_DECIMALS, HIGH_PRECISION_SMALL_LIMIT } from 'apps/explorer/const'
+import { getSmallLimit } from 'utils'
 
 import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorerLink'
 
@@ -29,8 +29,8 @@ function Row(props: RowProps): JSX.Element {
     ? formatSmart({
         amount: amount.toString(10),
         precision: erc20.decimals,
-        decimals: HIGH_PRECISION_DECIMALS,
-        smallLimit: HIGH_PRECISION_SMALL_LIMIT,
+        decimals: erc20.decimals,
+        smallLimit: getSmallLimit(erc20.decimals),
       })
     : amount.toString(10)
   // Name and symbol are optional on ERC20 spec. Fallback to address when no name,

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -8,7 +8,7 @@ import { media } from 'theme/styles/media'
 import { Order } from 'api/operator'
 
 import { ProgressBar } from 'components/common/ProgressBar'
-import { getSmallLimit } from 'utils'
+import { getMinimumRepresentableValue } from 'utils'
 
 export type Props = {
   order: Order
@@ -82,19 +82,19 @@ export function FilledProgress(props: Props): JSX.Element {
     amount: filledAmount.toString(10),
     precision: mainToken?.decimals || 0,
     decimals: mainToken?.decimals || 0,
-    smallLimit: getSmallLimit(mainToken?.decimals),
+    smallLimit: getMinimumRepresentableValue(mainToken?.decimals),
   })
   const formattedMainAmount = formatSmart({
     amount: mainAmount.toString(10),
     precision: mainToken?.decimals || 0,
     decimals: mainToken?.decimals || 0,
-    smallLimit: getSmallLimit(mainToken?.decimals),
+    smallLimit: getMinimumRepresentableValue(mainToken?.decimals),
   })
   const formattedSwappedAmount = formatSmart({
     amount: swappedAmount.toString(10),
     precision: swappedToken?.decimals || 0,
     decimals: swappedToken?.decimals || 0,
-    smallLimit: getSmallLimit(swappedToken?.decimals),
+    smallLimit: getMinimumRepresentableValue(swappedToken?.decimals),
   })
 
   const formattedPercentage = filledPercentage.times('100').toString(10)

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -8,6 +8,7 @@ import { media } from 'theme/styles/media'
 import { Order } from 'api/operator'
 
 import { ProgressBar } from 'components/common/ProgressBar'
+import { getSmallLimit } from 'utils'
 
 export type Props = {
   order: Order
@@ -77,9 +78,24 @@ export function FilledProgress(props: Props): JSX.Element {
   const mainSymbol = mainToken ? safeTokenName(mainToken) : mainAddress
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
-  const formattedFilledAmount = formatSmart(filledAmount.toString(10), mainToken?.decimals || 0)
-  const formattedMainAmount = formatSmart(mainAmount.toString(10), mainToken?.decimals || 0)
-  const formattedSwappedAmount = formatSmart(swappedAmount.toString(10), swappedToken?.decimals || 0)
+  const formattedFilledAmount = formatSmart({
+    amount: filledAmount.toString(10),
+    precision: mainToken?.decimals || 0,
+    decimals: mainToken?.decimals || 0,
+    smallLimit: getSmallLimit(mainToken?.decimals),
+  })
+  const formattedMainAmount = formatSmart({
+    amount: mainAmount.toString(10),
+    precision: mainToken?.decimals || 0,
+    decimals: mainToken?.decimals || 0,
+    smallLimit: getSmallLimit(mainToken?.decimals),
+  })
+  const formattedSwappedAmount = formatSmart({
+    amount: swappedAmount.toString(10),
+    precision: swappedToken?.decimals || 0,
+    decimals: swappedToken?.decimals || 0,
+    smallLimit: getSmallLimit(swappedToken?.decimals),
+  })
 
   const formattedPercentage = filledPercentage.times('100').toString(10)
 

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { formatSmart, safeTokenName } from '@gnosis.pm/dex-js'
-
 import { media } from 'theme/styles/media'
 
 import { Order } from 'api/operator'
 
+import { formatSmartMaxPrecision, safeTokenName } from 'utils'
+
 import { ProgressBar } from 'components/common/ProgressBar'
-import { getMinimumRepresentableValue } from 'utils'
 
 export type Props = {
   order: Order
@@ -78,24 +77,9 @@ export function FilledProgress(props: Props): JSX.Element {
   const mainSymbol = mainToken ? safeTokenName(mainToken) : mainAddress
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
-  const formattedFilledAmount = formatSmart({
-    amount: filledAmount.toString(10),
-    precision: mainToken?.decimals || 0,
-    decimals: mainToken?.decimals || 0,
-    smallLimit: getMinimumRepresentableValue(mainToken?.decimals),
-  })
-  const formattedMainAmount = formatSmart({
-    amount: mainAmount.toString(10),
-    precision: mainToken?.decimals || 0,
-    decimals: mainToken?.decimals || 0,
-    smallLimit: getMinimumRepresentableValue(mainToken?.decimals),
-  })
-  const formattedSwappedAmount = formatSmart({
-    amount: swappedAmount.toString(10),
-    precision: swappedToken?.decimals || 0,
-    decimals: swappedToken?.decimals || 0,
-    smallLimit: getMinimumRepresentableValue(swappedToken?.decimals),
-  })
+  const formattedFilledAmount = formatSmartMaxPrecision(filledAmount, mainToken)
+  const formattedMainAmount = formatSmartMaxPrecision(mainAmount, mainToken)
+  const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmount, swappedToken)
 
   const formattedPercentage = filledPercentage.times('100').toString(10)
 

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { formatSmart, safeTokenName } from '@gnosis.pm/dex-js'
-
 import { Order } from 'api/operator'
 
-import { getMinimumRepresentableValue } from 'utils'
+import { formatSmartMaxPrecision, safeTokenName } from 'utils'
 
 const Wrapper = styled.div`
   & > span {
@@ -28,7 +26,6 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
   // const executedFeeUSD = '0.99'
   // const totalFeeUSD = '0.35'
 
-  let smallLimit: string | undefined
   // When `sellToken` is not set, default to raw amounts
   let formattedExecutedFee: string = executedFeeAmount.toString(10)
   let formattedTotalFee: string = feeAmount.toString(10)
@@ -36,20 +33,8 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
   let quoteSymbol: string = sellTokenAddress
 
   if (sellToken) {
-    smallLimit = getMinimumRepresentableValue(sellToken.decimals)
-
-    formattedExecutedFee = formatSmart({
-      amount: executedFeeAmount.toString(10),
-      precision: sellToken.decimals,
-      decimals: sellToken.decimals,
-      smallLimit,
-    })
-    formattedTotalFee = formatSmart({
-      amount: feeAmount.toString(10),
-      precision: sellToken.decimals,
-      decimals: sellToken.decimals,
-      smallLimit,
-    })
+    formattedExecutedFee = formatSmartMaxPrecision(executedFeeAmount, sellToken)
+    formattedTotalFee = formatSmartMaxPrecision(feeAmount, sellToken)
 
     quoteSymbol = safeTokenName(sellToken)
   }

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -5,7 +5,7 @@ import { formatSmart, safeTokenName } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
-import { ONE_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
+import { getSmallLimit } from 'utils'
 
 const Wrapper = styled.div`
   & > span {
@@ -36,9 +36,7 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
   let quoteSymbol: string = sellTokenAddress
 
   if (sellToken) {
-    // Small limit === 1 token atom in relation to token units.
-    // E.g.: Token decimals: 5; 1 unit => 100000; 1 atom => 0.00001 === small limit
-    smallLimit = ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(sellToken.decimals)).toString(10)
+    smallLimit = getSmallLimit(sellToken.decimals)
 
     formattedExecutedFee = formatSmart({
       amount: executedFeeAmount.toString(10),

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -5,7 +5,7 @@ import { formatSmart, safeTokenName } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
 
-import { getSmallLimit } from 'utils'
+import { getMinimumRepresentableValue } from 'utils'
 
 const Wrapper = styled.div`
   & > span {
@@ -36,7 +36,7 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
   let quoteSymbol: string = sellTokenAddress
 
   if (sellToken) {
-    smallLimit = getSmallLimit(sellToken.decimals)
+    smallLimit = getMinimumRepresentableValue(sellToken.decimals)
 
     formattedExecutedFee = formatSmart({
       amount: executedFeeAmount.toString(10),

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { Order } from 'api/operator'
 
-import { formatSmart, getMinimumRepresentableValue, safeTokenName } from 'utils'
+import { formatSmart, formatSmartMaxPrecision, safeTokenName } from 'utils'
 
 import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
 
@@ -47,12 +47,7 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
     precision: PERCENTAGE_PRECISION,
     decimals: LOW_PRECISION_DECIMALS,
   })
-  const formattedSurplusAmount = formatSmart({
-    amount: surplusAmount.toString(10),
-    precision: surplusToken.decimals,
-    decimals: surplusToken.decimals,
-    smallLimit: getMinimumRepresentableValue(surplusToken.decimals),
-  })
+  const formattedSurplusAmount = formatSmartMaxPrecision(surplusAmount, surplusToken)
   const tokenSymbol = safeTokenName(surplusToken)
   // const formattedUsdAmount = formatSmart({
   //   amount: usdAmount,

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { Order } from 'api/operator'
 
-import { formatSmart, getSmallLimit, safeTokenName } from 'utils'
+import { formatSmart, getMinimumRepresentableValue, safeTokenName } from 'utils'
 
 import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
 
@@ -51,7 +51,7 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
     amount: surplusAmount.toString(10),
     precision: surplusToken.decimals,
     decimals: surplusToken.decimals,
-    smallLimit: getSmallLimit(surplusToken.decimals),
+    smallLimit: getMinimumRepresentableValue(surplusToken.decimals),
   })
   const tokenSymbol = safeTokenName(surplusToken)
   // const formattedUsdAmount = formatSmart({

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -3,13 +3,9 @@ import styled from 'styled-components'
 
 import { Order } from 'api/operator'
 
-import { formatSmart, safeTokenName } from 'utils'
-import {
-  HIGH_PRECISION_DECIMALS,
-  HIGH_PRECISION_SMALL_LIMIT,
-  LOW_PRECISION_DECIMALS,
-  PERCENTAGE_PRECISION,
-} from 'apps/explorer/const'
+import { formatSmart, getSmallLimit, safeTokenName } from 'utils'
+
+import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
 
 const Wrapper = styled.div`
   & > * {
@@ -54,8 +50,8 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   const formattedSurplusAmount = formatSmart({
     amount: surplusAmount.toString(10),
     precision: surplusToken.decimals,
-    decimals: HIGH_PRECISION_DECIMALS,
-    smallLimit: HIGH_PRECISION_SMALL_LIMIT,
+    decimals: surplusToken.decimals,
+    smallLimit: getSmallLimit(surplusToken.decimals),
   })
   const tokenSymbol = safeTokenName(surplusToken)
   // const formattedUsdAmount = formatSmart({

--- a/src/const.ts
+++ b/src/const.ts
@@ -30,6 +30,9 @@ export const ONE_BIG_NUMBER = new BigNumber(1)
 export const TEN_BIG_NUMBER = new BigNumber(10)
 export const ONE_HUNDRED_BIG_NUMBER = new BigNumber(100)
 
+// Value used on formatSmart's smallLimit for integer values, such as raw token amounts
+export const MINIMUM_ATOM_VALUE = '1'
+
 // How much of the order needs to be matched to consider it filled
 // Will divide the total sell amount by this factor.
 // E.g.: Sell = 500; ORDER_FILLED_FACTOR = 100 (1%) => 500/100 => 5

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,7 +2,14 @@ import BigNumber from 'bignumber.js'
 
 import { TokenErc20, formatSmart } from '@gnosis.pm/dex-js'
 
-import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMALS, ONE_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
+import {
+  ONE_HUNDRED_BIG_NUMBER,
+  BATCH_TIME_IN_MS,
+  DEFAULT_DECIMALS,
+  ONE_BIG_NUMBER,
+  TEN_BIG_NUMBER,
+  MINIMUM_ATOM_VALUE,
+} from 'const'
 import { batchIdToDate } from './time'
 
 export {
@@ -214,7 +221,7 @@ export function capitalize(sentence: string): string {
 export function getMinimumRepresentableValue(decimals?: number): string {
   // Small limit === 1 token atom in relation to token units.
   // E.g.: Token decimals: 5; 1 unit => 100000; 1 atom => 0.00001 === small limit
-  return decimals ? ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(decimals)).toString(10) : '1'
+  return decimals ? ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(decimals)).toString(10) : MINIMUM_ATOM_VALUE
 }
 
 /**

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMALS } from 'const'
+import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMALS, ONE_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
 import { batchIdToDate } from './time'
 
 export {
@@ -206,4 +206,10 @@ export function capitalize(sentence: string): string {
     .split(' ')
     .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
     .join(' ')
+}
+
+export function getSmallLimit(decimals?: number): string {
+  // Small limit === 1 token atom in relation to token units.
+  // E.g.: Token decimals: 5; 1 unit => 100000; 1 atom => 0.00001 === small limit
+  return decimals ? ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(decimals)).toString(10) : '1'
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,7 @@
 import BigNumber from 'bignumber.js'
+
+import { TokenErc20, formatSmart } from '@gnosis.pm/dex-js'
+
 import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMALS, ONE_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
 import { batchIdToDate } from './time'
 
@@ -212,4 +215,23 @@ export function getMinimumRepresentableValue(decimals?: number): string {
   // Small limit === 1 token atom in relation to token units.
   // E.g.: Token decimals: 5; 1 unit => 100000; 1 atom => 0.00001 === small limit
   return decimals ? ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(decimals)).toString(10) : '1'
+}
+
+/**
+ * Wrapper around `formatSmart` that formats amount to max precision for given token.
+ * Assumes `amount` to be in atom units. E.g:
+ * amount: 10001
+ * token.decimals: 4
+ * return: 1.0001
+ *
+ * @param amount BigNumber integer amount
+ * @param token Erc20 token
+ */
+export function formatSmartMaxPrecision(amount: BigNumber, token?: TokenErc20 | null): string {
+  return formatSmart({
+    amount: amount.toString(10),
+    precision: token?.decimals || 0,
+    decimals: token?.decimals || 0,
+    smallLimit: getMinimumRepresentableValue(token?.decimals),
+  })
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -208,7 +208,7 @@ export function capitalize(sentence: string): string {
     .join(' ')
 }
 
-export function getSmallLimit(decimals?: number): string {
+export function getMinimumRepresentableValue(decimals?: number): string {
   // Small limit === 1 token atom in relation to token units.
   // E.g.: Token decimals: 5; 1 unit => 100000; 1 atom => 0.00001 === small limit
   return decimals ? ONE_BIG_NUMBER.div(TEN_BIG_NUMBER.exponentiatedBy(decimals)).toString(10) : '1'


### PR DESCRIPTION
From https://github.com/gnosis/gp-ui/pull/244#discussion_r586706150

Increased precision of displayed amounts:
- From/to amounts
- Filled amounts
- Surplus amount

 (Gas fee amounts already are like that)

## Before
![screenshot_2021-03-08_12-57-29](https://user-images.githubusercontent.com/43217/110381249-0c592b80-800e-11eb-9834-965195f74a90.png)

## After
![screenshot_2021-03-08_12-56-48](https://user-images.githubusercontent.com/43217/110381243-09f6d180-800e-11eb-99b1-c4127d61bc8d.png)
