### PR TITLE
291/header link issues

### DIFF
--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -43,13 +43,13 @@ export const Header: React.FC = () => {
     return null
   }
 
-  const network = networkId !== 1 ? getNetworkFromId(networkId) : null
+  const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : null
 
   return (
-    <GenericHeader>
+    <GenericHeader logoAlt="GP Explorer homepage" linkTo={`/${network || ''}`}>
       <Navigation>
         <Logo>GP Explorer</Logo>
-        {network && <NetworkLabel className={network.toLowerCase()}>{network}</NetworkLabel>}
+        {network && <NetworkLabel className={network}>{network}</NetworkLabel>}
         {/*      
         <li>
           <Link to="/">Batches</Link>

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -13,6 +13,7 @@ const Logo = styled.span`
   font-size: 1.8rem;
   line-height: 1;
   font-weight: ${({ theme }): string => theme.fontBlack};
+  white-space: nowrap;
 `
 
 const NetworkLabel = styled.span`
@@ -46,9 +47,8 @@ export const Header: React.FC = () => {
   const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : null
 
   return (
-    <GenericHeader logoAlt="GP Explorer homepage" linkTo={`/${network || ''}`}>
+    <GenericHeader logoAlt="GP Explorer homepage" linkTo={`/${network || ''}`} label={<Logo>GP Explorer</Logo>}>
       <Navigation>
-        <Logo>GP Explorer</Logo>
         {network && <NetworkLabel className={network}>{network}</NetworkLabel>}
         {/*      
         <li>

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -47,7 +47,7 @@ export const Header: React.FC = () => {
   const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : null
 
   return (
-    <GenericHeader logoAlt="GP Explorer homepage" linkTo={`/${network || ''}`} label={<Logo>GP Explorer</Logo>}>
+    <GenericHeader logoAlt="Gnosis Protocol" linkTo={`/${network || ''}`} label={<Logo>Gnosis Protocol</Logo>}>
       <Navigation>
         {network && <NetworkLabel className={network}>{network}</NetworkLabel>}
         {/*      

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
 
@@ -25,7 +25,13 @@ const HeaderStyled = styled.header`
   }
 `
 
-const Logo = styled(Link)`
+const HeaderLink = styled(Link)`
+  display: flex;
+  align-content: center;
+  justify-content: center;
+`
+
+const Logo = styled.span`
   width: 2.8rem;
   height: 2.8rem;
   transform: perspective(20rem) rotateY(0);
@@ -33,9 +39,6 @@ const Logo = styled(Link)`
   transition: transform 1s ease-in-out;
   padding: 0;
   margin: 0 1rem 0 0;
-  display: flex;
-  align-content: center;
-  justify-content: center;
 
   &:hover {
     animation-name: spin;
@@ -66,11 +69,15 @@ const Logo = styled(Link)`
   }
 `
 
-export const Header: React.FC = ({ children }) => (
+type Props = PropsWithChildren<{ linkTo?: string; logoAlt?: string }>
+
+export const Header: React.FC<Props> = ({ children, linkTo, logoAlt }) => (
   <HeaderStyled>
-    <Logo to="/" href="#">
-      <img src={LogoImage} alt="Trading interface homepage" />
-    </Logo>
-    {children}
+    <HeaderLink to={linkTo || '/'}>
+      <Logo>
+        <img src={LogoImage} alt={logoAlt || 'Trading interface homepage'} />
+      </Logo>
+      {children}
+    </HeaderLink>
   </HeaderStyled>
 )

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -32,6 +32,10 @@ const Logo = styled(Link)`
   align-content: center;
   justify-content: center;
 
+  &:hover {
+    text-decoration: none;
+  }
+
   > img {
     transform: perspective(20rem) rotateY(0);
     transform-style: preserve-3d;

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -25,20 +25,16 @@ const HeaderStyled = styled.header`
   }
 `
 
-const HeaderLink = styled(Link)`
-  display: flex;
-  align-content: center;
-  justify-content: center;
-`
-
-const Logo = styled.span`
-  width: 2.8rem;
+const Logo = styled(Link)`
   height: 2.8rem;
   transform: perspective(20rem) rotateY(0);
   transform-style: preserve-3d;
   transition: transform 1s ease-in-out;
   padding: 0;
   margin: 0 1rem 0 0;
+  display: flex;
+  align-content: center;
+  justify-content: center;
 
   &:hover {
     animation-name: spin;
@@ -57,6 +53,14 @@ const Logo = styled.span`
     margin: auto;
   }
 
+  > span {
+    margin: 0 0 0 1rem;
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    color: ${({ theme }): string => theme.textPrimary1};
+  }
+
   @keyframes spin {
     0% {
       transform: perspective(20rem) rotateY(0);
@@ -70,15 +74,18 @@ const Logo = styled.span`
   }
 `
 
-type Props = PropsWithChildren<{ linkTo?: string; logoAlt?: string }>
+type Props = PropsWithChildren<{
+  label?: React.ReactNode
+  linkTo?: string
+  logoAlt?: string
+}>
 
-export const Header: React.FC<Props> = ({ children, linkTo, logoAlt }) => (
+export const Header: React.FC<Props> = ({ children, linkTo, logoAlt, label }) => (
   <HeaderStyled>
-    <HeaderLink to={linkTo || '/'}>
-      <Logo>
-        <img src={LogoImage} alt={logoAlt || 'Trading interface homepage'} />
-      </Logo>
-      {children}
-    </HeaderLink>
+    <Logo to={linkTo || '/'}>
+      <img src={LogoImage} alt={logoAlt || 'Trading interface homepage'} />
+      {label && <span>{label}</span>}
+    </Logo>
+    {children}
   </HeaderStyled>
 )

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -45,6 +45,7 @@ const Logo = styled.span`
     animation-duration: 4s;
     animation-iteration-count: infinite;
     animation-delay: 0.3s;
+    text-decoration: none;
   }
 
   > img {

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -27,24 +27,23 @@ const HeaderStyled = styled.header`
 
 const Logo = styled(Link)`
   height: 2.8rem;
-  transform: perspective(20rem) rotateY(0);
-  transform-style: preserve-3d;
-  transition: transform 1s ease-in-out;
   padding: 0;
-  margin: 0 1rem 0 0;
   display: flex;
   align-content: center;
   justify-content: center;
 
-  &:hover {
-    animation-name: spin;
-    animation-duration: 4s;
-    animation-iteration-count: infinite;
-    animation-delay: 0.3s;
-    text-decoration: none;
-  }
-
   > img {
+    transform: perspective(20rem) rotateY(0);
+    transform-style: preserve-3d;
+    transition: transform 1s ease-in-out;
+
+    &:hover {
+      animation-name: spin;
+      animation-duration: 4s;
+      animation-iteration-count: infinite;
+      animation-delay: 0.3s;
+    }
+
     background: url(${LogoImage}) no-repeat center/contain;
     border: 0;
     object-fit: contain;

--- a/src/hooks/useSearchSubmit.ts
+++ b/src/hooks/useSearchSubmit.ts
@@ -7,11 +7,11 @@ export function useSearchSubmit(): (query: string) => void {
 
   return useCallback(
     (query: string) => {
-      const pathPrefix = path === '/' ? '' : path
+      const pathPrefix = path.endsWith('/') ? path : path + '/'
 
       // For now assumes /orders/ path. Needs logic to try all types for a valid response:
       // Orders, transactions, tokens, batches
-      query && query.length > 0 && history.push(`${pathPrefix}/orders/${query}`)
+      query && query.length > 0 && history.push(`${pathPrefix}orders/${query}`)
     },
     [history, path],
   )


### PR DESCRIPTION
# Edit 2021/04/26:

- Rename header to `Gnosis Protocol`
- Made only the logo spin

![screenshot_2021-04-26_17-02-26](https://user-images.githubusercontent.com/43217/116165633-211e7b00-a6b1-11eb-8263-a28a1866330a.png)


# Summary

Closes #291 

- Makes the whole header logo + label clickable (and spinnable)
- Link now keeps selected network

@biocom probably styling fixes needed :sweat_smile: 
Not sure about the whole logo spinning thing, maybe we want to spin only the image =P

# Testing

1. Open app, search order ids from different network:
    - mainnet: 0x3da38a8e6d9725b6d1f1d1619004c5d2cd4cd1ff5db985ee9965abd9bfe22d097b2e78d4dfaaba045a167a70da285e30e8fca196606dbb23
    - rinkeby: 0x0f72377ed644b8bed0e1b8540904dc5b2308c17db3c0723025a60c1c1dde551a5b0abe214ab7875562adee331deff0fe1912fe42607df52d
    - xdai: 0xc64dae2bde7f4538030e056aace4312f8208e7144fd44aa3d018e7c4a574294804a66cbba0485d7b21af836f52b711401300fddb6066027c
2. For every order id:
    1. Search on home using the given id
    - [ ] Should redirect the appropriated network and load the order
    2. Click on the logo
    - [ ] Should load home in the same network

- [ ] Verify the whole logo (image and label) are clickable