### PR TITLE
375/transaction hash

### DIFF
--- a/src/api/operator/index.ts
+++ b/src/api/operator/index.ts
@@ -12,6 +12,7 @@ export const {
   // functions that have a mock
   getOrder,
   getOrders,
+  getTrades,
   // functions that do not have a mock
   getOrderLink = realApi.getOrderLink,
   postSignedOrder = realApi.postSignedOrder,

--- a/src/api/operator/operatorMock.ts
+++ b/src/api/operator/operatorMock.ts
@@ -1,6 +1,6 @@
-import { GetOrderParams, GetOrdersParams, RawOrder } from './types'
+import { GetOrderParams, GetOrdersParams, GetTradesParams, RawOrder, RawTrade } from './types'
 
-import { RAW_ORDER } from '../../../test/data'
+import { RAW_ORDER, RAW_TRADE } from '../../../test/data'
 
 export async function getOrder(params: GetOrderParams): Promise<RawOrder> {
   const { orderId } = params
@@ -19,4 +19,14 @@ export async function getOrders(params: GetOrdersParams): Promise<RawOrder[]> {
   order.owner = owner || order.owner
 
   return [order]
+}
+
+export async function getTrades(params: GetTradesParams): Promise<RawTrade[]> {
+  const { owner, orderId } = params
+
+  const trade = { ...RAW_TRADE }
+  trade.owner = owner || trade.owner
+  trade.orderUid = orderId || trade.orderUid
+
+  return [trade]
 }

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -73,6 +73,36 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   surplusPercentage: BigNumber
 }
 
+/**
+ * Raw API trade response type
+ */
+export type RawTrade = {
+  blockNumber: number
+  logIndex: number
+  owner: string
+  txHash: string
+  orderUid: string
+  buyAmount: string
+  sellAmount: string
+  sellAmountBeforeFees: string
+  buyToken: string
+  sellToken: string
+}
+
+/**
+ * Enriched Trade type
+ */
+export type Trade = Pick<RawTrade, 'blockNumber' | 'logIndex' | 'owner' | 'txHash'> & {
+  orderId: string // rename the field
+  buyAmount: BigNumber
+  sellAmount: BigNumber
+  sellAmountBeforeFees: BigNumber
+  buyToken?: TokenErc20 | null
+  buyTokenAddress: string
+  sellToken?: TokenErc20 | null
+  sellTokenAddress: string
+}
+
 type WithNetworkId = { networkId: Network }
 
 export type GetOrderParams = WithNetworkId & {
@@ -83,4 +113,9 @@ export type GetOrdersParams = WithNetworkId & {
   owner?: string
   sellToken?: string
   buyToken?: string
+}
+
+export type GetTradesParams = WithNetworkId & {
+  owner?: string
+  orderId?: string
 }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { useOrderAndErc20s } from 'hooks/useOperatorOrder'
+import { useOrderTrades } from 'hooks/useOperatorTrades'
 import { useSanitizeOrderIdAndUpdateUrl } from 'hooks/useSanitizeOrderIdAndUpdateUrl'
 
 import { ORDER_QUERY_INTERVAL } from 'apps/explorer/const'
@@ -12,11 +13,27 @@ export const OrderWidget: React.FC = () => {
   const networkId = useNetworkId()
   const orderId = useSanitizeOrderIdAndUpdateUrl()
 
-  const { order, isLoading, errors, errorOrderPresentInNetworkId } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
+  const { order, isLoading: isOrderLoading, errors, errorOrderPresentInNetworkId } = useOrderAndErc20s(
+    orderId,
+    ORDER_QUERY_INTERVAL,
+  )
+  const { trades, error, isLoading: areTradesLoading } = useOrderTrades(order)
+
+  if (error) {
+    errors['trades'] = error
+  }
 
   if (errorOrderPresentInNetworkId && networkId != errorOrderPresentInNetworkId) {
     return <RedirectToNetwork networkId={errorOrderPresentInNetworkId} />
   }
 
-  return <OrderDetails order={order} isLoading={isLoading} errors={errors} />
+  return (
+    <OrderDetails
+      order={order}
+      trades={trades}
+      isOrderLoading={isOrderLoading}
+      areTradesLoading={areTradesLoading}
+      errors={errors}
+    />
+  )
 }

--- a/src/components/orders/DetailsTable/DetailsTable.stories.tsx
+++ b/src/components/orders/DetailsTable/DetailsTable.stories.tsx
@@ -30,7 +30,7 @@ const order = {
   txHash: '0x489d8fd1efd43394c7c2b26216f36f1ab49b8d67623047e0fcb60efa2a2c420b',
 }
 
-const defaultProps: Props = { order }
+const defaultProps: Props = { order, areTradesLoading: false }
 
 export const DefaultFillOrKill = Template.bind({})
 DefaultFillOrKill.args = { ...defaultProps }

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -10,6 +10,7 @@ import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorer
 import { HelpTooltip } from 'components/Tooltip'
 
 import { SimpleTable } from 'components/common/SimpleTable'
+import Spinner from 'components/common/Spinner'
 
 import { AmountsDisplay } from 'components/orders/AmountsDisplay'
 import { DateDisplay } from 'components/orders/DateDisplay'
@@ -83,16 +84,17 @@ const tooltip = {
 
 export type Props = {
   order: Order
+  areTradesLoading: boolean
 }
 
 export function DetailsTable(props: Props): JSX.Element | null {
-  const { order } = props
+  const { order, areTradesLoading } = props
   const {
     uid,
     shortId,
     owner,
     receiver,
-    // txHash,
+    txHash,
     kind,
     partiallyFillable,
     creationDate,
@@ -156,14 +158,15 @@ export function DetailsTable(props: Props): JSX.Element | null {
               />
             </td>
           </tr>
-          {/* TODO: re-enable once this data is available on the API */}
-          {/* {!partiallyFillable && (
+          {!partiallyFillable && (
             <tr>
               <td>
                 <HelpTooltip tooltip={tooltip.hash} /> Transaction hash
               </td>
               <td>
-                {txHash ? (
+                {areTradesLoading ? (
+                  <Spinner />
+                ) : txHash ? (
                   <RowWithCopyButton
                     textToCopy={txHash}
                     onCopy={(): void => onCopy('settlementTx')}
@@ -174,7 +177,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
                 )}
               </td>
             </tr>
-          )} */}
+          )}
           <tr>
             <td>
               <HelpTooltip tooltip={tooltip.status} /> Status

--- a/src/components/orders/OrderDetails/OrderDetails.stories.tsx
+++ b/src/components/orders/OrderDetails/OrderDetails.stories.tsx
@@ -17,13 +17,16 @@ export default {
 
 const Template: Story<Props> = (args) => <OrderDetails {...args} />
 
-const defaultProps: Props = { order: null, isLoading: false, errors: {} }
+const defaultProps: Props = { order: null, isOrderLoading: false, areTradesLoading: false, trades: [], errors: {} }
 
 export const OrderFound = Template.bind({})
 OrderFound.args = { ...defaultProps, order: RICH_ORDER }
 
 export const OrderLoading = Template.bind({})
-OrderLoading.args = { ...defaultProps, isLoading: true }
+OrderLoading.args = { ...defaultProps, isOrderLoading: true }
+
+export const TradesLoading = Template.bind({})
+TradesLoading.args = { ...defaultProps, order: RICH_ORDER, areTradesLoading: true }
 
 export const OrderNotFound = Template.bind({})
 OrderNotFound.args = { ...defaultProps }

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -5,7 +5,7 @@ import { media } from 'theme/styles/media'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import { Order } from 'api/operator'
+import { Order, Trade } from 'api/operator'
 
 import { DetailsTable } from 'components/orders/DetailsTable'
 import { RowWithCopyButton } from 'components/orders/RowWithCopyButton'
@@ -43,14 +43,20 @@ const TitleUid = styled(RowWithCopyButton)`
 
 export type Props = {
   order: Order | null
-  isLoading: boolean
+  trades: Trade[]
+  isOrderLoading: boolean
+  areTradesLoading: boolean
   errors: Record<string, string>
 }
 
 export const OrderDetails: React.FC<Props> = (props) => {
-  const { order, isLoading, errors } = props
+  const { order, isOrderLoading, areTradesLoading, errors, trades } = props
   const areTokensLoaded = order?.buyToken && order?.sellToken
-  const isLoadingForTheFirstTime = isLoading && !areTokensLoaded
+  const isLoadingForTheFirstTime = isOrderLoading && !areTokensLoaded
+
+  // Only set txHash for fillOrKill orders, if any
+  // Partially fillable order will have a tab only for the trades
+  const txHash = order && !order.partiallyFillable && trades && trades.length === 1 ? trades[0].txHash : undefined
 
   return (
     <Wrapper>
@@ -59,10 +65,10 @@ export const OrderDetails: React.FC<Props> = (props) => {
         {order && <TitleUid textToCopy={order.uid} contentsToDisplay={order.shortId} />}
       </h1>
       {/* TODO: add tabs (overview/fills) */}
-      {order && areTokensLoaded && <DetailsTable order={order} />}
+      {order && areTokensLoaded && <DetailsTable order={{ ...order, txHash }} areTradesLoading={areTradesLoading} />}
       {/* TODO: add fills tab for partiallyFillable orders */}
-      {!order && !isLoading && <p>Order not found</p>}
-      {!isLoading && order && !areTokensLoaded && <p>Not able to load tokens</p>}
+      {!order && !isOrderLoading && <p>Order not found</p>}
+      {!isOrderLoading && order && !areTokensLoaded && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}
       {Object.keys(errors).map((key) => (
         <p key={key}>{errors[key]}</p>

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -1,0 +1,104 @@
+import { getTrades, Order, Trade } from 'api/operator'
+import { useCallback, useEffect, useState } from 'react'
+import { useNetworkId } from 'state/network'
+import { Network } from 'types'
+import { transformTrade } from 'utils'
+
+type Params = {
+  owner?: string
+  orderId?: string
+}
+
+type Result = {
+  trades: Trade[]
+  error: string
+  isLoading: boolean
+}
+
+/**
+ * Fetches trades for given filters
+ * When no filter is given, fetches all trades for current network
+ */
+export function useTrades(params: Params): Result {
+  const { owner, orderId } = params
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [trades, setTrades] = useState<Trade[]>([])
+
+  // Here we assume that we are already in the right network
+  // contrary to useOrder hook, where it searches all networks for a given orderId
+  const networkId = useNetworkId()
+
+  const fetchTrades = useCallback(async (networkId: Network, owner?: string, orderId?: string): Promise<void> => {
+    setIsLoading(true)
+    setError('')
+
+    try {
+      const trades = await getTrades({ networkId, owner, orderId })
+
+      // TODO: fetch buy/sellToken objects
+      setTrades(trades.map((trade) => transformTrade(trade)))
+    } catch (e) {
+      const msg = `Failed to fetch trades`
+      console.error(msg, e)
+      setError(msg)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!networkId) {
+      return
+    }
+
+    fetchTrades(networkId, owner, orderId)
+  }, [fetchTrades, networkId, orderId, owner])
+
+  return { trades, error, isLoading }
+}
+
+/**
+ * Fetches trades for given order
+ */
+export function useOrderTrades(order: Order | null): Result {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [trades, setTrades] = useState<Trade[]>([])
+
+  // Here we assume that we are already in the right network
+  // contrary to useOrder hook, where it searches all networks for a given orderId
+  const networkId = useNetworkId()
+
+  const fetchTrades = useCallback(async (networkId: Network, order: Order): Promise<void> => {
+    setIsLoading(true)
+    setError('')
+
+    const { uid: orderId, buyToken, sellToken } = order
+
+    try {
+      const trades = await getTrades({ networkId, orderId })
+
+      setTrades(trades.map((trade) => ({ ...transformTrade(trade), buyToken, sellToken })))
+    } catch (e) {
+      const msg = `Failed to fetch trades`
+      console.error(msg, e)
+      setError(msg)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!networkId || !order?.uid) {
+      return
+    }
+
+    fetchTrades(networkId, order)
+    // Depending on order UID to avoid re-fetching when obj changes but ID remains the same
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchTrades, networkId, order?.uid])
+
+  return { trades, error, isLoading }
+}

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -5,7 +5,7 @@ import { calculatePrice, invertPrice } from '@gnosis.pm/dex-js'
 
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
-import { Order, OrderStatus, RawOrder } from 'api/operator/types'
+import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount
@@ -276,5 +276,22 @@ export function transformOrder(rawOrder: RawOrder): Order {
     filledPercentage,
     surplusAmount,
     surplusPercentage,
+  }
+}
+
+/**
+ * Transforms a RawTrade into a Trade object
+ */
+export function transformTrade(rawTrade: RawTrade): Trade {
+  const { orderUid, buyAmount, sellAmount, sellAmountBeforeFees, buyToken, sellToken, ...rest } = rawTrade
+
+  return {
+    ...rest,
+    orderId: orderUid,
+    buyAmount: new BigNumber(buyAmount),
+    sellAmount: new BigNumber(sellAmount),
+    sellAmountBeforeFees: new BigNumber(sellAmountBeforeFees),
+    buyTokenAddress: buyToken,
+    sellTokenAddress: sellToken,
   }
 }

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 
-import { Order, RawOrder } from 'api/operator'
+import { Order, RawOrder, RawTrade, Trade } from 'api/operator'
 
 import { ZERO_BIG_NUMBER } from 'const'
 
@@ -51,4 +51,30 @@ export const RICH_ORDER: Order = {
   sellToken: USDT,
   surplusAmount: ZERO_BIG_NUMBER,
   surplusPercentage: ZERO_BIG_NUMBER,
+}
+
+export const RAW_TRADE: RawTrade = {
+  blockNumber: 8453440,
+  logIndex: 3,
+  orderUid:
+    '0x9754ac5510f5057c71e7da67c63edfb2258c608e26f102418e15fef6110c61595b0abe214ab7875562adee331deff0fe1912fe42608087c7',
+  buyAmount: '50000000000000000',
+  sellAmount: '455756789061273449606',
+  sellAmountBeforeFees: '454756979170023164166',
+  owner: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
+  buyToken: '0xc778417e063141139fce010982780140aa0cd5ab',
+  sellToken: '0xd9ba894e0097f8cc2bbc9d24d308b98e36dc6d02',
+  txHash: '0x2ebf2ba8c2a568af0b11d2498648d6fec01db11e81c6e4bc5dbba9237472dce9',
+}
+
+export const RICH_TRADE: Trade = {
+  ...RAW_TRADE,
+  orderId: RAW_TRADE.orderUid,
+  buyAmount: new BigNumber(RAW_TRADE.buyAmount),
+  sellAmount: new BigNumber(RAW_TRADE.sellAmount),
+  sellAmountBeforeFees: new BigNumber(RAW_TRADE.sellAmountBeforeFees),
+  buyToken: WETH,
+  buyTokenAddress: RAW_TRADE.buyToken,
+  sellToken: USDT,
+  sellTokenAddress: RAW_TRADE.sellToken,
 }


### PR DESCRIPTION
# Summary

Closes #375 

Display txHash for matched `fillOrKill` orders
![screenshot_2021-04-21_16-20-52](https://user-images.githubusercontent.com/43217/115633010-7deaf180-a2bd-11eb-9975-c26a523548ed.png)


- Added `getTrades` operator API
- Fetching trades for order details page

# Testing

## Explorer app
1. With an order that has been matched, open the explorer
- [ ] It should have the `transaction hash` field filled

2. With an order that's open OR expired
- [ ] It should have the `transaction hash` field set to `-`

## Storybook

Check the stories:
- Details table -> * fill or kill (assert tx hash field is present)
- Details table -> * partially fillable (assert tx hash field is NOT present)
- Order details -> Trades loading

![screenshot_2021-04-21_16-19-25](https://user-images.githubusercontent.com/43217/115632767-4da35300-a2bd-11eb-8f39-6ebeefc3deb7.png)
