### PR TITLE
Show spinner for open orders

### DIFF
--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -1,14 +1,7 @@
 import React from 'react'
 import styled, { DefaultTheme } from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faCheckCircle,
-  faClock,
-  faDotCircle,
-  faSpinner,
-  faTimesCircle,
-  IconDefinition,
-} from '@fortawesome/free-solid-svg-icons'
+import { faCheckCircle, faCircleNotch, faClock, faTimesCircle, IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
 import { OrderStatus } from 'api/operator'
 
@@ -66,10 +59,6 @@ const PartialFill = styled.div`
   color: ${({ theme }): string => theme.textPrimary1};
 `
 
-const Loader = styled(FontAwesomeIcon)`
-  margin-left: 1rem;
-`
-
 function getStatusIcon(status: OrderStatus): IconDefinition {
   switch (status) {
     case 'expired':
@@ -79,21 +68,21 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
     case 'canceled':
       return faTimesCircle
     case 'open':
-      return faDotCircle
+      return faCircleNotch
   }
 }
 
 function StatusIcon({ status }: DisplayProps): JSX.Element {
   const icon = getStatusIcon(status)
+  const isOpen = status === 'open'
 
-  return <StyledFAIcon icon={icon} />
+  return <StyledFAIcon icon={icon} spin={isOpen} />
 }
 
 export type Props = DisplayProps & { partiallyFilled: boolean }
 
 export function StatusLabel(props: Props): JSX.Element {
   const { status, partiallyFilled } = props
-  const isOpen = status === 'open'
 
   return (
     <Wrapper>
@@ -102,7 +91,6 @@ export function StatusLabel(props: Props): JSX.Element {
         {status}
       </Label>
       {partiallyFilled && <PartialFill>(partial fill)</PartialFill>}
-      {isOpen && <Loader icon={faSpinner} spin size="1x" />}
     </Wrapper>
   )
 }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import styled, { DefaultTheme } from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCheckCircle, faClock, faDotCircle, faTimesCircle, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import {
+  faCheckCircle,
+  faClock,
+  faDotCircle,
+  faSpinner,
+  faTimesCircle,
+  IconDefinition,
+} from '@fortawesome/free-solid-svg-icons'
 
 import { OrderStatus } from 'api/operator'
 
@@ -59,6 +66,10 @@ const PartialFill = styled.div`
   color: ${({ theme }): string => theme.textPrimary1};
 `
 
+const Loader = styled(FontAwesomeIcon)`
+  margin-left: 1rem;
+`
+
 function getStatusIcon(status: OrderStatus): IconDefinition {
   switch (status) {
     case 'expired':
@@ -82,6 +93,7 @@ export type Props = DisplayProps & { partiallyFilled: boolean }
 
 export function StatusLabel(props: Props): JSX.Element {
   const { status, partiallyFilled } = props
+  const isOpen = status === 'open'
 
   return (
     <Wrapper>
@@ -90,6 +102,7 @@ export function StatusLabel(props: Props): JSX.Element {
         {status}
       </Label>
       {partiallyFilled && <PartialFill>(partial fill)</PartialFill>}
+      {isOpen && <Loader icon={faSpinner} spin size="1x" />}
     </Wrapper>
   )
 }


### PR DESCRIPTION
# Edit 1

Following the suggestion, removed the external spinner and replaced the `open` label by a circle notch, and made that spin
![screenshot_2021-04-21_09-02-43](https://user-images.githubusercontent.com/43217/115585237-47db4c80-a280-11eb-9e1a-771984cd5c1d.png)


# Summary

Closes #380 

~Adding spinner for open orders~
![screenshot_2021-04-20_14-48-23](https://user-images.githubusercontent.com/43217/115468273-b4563d00-a1e7-11eb-925f-9fc123d2e967.png)

# Testing

## Explorer app

1. Place an order
2. Open the explorer with given order and observe the status label while it's `Open`

- [ ] There should be a spinner

## Storybook

Alternatively, check the Storybook stories for `Status label`
![screenshot_2021-04-20_14-52-29](https://user-images.githubusercontent.com/43217/115468465-fbdcc900-a1e7-11eb-97d8-9f77d48338d1.png)

