### PR TITLE
374/prod endpoints for operator api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ MOCK=true
 
 # Enables autoconnect for mock mode (default = true)
 AUTOCONNECT=true
+
+# Use dev operator locally
+OPERATOR_ENDPOINT_MAINNET='https://protocol-mainnet.dev.gnosisdev.com/api'
+OPERATOR_ENDPOINT_RINKEBY='https://protocol-rinkeby.dev.gnosisdev.com/api'
+OPERATOR_ENDPOINT_XDAI='https://protocol-xdai.dev.gnosisdev.com/api'

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,3 @@ MOCK=true
 
 # Enables autoconnect for mock mode (default = true)
 AUTOCONNECT=true
-
-# Use dev operator locally
-OPERATOR_ENDPOINT_MAINNET='https://protocol-mainnet.dev.gnosisdev.com/api'
-OPERATOR_ENDPOINT_RINKEBY='https://protocol-rinkeby.dev.gnosisdev.com/api'
-OPERATOR_ENDPOINT_XDAI='https://protocol-xdai.dev.gnosisdev.com/api'

--- a/getWebpackConfig.js
+++ b/getWebpackConfig.js
@@ -96,7 +96,15 @@ function _getPlugins({ apps, config, envVars, stats, defineVars, publicPaths, is
   // Environment plugin: Like e DefinePlugin but on process.env
   plugins.push(
     new webpack.EnvironmentPlugin({
-      NODE_ENV: 'development', // FIXME: Shouldn't this is isProduction??
+      NODE_ENV: 'development', // defaults to `development` when not set
+      // Load app's env vars, if any
+      ...apps.reduce((acc, app) => {
+        if (app && app.envVars) {
+          acc = { ...acc, ...app.envVars }
+        }
+        return acc
+      }, {}),
+      // Finally load global env vars
       ...envVars,
     }),
   )

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -9,15 +9,15 @@ import { FeeInformation, GetOrderParams, GetOrdersParams, OrderID, OrderPostErro
 function getOperatorUrl(): Partial<Record<Network, string>> {
   if (isProd || isStaging) {
     return {
-      [Network.Mainnet]: 'https://protocol-mainnet.gnosis.io/api',
-      [Network.Rinkeby]: 'https://protocol-rinkeby.gnosis.io/api',
-      [Network.xDAI]: 'https://protocol-xdai.gnosis.io/api',
+      [Network.Mainnet]: process.env.OPERATOR_URL_PROD_MAINNET,
+      [Network.Rinkeby]: process.env.OPERATOR_URL_PROD_RINKEBY,
+      [Network.xDAI]: process.env.OPERATOR_URL_PROD_XDAI,
     }
   } else {
     return {
-      [Network.Mainnet]: 'https://protocol-mainnet.dev.gnosisdev.com/api',
-      [Network.Rinkeby]: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
-      [Network.xDAI]: 'https://protocol-xdai.dev.gnosisdev.com/api',
+      [Network.Mainnet]: process.env.OPERATOR_URL_STAGING_MAINNET,
+      [Network.Rinkeby]: process.env.OPERATOR_URL_STAGING_RINKEBY,
+      [Network.xDAI]: process.env.OPERATOR_URL_STAGING_XDAI,
     }
   }
 }

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -10,9 +10,9 @@ import { FeeInformation, GetOrderParams, GetOrdersParams, OrderID, OrderPostErro
  *    https://protocol-rinkeby.dev.gnosisdev.com/api/
  */
 const API_BASE_URL: Partial<Record<Network, string>> = {
-  [Network.Mainnet]: 'https://protocol-mainnet.dev.gnosisdev.com/api/v1',
-  [Network.Rinkeby]: 'https://protocol-rinkeby.dev.gnosisdev.com/api/v1',
-  [Network.xDAI]: 'https://protocol-xdai.dev.gnosisdev.com/api/v1',
+  [Network.Mainnet]: process.env.OPERATOR_ENDPOINT_MAINNET,
+  [Network.Rinkeby]: process.env.OPERATOR_ENDPOINT_RINKEBY,
+  [Network.xDAI]: process.env.OPERATOR_ENDPOINT_XDAI,
 }
 
 const DEFAULT_HEADERS: Headers = new Headers({
@@ -31,7 +31,7 @@ function _getApiBaseUrl(networkId: Network): string {
   if (!baseUrl) {
     throw new Error('Unsupported Network. The operator API is not deployed in the Network ' + networkId)
   } else {
-    return baseUrl
+    return baseUrl + '/v1'
   }
 }
 

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -10,9 +10,9 @@ import { FeeInformation, GetOrderParams, GetOrdersParams, OrderID, OrderPostErro
  *    https://protocol-rinkeby.dev.gnosisdev.com/api/
  */
 const API_BASE_URL: Partial<Record<Network, string>> = {
-  [Network.Mainnet]: process.env.OPERATOR_ENDPOINT_MAINNET,
-  [Network.Rinkeby]: process.env.OPERATOR_ENDPOINT_RINKEBY,
-  [Network.xDAI]: process.env.OPERATOR_ENDPOINT_XDAI,
+  [Network.Mainnet]: 'https://protocol-mainnet.dev.gnosisdev.com/api/v1',
+  [Network.Rinkeby]: 'https://protocol-rinkeby.dev.gnosisdev.com/api/v1',
+  [Network.xDAI]: 'https://protocol-xdai.dev.gnosisdev.com/api/v1',
 }
 
 const DEFAULT_HEADERS: Headers = new Headers({
@@ -31,7 +31,7 @@ function _getApiBaseUrl(networkId: Network): string {
   if (!baseUrl) {
     throw new Error('Unsupported Network. The operator API is not deployed in the Network ' + networkId)
   } else {
-    return baseUrl + '/v1'
+    return baseUrl
   }
 }
 

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -1,19 +1,28 @@
 import { Network } from 'types'
 
 import { buildSearchString } from 'utils/url'
+import { isProd, isStaging } from 'utils/env'
 
 import { OrderCreation } from './signatures'
 import { FeeInformation, GetOrderParams, GetOrdersParams, OrderID, OrderPostError, RawOrder } from './types'
 
-/**
- * See Swagger documentation:
- *    https://protocol-rinkeby.dev.gnosisdev.com/api/
- */
-const API_BASE_URL: Partial<Record<Network, string>> = {
-  [Network.Mainnet]: 'https://protocol-mainnet.dev.gnosisdev.com/api/v1',
-  [Network.Rinkeby]: 'https://protocol-rinkeby.dev.gnosisdev.com/api/v1',
-  [Network.xDAI]: 'https://protocol-xdai.dev.gnosisdev.com/api/v1',
+function getOperatorUrl(): Partial<Record<Network, string>> {
+  if (isProd || isStaging) {
+    return {
+      [Network.Mainnet]: 'https://protocol-mainnet.gnosis.io/api',
+      [Network.Rinkeby]: 'https://protocol-rinkeby.gnosis.io/api',
+      [Network.xDAI]: 'https://protocol-xdai.gnosis.io/api',
+    }
+  } else {
+    return {
+      [Network.Mainnet]: 'https://protocol-mainnet.dev.gnosisdev.com/api',
+      [Network.Rinkeby]: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
+      [Network.xDAI]: 'https://protocol-xdai.dev.gnosisdev.com/api',
+    }
+  }
 }
+
+const API_BASE_URL = getOperatorUrl()
 
 const DEFAULT_HEADERS: Headers = new Headers({
   'Content-Type': 'application/json',

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -40,7 +40,7 @@ function _getApiBaseUrl(networkId: Network): string {
   if (!baseUrl) {
     throw new Error('Unsupported Network. The operator API is not deployed in the Network ' + networkId)
   } else {
-    return baseUrl
+    return baseUrl + '/v1'
   }
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,23 @@
+type Envs = {
+  isDev: boolean
+  isStaging: boolean
+  isProd: boolean
+}
+
+const getRegex = (regex: string | undefined): RegExp | undefined => (regex ? new RegExp(regex) : undefined)
+
+function checkEnvironment(host: string): Envs {
+  const domainDevRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_DEV)
+  const domainStagingRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_STAGING)
+  const domainProdRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_PROD)
+
+  return {
+    isDev: domainDevRegex?.test(host) || false,
+    isStaging: domainStagingRegex?.test(host) || false,
+    isProd: domainProdRegex?.test(host) || false,
+  }
+}
+
+const { isDev, isStaging, isProd } = checkEnvironment(window.location.host)
+
+export { isDev, isStaging, isProd }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,13 @@ const EXPLORER_APP = {
     EXPLORER_APP_DOMAIN_REGEX_DEV: '^protocol-explorer\\.dev|^localhost:\\d{2,5}|^pr\\d+--gpui\\.review',
     EXPLORER_APP_DOMAIN_REGEX_STAGING: '^protocol-explorer\\.staging',
     EXPLORER_APP_DOMAIN_REGEX_PROD: '^gnosis-protocol\\.io',
+
+    OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
+    OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
+    OPERATOR_URL_STAGING_XDAI: 'https://protocol-xdai.dev.gnosisdev.com/api',
+    OPERATOR_URL_PROD_MAINNET: 'https://protocol-mainnet.gnosis.io/api',
+    OPERATOR_URL_PROD_RINKEBY: 'https://protocol-rinkeby.gnosis.io/api',
+    OPERATOR_URL_PROD_XDAI: 'https://protocol-xdai.gnosis.io/api',
   },
 }
 const SAFE_SWAP_APP = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,16 @@ const CONFIG = loadConfig()
 
 const config = overrideEnvConfig(CONFIG)
 const TRADE_APP = { name: 'trade', title: 'Gnosis Protocol Exchange', filename: 'trade.html' }
-const EXPLORER_APP = { name: 'explorer', title: 'Gnosis Protocol Explorer', filename: 'index.html' }
+const EXPLORER_APP = {
+  name: 'explorer',
+  title: 'Gnosis Protocol Explorer',
+  filename: 'index.html',
+  envVars: {
+    EXPLORER_APP_DOMAIN_REGEX_DEV: '^protocol-explorer\\.dev|^localhost:\\d{2,5}|^pr\\d+--gpui\\.review',
+    EXPLORER_APP_DOMAIN_REGEX_STAGING: '^protocol-explorer\\.staging',
+    EXPLORER_APP_DOMAIN_REGEX_PROD: '^gnosis-protocol\\.io',
+  },
+}
 const SAFE_SWAP_APP = {
   name: 'safe-swap',
   title: 'Gnosis Safe - Swap app',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,9 +52,6 @@ module.exports = getWebpackConfig({
   baseUrl,
   envVars: {
     BASE_URL: baseUrl,
-    OPERATOR_ENDPOINT_MAINNET: 'https://protocol-mainnet.gnosis.io/api', // defaults to prod endpoints
-    OPERATOR_ENDPOINT_RINKEBY: 'https://protocol-rinkeby.gnosis.io/api',
-    OPERATOR_ENDPOINT_XDAI: 'https://protocol-xdai.gnosis.io/api',
   },
   defineVars: {
     CONFIG: JSON.stringify(config),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,9 @@ module.exports = getWebpackConfig({
   baseUrl,
   envVars: {
     BASE_URL: baseUrl,
+    OPERATOR_ENDPOINT_MAINNET: 'https://protocol-mainnet.gnosis.io/api', // defaults to prod endpoints
+    OPERATOR_ENDPOINT_RINKEBY: 'https://protocol-rinkeby.gnosis.io/api',
+    OPERATOR_ENDPOINT_XDAI: 'https://protocol-xdai.gnosis.io/api',
   },
   defineVars: {
     CONFIG: JSON.stringify(config),


### PR DESCRIPTION
# Summary

Closes #374 

Based on the location, uses a different operator API endpoint.

Everything configurable via env vars.

Defaults to operator API staging when not able to identify where we are running.

# Testing

Open the version deployed in this PR and verify that calls to operator API go to their staging, which depending on the network will be:

```
    OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
    OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
    OPERATOR_URL_STAGING_XDAI: 'https://protocol-xdai.dev.gnosisdev.com/api',
```

The next step is can only be tested when deployed to staging/prod.
Verify calls to operator API go to their prod:

```
    OPERATOR_URL_PROD_MAINNET: 'https://protocol-mainnet.gnosis.io/api',
    OPERATOR_URL_PROD_RINKEBY: 'https://protocol-rinkeby.gnosis.io/api',
    OPERATOR_URL_PROD_XDAI: 'https://protocol-xdai.gnosis.io/api',
```