### PR TITLE
372/add receiver field

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -25,6 +25,7 @@ export type OrderStatus = 'open' | 'filled' | 'canceled' | 'expired'
 export type RawOrder = {
   creationDate: string
   owner: string
+  receiver?: string
   uid: string
   executedBuyAmount: string
   executedSellAmount: string
@@ -48,6 +49,7 @@ export type RawOrder = {
  * Some fields are kept as is.
  */
 export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature'> & {
+  receiver: string
   txHash?: string
   shortId: string
   creationDate: Date

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -62,6 +62,7 @@ const Table = styled(SimpleTable)`
 const tooltip = {
   orderID: 'A unique identifier ID for this order.',
   from: 'The account address which signed the order.',
+  to: 'The account address which will/did receive the bought amount.',
   hash: 'The onchain settlement transaction for this order. Can be viewed on Etherscan.',
   status: 'The order status is either Open, Filled, Expired or Canceled.',
   submission:
@@ -90,6 +91,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
     uid,
     shortId,
     owner,
+    receiver,
     // txHash,
     kind,
     partiallyFillable,
@@ -139,6 +141,18 @@ export function DetailsTable(props: Props): JSX.Element | null {
                 textToCopy={owner}
                 onCopy={(): void => onCopy('ownerAddress')}
                 contentsToDisplay={<BlockExplorerLink identifier={owner} type="address" label={owner} />}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <HelpTooltip tooltip={tooltip.to} /> To
+            </td>
+            <td>
+              <RowWithCopyButton
+                textToCopy={receiver}
+                onCopy={(): void => onCopy('receiverAddress')}
+                contentsToDisplay={<BlockExplorerLink identifier={receiver} type="address" label={receiver} />}
               />
             </td>
           </tr>

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -217,6 +217,14 @@ function getShortOrderId(orderId: string, length = 8): string {
   return orderId.replace(/^0x/, '').slice(0, length)
 }
 
+function isZeroAddress(address: string): boolean {
+  return /^0x0{40}$/.test(address)
+}
+
+function getReceiverAddress({ owner, receiver }: RawOrder): string {
+  return !receiver || isZeroAddress(receiver) ? owner : receiver
+}
+
 /**
  * Transforms a RawOrder into an Order object
  *
@@ -235,6 +243,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
     invalidated,
     ...rest
   } = rawOrder
+  const receiver = getReceiverAddress(rawOrder)
   const shortId = getShortOrderId(rawOrder.uid)
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(rawOrder)
   const status = getOrderStatus(rawOrder)
@@ -247,6 +256,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
 
   return {
     ...rest,
+    receiver,
     txHash,
     shortId,
     creationDate: new Date(creationDate),

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -9,6 +9,7 @@ import { USDT, WETH } from './erc20s'
 export const RAW_ORDER: RawOrder = {
   creationDate: '2021-01-20T23:15:07.892538607Z',
   owner: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
+  receiver: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
   uid: '0xadef89adea9e8d7f987e98f79a87efde5f7e65df65e76d5f67e5d76f5edf',
   buyAmount: '0',
   executedBuyAmount: '0',
@@ -29,6 +30,7 @@ export const RAW_ORDER: RawOrder = {
 
 export const RICH_ORDER: Order = {
   ...RAW_ORDER,
+  receiver: RAW_ORDER.owner,
   shortId: 'adef89ad',
   creationDate: new Date(RAW_ORDER.creationDate),
   expirationDate: new Date(RAW_ORDER.validTo * 1000),


### PR DESCRIPTION
# Summary

Closes #372 

`To` field added to order details page

## Order with from = to
![screenshot_2021-04-13_08-27-44](https://user-images.githubusercontent.com/43217/114578794-159f6e80-9c32-11eb-8f9b-c297b58366c9.png)
`0x434af024df656a0a669e80ec0daf1fb1a20076164d5a1eb15435b73d0ca8b33c5b0abe214ab7875562adee331deff0fe1912fe42606ca38f`

## Order with from != to
![screenshot_2021-04-13_08-28-25](https://user-images.githubusercontent.com/43217/114578876-2cde5c00-9c32-11eb-813a-a52787d6dcd2.png)
`0xf2ff7a2cc857dd305cf0ab49caddcdc692a222b93b7de8450c7ab0640f6f2b285b0abe214ab7875562adee331deff0fe1912fe4260748bb0`

# Testing

You can verify the order ids above.
Alternatively, you can do the whole flow:
1. On the swap app, enable expert mode (for now the change is only on [`dev`](https://cow-trade.dev.gnosisdev.com/)
2. Now, `add send` button will show up
![screenshot_2021-04-13_08-30-53](https://user-images.githubusercontent.com/43217/114579277-8e9ec600-9c32-11eb-9667-07cfade00d7e.png)
3. Add a valid address in the input, different from the account currently connected
4. Place an order
5. Open the Explorer link

- [ ] Verify the Explorer `To` field matches the value input on step `3`

6. Repeat the process, this time WITHOUT adding a custom receiver

- [ ] Verify the Explorer `To` field matches the `From` field

