### PR TITLE
330/surplus buy orders

### DIFF
--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -89,7 +89,7 @@ export function getSellSurplus(buyAmount: BigNumberIsh, executedBuyAmount: BigNu
   // SELL order has the sell amount fixed (minus the fees),
   // so it'll buy AT LEAST `buyAmount`
   // Surplus is in the form of additional buy amount, buying more than `buyAmount`
-  // Since this is a `fillOrKill`, whenever `executedBuyAmount >= buyAmount` the order was fully executed.
+  // For `fillOrKill` orders, whenever `executedBuyAmount >= buyAmount` the order was fully executed.
   // The difference between `executedBuyAmount - buyAmount` is the surplus.
   const amount = executedAmountBigNumber.gt(buyAmountBigNumber)
     ? executedAmountBigNumber.minus(buyAmountBigNumber)
@@ -112,7 +112,7 @@ export function getBuySurplus(sellAmount: BigNumberIsh, executedSellAmount: BigN
   const executedAmountBigNumber = new BigNumber(executedSellAmount)
   // BUY order has the buy amount fixed, so it'll sell AT MOST `sellAmount` (minus the fees)
   // Surplus will come in the form of a "discount", selling less than `sellAmount`
-  // Since this is a `fillOrKill`, whenever `executedSellAmount` > 0 the order was fully executed.
+  // For `fillOrKill` orders, whenever `executedSellAmount` > 0 the order was fully executed.
   // The difference between `sellAmount` - `executedSellAmount` is the surplus.
   // When there's no difference, there's no surplus
   const amount = executedAmountBigNumber.gt(ZERO_BIG_NUMBER)

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -85,12 +85,17 @@ export function getSurplus(
 }
 
 export function getOrderSurplus(order: RawOrder): { amount: BigNumber; percentage: BigNumber } {
-  const { kind, buyAmount, sellAmount } = order
+  const { kind, buyAmount, sellAmount, executedFeeAmount, partiallyFillable } = order
 
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
 
+  if (partiallyFillable) {
+    // TODO: calculate how much was matched based on the type and check whether there was any surplus
+    throw Error('Not implemented')
+  }
+
   if (kind === 'buy') {
-    const _sellAmount = new BigNumber(sellAmount)
+    const _sellAmount = new BigNumber(sellAmount).minus(executedFeeAmount)
     // BUY order has the buy amount fixed, so it'll sell AT MOST `sellAmount`
     // Surplus will come in the form of a "discount", selling less than `sellAmount`
     // Since this is a `fillOrKill`, whenever `executedSellAmount` > 0 the order was fully executed.

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -84,15 +84,17 @@ type BigNumberIsh = string | BigNumber
  * @returns Sell surplus
  */
 export function getSellSurplus(buyAmount: BigNumberIsh, executedBuyAmount: BigNumberIsh): Surplus {
-  const _buyAmount = new BigNumber(buyAmount)
-  const _executedAmount = new BigNumber(executedBuyAmount)
+  const buyAmountBigNumber = new BigNumber(buyAmount)
+  const executedAmountBigNumber = new BigNumber(executedBuyAmount)
   // SELL order has the sell amount fixed (minus the fees),
   // so it'll buy AT LEAST `buyAmount`
   // Surplus is in the form of additional buy amount, buying more than `buyAmount`
   // Since this is a `fillOrKill`, whenever `executedBuyAmount >= buyAmount` the order was fully executed.
   // The difference between `executedBuyAmount - buyAmount` is the surplus.
-  const amount = _executedAmount.gt(_buyAmount) ? _executedAmount.minus(_buyAmount) : ZERO_BIG_NUMBER
-  const percentage = amount.dividedBy(_buyAmount)
+  const amount = executedAmountBigNumber.gt(buyAmountBigNumber)
+    ? executedAmountBigNumber.minus(buyAmountBigNumber)
+    : ZERO_BIG_NUMBER
+  const percentage = amount.dividedBy(buyAmountBigNumber)
 
   return { amount, percentage }
 }
@@ -106,15 +108,17 @@ export function getSellSurplus(buyAmount: BigNumberIsh, executedBuyAmount: BigNu
  * @returns Buy surplus
  */
 export function getBuySurplus(sellAmount: BigNumberIsh, executedSellAmount: BigNumberIsh): Surplus {
-  const _sellAmount = new BigNumber(sellAmount)
-  const _executedAmount = new BigNumber(executedSellAmount)
+  const sellAmountBigNumber = new BigNumber(sellAmount)
+  const executedAmountBigNumber = new BigNumber(executedSellAmount)
   // BUY order has the buy amount fixed, so it'll sell AT MOST `sellAmount` (minus the fees)
   // Surplus will come in the form of a "discount", selling less than `sellAmount`
   // Since this is a `fillOrKill`, whenever `executedSellAmount` > 0 the order was fully executed.
   // The difference between `sellAmount` - `executedSellAmount` is the surplus.
   // When there's no difference, there's no surplus
-  const amount = _executedAmount.gt(ZERO_BIG_NUMBER) ? _sellAmount.minus(_executedAmount) : ZERO_BIG_NUMBER
-  const percentage = amount.dividedBy(_sellAmount)
+  const amount = executedAmountBigNumber.gt(ZERO_BIG_NUMBER)
+    ? sellAmountBigNumber.minus(executedAmountBigNumber)
+    : ZERO_BIG_NUMBER
+  const percentage = amount.dividedBy(sellAmountBigNumber)
 
   return { amount, percentage }
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -90,9 +90,19 @@ export function getOrderSurplus(order: RawOrder): { amount: BigNumber; percentag
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
 
   if (kind === 'buy') {
-    return getSurplus(sellAmount, executedSellAmount)
+    const esa = new BigNumber(executedSellAmount)
+    const sa = new BigNumber(sellAmount)
+    const amount = esa.gt(ZERO_BIG_NUMBER) ? sa.minus(esa) : ZERO_BIG_NUMBER
+    const percentage = amount.dividedBy(sellAmount)
+
+    return { amount, percentage }
   } else {
-    return getSurplus(buyAmount, executedBuyAmount)
+    const eba = new BigNumber(executedBuyAmount)
+    const ba = new BigNumber(buyAmount)
+    const amount = eba.gt(buyAmount) ? eba.minus(ba) : ZERO_BIG_NUMBER
+    const percentage = amount.dividedBy(ba)
+
+    return { amount, percentage }
   }
 }
 

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -54,8 +54,8 @@ describe('getOrderSurplus', () => {
         const order: RawOrder = {
           ...RAW_ORDER,
           kind: 'buy',
-          sellAmount: '110',
-          executedSellAmount: '109',
+          sellAmount: '100',
+          executedSellAmount: '109', // 10 is the fee, total sold is 99; surplus === 1
           feeAmount: '10',
           executedFeeAmount: '10',
           partiallyFillable: false,

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -9,6 +9,7 @@ import { getOrderSurplus, getSurplus } from 'utils'
 import { RAW_ORDER } from '../../data'
 
 const ZERO_DOT_ZERO_ONE = new BigNumber('0.01')
+// const TWENTY_PERCENT = new BigNumber('0.2')
 
 describe('getSurplus', () => {
   const inputAmount = ONE_HUNDRED_BIG_NUMBER
@@ -25,13 +26,89 @@ describe('getSurplus', () => {
 })
 
 describe('getOrderSurplus', () => {
-  test('Buy order', () => {
-    const order: RawOrder = { ...RAW_ORDER, kind: 'buy', sellAmount: '100', executedSellAmount: '99' }
-    expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+  describe('Buy order', () => {
+    describe('fillOrKill', () => {
+      test('With fees = 0', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'buy',
+          sellAmount: '100',
+          executedSellAmount: '99',
+          feeAmount: '0',
+          executedFeeAmount: '0',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+      })
+      test('With fees > 0', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'buy',
+          sellAmount: '110',
+          executedSellAmount: '109',
+          feeAmount: '10',
+          executedFeeAmount: '10',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+      })
+    })
+    test('partiallyFillable', () => {
+      const order: RawOrder = {
+        ...RAW_ORDER,
+        kind: 'buy',
+        sellAmount: '100',
+        executedSellAmount: '50',
+        buyAmount: '100',
+        executedBuyAmount: '40',
+        partiallyFillable: true,
+      }
+      // TODO: uncomment when implemented
+      // expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
+      expect(() => getOrderSurplus(order)).toThrow('Not implemented')
+    })
   })
 
-  test('Sell order', () => {
-    const order: RawOrder = { ...RAW_ORDER, kind: 'sell', buyAmount: '100', executedBuyAmount: '101' }
-    expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+  describe('Sell order', () => {
+    describe('fillOrKill', () => {
+      test('With fees = 0', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'sell',
+          buyAmount: '100',
+          executedBuyAmount: '101',
+          feeAmount: '0',
+          executedFeeAmount: '0',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+      })
+      test('With fees > 0', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'sell',
+          buyAmount: '100',
+          executedBuyAmount: '101',
+          feeAmount: '10',
+          executedFeeAmount: '10',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+      })
+    })
+    test('partiallyFillable', () => {
+      const order: RawOrder = {
+        ...RAW_ORDER,
+        kind: 'sell',
+        buyAmount: '100',
+        executedBuyAmount: '50',
+        sellAmount: '100',
+        executedSellAmount: '40',
+        partiallyFillable: true,
+      }
+      // TODO: uncomment when implemented
+      // expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
+      expect(() => getOrderSurplus(order)).toThrow('Not implemented')
+    })
   })
 })

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -1,33 +1,43 @@
 import BigNumber from 'bignumber.js'
 
-import { ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
+import { ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
 import { RawOrder } from 'api/operator'
 
-import { getOrderSurplus, getSurplus } from 'utils'
+import { getOrderSurplus } from 'utils'
 
 import { RAW_ORDER } from '../../data'
 
 const ZERO_DOT_ZERO_ONE = new BigNumber('0.01')
 // const TWENTY_PERCENT = new BigNumber('0.2')
 
-describe('getSurplus', () => {
-  const inputAmount = ONE_HUNDRED_BIG_NUMBER
-
-  test('executedAmount = 0', () => {
-    const executedAmount = ZERO_BIG_NUMBER
-    expect(getSurplus(inputAmount, executedAmount)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
-  })
-
-  test('surplus 1%', () => {
-    const executedAmount = ONE_BIG_NUMBER.plus(ONE_HUNDRED_BIG_NUMBER)
-    expect(getSurplus(inputAmount, executedAmount)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
-  })
-})
-
 describe('getOrderSurplus', () => {
   describe('Buy order', () => {
     describe('fillOrKill', () => {
+      test('No surplus', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'buy',
+          sellAmount: '100',
+          executedSellAmount: '100',
+          feeAmount: '0',
+          executedFeeAmount: '0',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
+      })
+      test('No matches', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'buy',
+          sellAmount: '100',
+          executedSellAmount: '0',
+          feeAmount: '0',
+          executedFeeAmount: '0',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
+      })
       test('With fees = 0', () => {
         const order: RawOrder = {
           ...RAW_ORDER,
@@ -71,6 +81,30 @@ describe('getOrderSurplus', () => {
 
   describe('Sell order', () => {
     describe('fillOrKill', () => {
+      test('No surplus', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'sell',
+          buyAmount: '100',
+          executedBuyAmount: '100',
+          feeAmount: '0',
+          executedFeeAmount: '0',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
+      })
+      test('No matches', () => {
+        const order: RawOrder = {
+          ...RAW_ORDER,
+          kind: 'sell',
+          buyAmount: '100',
+          executedBuyAmount: '0',
+          feeAmount: '0',
+          executedFeeAmount: '0',
+          partiallyFillable: false,
+        }
+        expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
+      })
       test('With fees = 0', () => {
         const order: RawOrder = {
           ...RAW_ORDER,

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -26,7 +26,7 @@ describe('getSurplus', () => {
 
 describe('getOrderSurplus', () => {
   test('Buy order', () => {
-    const order: RawOrder = { ...RAW_ORDER, kind: 'buy', sellAmount: '100', executedSellAmount: '101' }
+    const order: RawOrder = { ...RAW_ORDER, kind: 'buy', sellAmount: '100', executedSellAmount: '99' }
     expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
   })
 


### PR DESCRIPTION
# Summary

Closes #330 

Added proper calculation of surplus for __buy__ orders

For now, it's available __only__ for `fillOrKill` orders.
It'll intentionally throw for partially fillable orders.

# Testing

1. Get a __buy__ order that has been executed
2. Search for it using this PR's deployed link

- [ ] Check the surplus displayed matches the actual order surplus

How to do that? You can check the raw order data either checking the browser console log requests tab. This is on Firefox:
![screenshot_2021-03-30_16-26-23](https://user-images.githubusercontent.com/43217/113069198-aa0acb00-9174-11eb-9cfd-4c3e7ab719a1.png)

Or check the order id in the [api (this link is for rinkeby)](https://protocol-rinkeby.dev.gnosisdev.com/api/#/default/get_api_v1_orders__UID_).

Then, compare `sellAmount` against `executedSellAmount`.
The difference `sellAmount` - `executedSellAmount` is the surplus. 
No difference means no surplus.

## Note
~I was not able to get a buy order that gave me surplus so far.~
~So this test will likely result in no surplus for you as well.~
~(It's covered by unit tests, though)~

I had at first understood wrong, due to how the Swap UI was creating orders.
That lead to a coincidence where the sell amount == executedSellAmount + fees.
The bug has been fixed here, as well as on the Swap (see https://github.com/gnosis/gp-swap-ui/pull/382).

Try it out with this order for example [`0x03e72fe591d0d203eb03b032ccb7857999109028ffb9b1f564764ceb67f76bae5b0abe214ab7875562adee331deff0fe1912fe426065ff53`](https://pr349--gpui.review.gnosisdev.com/rinkeby/orders/0x03e72fe591d0d203eb03b032ccb7857999109028ffb9b1f564764ceb67f76bae5b0abe214ab7875562adee331deff0fe1912fe426065ff53)