### PR TITLE
Release v2.1

### DIFF
--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-
-set -ev
+set -e
 
 # Only:
 # - Tagged commits
 # - Security env variables are available.
+echo "🚀 Preparing version $VERSION_TAG for deployment"
+
 if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
 then
   curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
@@ -13,5 +14,6 @@ then
      -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
       $PROD_DEPLOYMENT_HOOK_URL
 else
-  echo "[ERROR] Deployment to production could not be prepared"
+  echo  >&2 "[ERROR] Deployment to production could not be prepared. Some Environment variables are missing"
+  exit 100
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
     types: [opened, synchronize]
   push:
     branches: [master, develop]
-  release:
-    types: [published]
+    tags: [v*]
 
 env:
   APP_ID: 1
@@ -153,10 +152,13 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [build, storybook]
+    # needs: [build, storybook]
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Download website
         uses: actions/download-artifact@v2
 
@@ -194,16 +196,24 @@ jobs:
 
       - name: 'Deploy to S3: Staging'
         if: github.ref == 'refs/heads/master'
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
       - name: 'Production deployment: Upload release build files to be deployed'
         if: startsWith(github.ref, 'refs/tags/v')
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        run: bash ./.github/scripts/prepare_production_deployment.sh
+        run: bash .github/scripts/prepare_production_deployment.sh
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          VERSION_TAG: ${{ github.event.release.tag_name }}
+          VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
+
+      
+          
+          

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.0.0-rc.2",
+  "version": "2.1.0-rc.0",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.0",
+  "version": "2.1.0-rc.24",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/src/api/operator/index.ts
+++ b/src/api/operator/index.ts
@@ -12,6 +12,7 @@ export const {
   // functions that have a mock
   getOrder,
   getOrders,
+  getTrades,
   // functions that do not have a mock
   getOrderLink = realApi.getOrderLink,
   postSignedOrder = realApi.postSignedOrder,

--- a/src/api/operator/operatorMock.ts
+++ b/src/api/operator/operatorMock.ts
@@ -1,6 +1,6 @@
-import { GetOrderParams, GetOrdersParams, RawOrder } from './types'
+import { GetOrderParams, GetOrdersParams, GetTradesParams, RawOrder, RawTrade } from './types'
 
-import { RAW_ORDER } from '../../../test/data'
+import { RAW_ORDER, RAW_TRADE } from '../../../test/data'
 
 export async function getOrder(params: GetOrderParams): Promise<RawOrder> {
   const { orderId } = params
@@ -19,4 +19,14 @@ export async function getOrders(params: GetOrdersParams): Promise<RawOrder[]> {
   order.owner = owner || order.owner
 
   return [order]
+}
+
+export async function getTrades(params: GetTradesParams): Promise<RawTrade[]> {
+  const { owner, orderId } = params
+
+  const trade = { ...RAW_TRADE }
+  trade.owner = owner || trade.owner
+  trade.orderUid = orderId || trade.orderUid
+
+  return [trade]
 }

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -73,6 +73,36 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   surplusPercentage: BigNumber
 }
 
+/**
+ * Raw API trade response type
+ */
+export type RawTrade = {
+  blockNumber: number
+  logIndex: number
+  owner: string
+  txHash: string
+  orderUid: string
+  buyAmount: string
+  sellAmount: string
+  sellAmountBeforeFees: string
+  buyToken: string
+  sellToken: string
+}
+
+/**
+ * Enriched Trade type
+ */
+export type Trade = Pick<RawTrade, 'blockNumber' | 'logIndex' | 'owner' | 'txHash'> & {
+  orderId: string // rename the field
+  buyAmount: BigNumber
+  sellAmount: BigNumber
+  sellAmountBeforeFees: BigNumber
+  buyToken?: TokenErc20 | null
+  buyTokenAddress: string
+  sellToken?: TokenErc20 | null
+  sellTokenAddress: string
+}
+
 type WithNetworkId = { networkId: Network }
 
 export type GetOrderParams = WithNetworkId & {
@@ -83,4 +113,9 @@ export type GetOrdersParams = WithNetworkId & {
   owner?: string
   sellToken?: string
   buyToken?: string
+}
+
+export type GetTradesParams = WithNetworkId & {
+  owner?: string
+  orderId?: string
 }

--- a/src/apps/explorer/components/OrderWidget/index.tsx
+++ b/src/apps/explorer/components/OrderWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { useOrderAndErc20s } from 'hooks/useOperatorOrder'
+import { useOrderTrades } from 'hooks/useOperatorTrades'
 import { useSanitizeOrderIdAndUpdateUrl } from 'hooks/useSanitizeOrderIdAndUpdateUrl'
 
 import { ORDER_QUERY_INTERVAL } from 'apps/explorer/const'
@@ -12,11 +13,27 @@ export const OrderWidget: React.FC = () => {
   const networkId = useNetworkId()
   const orderId = useSanitizeOrderIdAndUpdateUrl()
 
-  const { order, isLoading, errors, errorOrderPresentInNetworkId } = useOrderAndErc20s(orderId, ORDER_QUERY_INTERVAL)
+  const { order, isLoading: isOrderLoading, errors, errorOrderPresentInNetworkId } = useOrderAndErc20s(
+    orderId,
+    ORDER_QUERY_INTERVAL,
+  )
+  const { trades, error, isLoading: areTradesLoading } = useOrderTrades(order)
+
+  if (error) {
+    errors['trades'] = error
+  }
 
   if (errorOrderPresentInNetworkId && networkId != errorOrderPresentInNetworkId) {
     return <RedirectToNetwork networkId={errorOrderPresentInNetworkId} />
   }
 
-  return <OrderDetails order={order} isLoading={isLoading} errors={errors} />
+  return (
+    <OrderDetails
+      order={order}
+      trades={trades}
+      isOrderLoading={isOrderLoading}
+      areTradesLoading={areTradesLoading}
+      errors={errors}
+    />
+  )
 }

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -13,6 +13,7 @@ const Logo = styled.span`
   font-size: 1.8rem;
   line-height: 1;
   font-weight: ${({ theme }): string => theme.fontBlack};
+  white-space: nowrap;
 `
 
 const NetworkLabel = styled.span`
@@ -43,13 +44,12 @@ export const Header: React.FC = () => {
     return null
   }
 
-  const network = networkId !== 1 ? getNetworkFromId(networkId) : null
+  const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : null
 
   return (
-    <GenericHeader>
+    <GenericHeader logoAlt="Gnosis Protocol" linkTo={`/${network || ''}`} label={<Logo>Gnosis Protocol</Logo>}>
       <Navigation>
-        <Logo>GP Explorer</Logo>
-        {network && <NetworkLabel className={network.toLowerCase()}>{network}</NetworkLabel>}
+        {network && <NetworkLabel className={network}>{network}</NetworkLabel>}
         {/*      
         <li>
           <Link to="/">Batches</Link>

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
 
@@ -26,31 +26,42 @@ const HeaderStyled = styled.header`
 `
 
 const Logo = styled(Link)`
-  width: 2.8rem;
   height: 2.8rem;
-  transform: perspective(20rem) rotateY(0);
-  transform-style: preserve-3d;
-  transition: transform 1s ease-in-out;
   padding: 0;
-  margin: 0 1rem 0 0;
   display: flex;
   align-content: center;
   justify-content: center;
 
   &:hover {
-    animation-name: spin;
-    animation-duration: 4s;
-    animation-iteration-count: infinite;
-    animation-delay: 0.3s;
+    text-decoration: none;
   }
 
   > img {
+    transform: perspective(20rem) rotateY(0);
+    transform-style: preserve-3d;
+    transition: transform 1s ease-in-out;
+
+    &:hover {
+      animation-name: spin;
+      animation-duration: 4s;
+      animation-iteration-count: infinite;
+      animation-delay: 0.3s;
+    }
+
     background: url(${LogoImage}) no-repeat center/contain;
     border: 0;
     object-fit: contain;
     width: inherit;
     height: inherit;
     margin: auto;
+  }
+
+  > span {
+    margin: 0 0 0 1rem;
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    color: ${({ theme }): string => theme.textPrimary1};
   }
 
   @keyframes spin {
@@ -66,10 +77,17 @@ const Logo = styled(Link)`
   }
 `
 
-export const Header: React.FC = ({ children }) => (
+type Props = PropsWithChildren<{
+  label?: React.ReactNode
+  linkTo?: string
+  logoAlt?: string
+}>
+
+export const Header: React.FC<Props> = ({ children, linkTo, logoAlt, label }) => (
   <HeaderStyled>
-    <Logo to="/" href="#">
-      <img src={LogoImage} alt="Trading interface homepage" />
+    <Logo to={linkTo || '/'}>
+      <img src={LogoImage} alt={logoAlt || 'Trading interface homepage'} />
+      {label && <span>{label}</span>}
     </Logo>
     {children}
   </HeaderStyled>

--- a/src/components/orders/DetailsTable/DetailsTable.stories.tsx
+++ b/src/components/orders/DetailsTable/DetailsTable.stories.tsx
@@ -30,7 +30,7 @@ const order = {
   txHash: '0x489d8fd1efd43394c7c2b26216f36f1ab49b8d67623047e0fcb60efa2a2c420b',
 }
 
-const defaultProps: Props = { order }
+const defaultProps: Props = { order, areTradesLoading: false }
 
 export const DefaultFillOrKill = Template.bind({})
 DefaultFillOrKill.args = { ...defaultProps }

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -271,7 +271,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
           )}
           <tr>
             <td>
-              <HelpTooltip tooltip={tooltip.fees} /> Gas Fees paid
+              <HelpTooltip tooltip={tooltip.fees} /> Fees
             </td>
             <td>
               <GasFeeDisplay order={order} />

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -10,6 +10,7 @@ import { BlockExplorerLink } from 'apps/explorer/components/common/BlockExplorer
 import { HelpTooltip } from 'components/Tooltip'
 
 import { SimpleTable } from 'components/common/SimpleTable'
+import Spinner from 'components/common/Spinner'
 
 import { AmountsDisplay } from 'components/orders/AmountsDisplay'
 import { DateDisplay } from 'components/orders/DateDisplay'
@@ -83,16 +84,17 @@ const tooltip = {
 
 export type Props = {
   order: Order
+  areTradesLoading: boolean
 }
 
 export function DetailsTable(props: Props): JSX.Element | null {
-  const { order } = props
+  const { order, areTradesLoading } = props
   const {
     uid,
     shortId,
     owner,
     receiver,
-    // txHash,
+    txHash,
     kind,
     partiallyFillable,
     creationDate,
@@ -156,14 +158,15 @@ export function DetailsTable(props: Props): JSX.Element | null {
               />
             </td>
           </tr>
-          {/* TODO: re-enable once this data is available on the API */}
-          {/* {!partiallyFillable && (
+          {!partiallyFillable && (
             <tr>
               <td>
                 <HelpTooltip tooltip={tooltip.hash} /> Transaction hash
               </td>
               <td>
-                {txHash ? (
+                {areTradesLoading ? (
+                  <Spinner />
+                ) : txHash ? (
                   <RowWithCopyButton
                     textToCopy={txHash}
                     onCopy={(): void => onCopy('settlementTx')}
@@ -174,7 +177,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
                 )}
               </td>
             </tr>
-          )} */}
+          )}
           <tr>
             <td>
               <HelpTooltip tooltip={tooltip.status} /> Status

--- a/src/components/orders/OrderDetails/OrderDetails.stories.tsx
+++ b/src/components/orders/OrderDetails/OrderDetails.stories.tsx
@@ -17,13 +17,16 @@ export default {
 
 const Template: Story<Props> = (args) => <OrderDetails {...args} />
 
-const defaultProps: Props = { order: null, isLoading: false, errors: {} }
+const defaultProps: Props = { order: null, isOrderLoading: false, areTradesLoading: false, trades: [], errors: {} }
 
 export const OrderFound = Template.bind({})
 OrderFound.args = { ...defaultProps, order: RICH_ORDER }
 
 export const OrderLoading = Template.bind({})
-OrderLoading.args = { ...defaultProps, isLoading: true }
+OrderLoading.args = { ...defaultProps, isOrderLoading: true }
+
+export const TradesLoading = Template.bind({})
+TradesLoading.args = { ...defaultProps, order: RICH_ORDER, areTradesLoading: true }
 
 export const OrderNotFound = Template.bind({})
 OrderNotFound.args = { ...defaultProps }

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -5,7 +5,7 @@ import { media } from 'theme/styles/media'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import { Order } from 'api/operator'
+import { Order, Trade } from 'api/operator'
 
 import { DetailsTable } from 'components/orders/DetailsTable'
 import { RowWithCopyButton } from 'components/orders/RowWithCopyButton'
@@ -43,14 +43,20 @@ const TitleUid = styled(RowWithCopyButton)`
 
 export type Props = {
   order: Order | null
-  isLoading: boolean
+  trades: Trade[]
+  isOrderLoading: boolean
+  areTradesLoading: boolean
   errors: Record<string, string>
 }
 
 export const OrderDetails: React.FC<Props> = (props) => {
-  const { order, isLoading, errors } = props
+  const { order, isOrderLoading, areTradesLoading, errors, trades } = props
   const areTokensLoaded = order?.buyToken && order?.sellToken
-  const isLoadingForTheFirstTime = isLoading && !areTokensLoaded
+  const isLoadingForTheFirstTime = isOrderLoading && !areTokensLoaded
+
+  // Only set txHash for fillOrKill orders, if any
+  // Partially fillable order will have a tab only for the trades
+  const txHash = order && !order.partiallyFillable && trades && trades.length === 1 ? trades[0].txHash : undefined
 
   return (
     <Wrapper>
@@ -59,10 +65,10 @@ export const OrderDetails: React.FC<Props> = (props) => {
         {order && <TitleUid textToCopy={order.uid} contentsToDisplay={order.shortId} />}
       </h1>
       {/* TODO: add tabs (overview/fills) */}
-      {order && areTokensLoaded && <DetailsTable order={order} />}
+      {order && areTokensLoaded && <DetailsTable order={{ ...order, txHash }} areTradesLoading={areTradesLoading} />}
       {/* TODO: add fills tab for partiallyFillable orders */}
-      {!order && !isLoading && <p>Order not found</p>}
-      {!isLoading && order && !areTokensLoaded && <p>Not able to load tokens</p>}
+      {!order && !isOrderLoading && <p>Order not found</p>}
+      {!isOrderLoading && order && !areTokensLoaded && <p>Not able to load tokens</p>}
       {/* TODO: do a better error display. Toast notification maybe? */}
       {Object.keys(errors).map((key) => (
         <p key={key}>{errors[key]}</p>

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -1,0 +1,104 @@
+import { getTrades, Order, Trade } from 'api/operator'
+import { useCallback, useEffect, useState } from 'react'
+import { useNetworkId } from 'state/network'
+import { Network } from 'types'
+import { transformTrade } from 'utils'
+
+type Params = {
+  owner?: string
+  orderId?: string
+}
+
+type Result = {
+  trades: Trade[]
+  error: string
+  isLoading: boolean
+}
+
+/**
+ * Fetches trades for given filters
+ * When no filter is given, fetches all trades for current network
+ */
+export function useTrades(params: Params): Result {
+  const { owner, orderId } = params
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [trades, setTrades] = useState<Trade[]>([])
+
+  // Here we assume that we are already in the right network
+  // contrary to useOrder hook, where it searches all networks for a given orderId
+  const networkId = useNetworkId()
+
+  const fetchTrades = useCallback(async (networkId: Network, owner?: string, orderId?: string): Promise<void> => {
+    setIsLoading(true)
+    setError('')
+
+    try {
+      const trades = await getTrades({ networkId, owner, orderId })
+
+      // TODO: fetch buy/sellToken objects
+      setTrades(trades.map((trade) => transformTrade(trade)))
+    } catch (e) {
+      const msg = `Failed to fetch trades`
+      console.error(msg, e)
+      setError(msg)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!networkId) {
+      return
+    }
+
+    fetchTrades(networkId, owner, orderId)
+  }, [fetchTrades, networkId, orderId, owner])
+
+  return { trades, error, isLoading }
+}
+
+/**
+ * Fetches trades for given order
+ */
+export function useOrderTrades(order: Order | null): Result {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [trades, setTrades] = useState<Trade[]>([])
+
+  // Here we assume that we are already in the right network
+  // contrary to useOrder hook, where it searches all networks for a given orderId
+  const networkId = useNetworkId()
+
+  const fetchTrades = useCallback(async (networkId: Network, order: Order): Promise<void> => {
+    setIsLoading(true)
+    setError('')
+
+    const { uid: orderId, buyToken, sellToken } = order
+
+    try {
+      const trades = await getTrades({ networkId, orderId })
+
+      setTrades(trades.map((trade) => ({ ...transformTrade(trade), buyToken, sellToken })))
+    } catch (e) {
+      const msg = `Failed to fetch trades`
+      console.error(msg, e)
+      setError(msg)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!networkId || !order?.uid) {
+      return
+    }
+
+    fetchTrades(networkId, order)
+    // Depending on order UID to avoid re-fetching when obj changes but ID remains the same
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchTrades, networkId, order?.uid])
+
+  return { trades, error, isLoading }
+}

--- a/src/hooks/useSearchSubmit.ts
+++ b/src/hooks/useSearchSubmit.ts
@@ -7,11 +7,11 @@ export function useSearchSubmit(): (query: string) => void {
 
   return useCallback(
     (query: string) => {
-      const pathPrefix = path === '/' ? '' : path
+      const pathPrefix = path.endsWith('/') ? path : path + '/'
 
       // For now assumes /orders/ path. Needs logic to try all types for a valid response:
       // Orders, transactions, tokens, batches
-      query && query.length > 0 && history.push(`${pathPrefix}/orders/${query}`)
+      query && query.length > 0 && history.push(`${pathPrefix}orders/${query}`)
     },
     [history, path],
   )

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -5,7 +5,7 @@ import { calculatePrice, invertPrice } from '@gnosis.pm/dex-js'
 
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
-import { Order, OrderStatus, RawOrder } from 'api/operator/types'
+import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount
@@ -276,5 +276,22 @@ export function transformOrder(rawOrder: RawOrder): Order {
     filledPercentage,
     surplusAmount,
     surplusPercentage,
+  }
+}
+
+/**
+ * Transforms a RawTrade into a Trade object
+ */
+export function transformTrade(rawTrade: RawTrade): Trade {
+  const { orderUid, buyAmount, sellAmount, sellAmountBeforeFees, buyToken, sellToken, ...rest } = rawTrade
+
+  return {
+    ...rest,
+    orderId: orderUid,
+    buyAmount: new BigNumber(buyAmount),
+    sellAmount: new BigNumber(sellAmount),
+    sellAmountBeforeFees: new BigNumber(sellAmountBeforeFees),
+    buyTokenAddress: buyToken,
+    sellTokenAddress: sellToken,
   }
 }

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 
-import { Order, RawOrder } from 'api/operator'
+import { Order, RawOrder, RawTrade, Trade } from 'api/operator'
 
 import { ZERO_BIG_NUMBER } from 'const'
 
@@ -51,4 +51,30 @@ export const RICH_ORDER: Order = {
   sellToken: USDT,
   surplusAmount: ZERO_BIG_NUMBER,
   surplusPercentage: ZERO_BIG_NUMBER,
+}
+
+export const RAW_TRADE: RawTrade = {
+  blockNumber: 8453440,
+  logIndex: 3,
+  orderUid:
+    '0x9754ac5510f5057c71e7da67c63edfb2258c608e26f102418e15fef6110c61595b0abe214ab7875562adee331deff0fe1912fe42608087c7',
+  buyAmount: '50000000000000000',
+  sellAmount: '455756789061273449606',
+  sellAmountBeforeFees: '454756979170023164166',
+  owner: '0x5b0abe214ab7875562adee331deff0fe1912fe42',
+  buyToken: '0xc778417e063141139fce010982780140aa0cd5ab',
+  sellToken: '0xd9ba894e0097f8cc2bbc9d24d308b98e36dc6d02',
+  txHash: '0x2ebf2ba8c2a568af0b11d2498648d6fec01db11e81c6e4bc5dbba9237472dce9',
+}
+
+export const RICH_TRADE: Trade = {
+  ...RAW_TRADE,
+  orderId: RAW_TRADE.orderUid,
+  buyAmount: new BigNumber(RAW_TRADE.buyAmount),
+  sellAmount: new BigNumber(RAW_TRADE.sellAmount),
+  sellAmountBeforeFees: new BigNumber(RAW_TRADE.sellAmountBeforeFees),
+  buyToken: WETH,
+  buyTokenAddress: RAW_TRADE.buyToken,
+  sellToken: USDT,
+  sellTokenAddress: RAW_TRADE.sellToken,
 }


### PR DESCRIPTION
# Summary

Release `v2.1`

## Do not Squash 🥒, just normal merge

```
# To get commits used in the description (useful for next releases) 
git log v2.0.0-rc.2..HEAD --oneline --decorate=0
```

## Changes/ QA notes
* Add transaction hash (link to etherscan): https://github.com/gnosis/gp-ui/pull/388
* Point to the right environment - API: https://github.com/gnosis/gp-ui/pull/385 (QA, we will test this one)
* Show a spinner for open state: https://github.com/gnosis/gp-ui/pull/386
* Update contract number in footer: https://github.com/gnosis/gp-ui/pull/381 
* Add native token support: https://github.com/gnosis/gp-ui/pull/383
* Add receiver field: https://github.com/gnosis/gp-ui/pull/373

## Changelog
ebc1ef1c 375/transaction hash (#388)
43abec78 Merge pull request #387 from gnosis/release/v2.0.0
588e32f7 374/prod endpoints for operator api (#385)
487d4993 Show spinner for open orders (#386)
ee51c769 376/update contract version (#381)
201eb7b6 [Security] Bump ssri from 6.0.1 to 6.0.2
dfb80806 Native token support (#383)
8ca6248b Setup CI and scripts to prepare production deployments (#348)
c22d2b8c 372/add receiver field (#373)
860547d7 Bump styled-components from 5.2.1 to 5.2.3
d0032478 Bump @popperjs/core from 2.9.1 to 2.9.2 (#367)
9305bb1a Bump @types/react-dom from 16.9.11 to 16.9.12 (#369)
a417686f Bump @types/react from 16.14.4 to 16.14.5 (#366)
6732edc8 Bump @storybook/addon-links from 6.1.19 to 6.2.7 (#368)
24782d8f Bump @babel/preset-env from 7.13.5 to 7.13.15 (#370)
18995a60 Bump typescript from 4.2.3 to 4.2.4 (#371)
9c8ca8f8 Bump @apollo/client from 3.3.11 to 3.3.14 (#365)
1d93ad17 Bump @typescript-eslint/eslint-plugin from 4.15.2 to 4.21.0 (#364)
0b575fc0 Bump ts-loader from 8.0.18 to 8.1.0 (#363)
0dbb66d4 Bump yaml from 1.10.0 to 1.10.2 (#356)
f6ae5b53 Bump eslint-plugin-react from 7.22.0 to 7.23.1
6c6321c5 Bump @babel/core from 7.13.10 to 7.13.14 (#355)
0c9701fa Bump @fortawesome/fontawesome-svg-core from 1.2.34 to 1.2.35 (#354)
02c574cf Bump eslint-plugin-jest from 24.3.1 to 24.3.4 (#353)
c51f2025 Bump @types/react-router from 5.1.12 to 5.1.13 (#351)
95a3a59a Bump @truffle/hdwallet-provider from 1.2.2 to 1.2.6 (#352)
25b449ca Bump @babel/register from 7.13.8 to 7.13.14 (#358)
ad22b741 Bump inter-ui from 3.15.0 to 3.18.0 (#359)
e5243f18 Use PR number from github context (#350)
417be156 330/surplus buy orders (#349)
c131b102 Update issue templates
5d6898db Bump typescript from 4.1.5 to 4.2.3 (#342)
3827a1b6 Bump @babel/register from 7.13.0 to 7.13.8 (#345)
8da09d52 Bump eslint from 7.22.0 to 7.23.0 (#338)
16367fa6 Bump date-fns from 2.17.0 to 2.19.0 (#343)
cd35220e Bump playwright from 1.9.2 to 1.10.0 (#341)
0953bc67 Bump react-device-detect from 1.15.0 to 1.17.0 (#344)
748b44c6 Bump @babel/preset-react from 7.12.13 to 7.13.13 (#340)
77027b70 Bump @types/jest from 26.0.20 to 26.0.22
273e5deb Bump @types/styled-components from 5.1.7 to 5.1.9
e867c5a2 Bump ts-jest from 26.5.2 to 26.5.4 (#336)
4d9e9b60 Pr323/comments (#327)
534de13c Invert symbols for base/quote price (#329)
748ba6e6 Lowercase order id when searching (#323)
715f15c9 Merge tag 'v2.0.0-rc.2' into develop
1a87917e Bump @fortawesome/free-solid-svg-icons from 5.15.2 to 5.15.3 (#320)
60ea1ff6 Bump @fortawesome/free-regular-svg-icons from 5.15.2 to 5.15.3 (#319)
c7b6684e Bump @babel/core from 7.13.8 to 7.13.10 (#318)
b51133cc Bump eslint from 7.21.0 to 7.22.0
dddbe0f3 Bump @popperjs/core from 2.6.0 to 2.9.1
dca10762 Bump @amcharts/amcharts4 from 4.10.15 to 4.10.17 (#321)
aeda8fbc Bump stylelint from 13.11.0 to 13.12.0
c0da4020 Bump @storybook/addon-knobs from 6.1.15 to 6.1.21 (#293)
0f114ac9 [Security] Bump is-svg from 4.2.1 to 4.3.1 (#317)
d87d908e Bump playwright from 1.9.1 to 1.9.2 (#300)
edd6d491 Bump ts-loader from 8.0.17 to 8.0.18 (#298)
6063752c Bump polished from 4.1.0 to 4.1.1 (#299)
99f6f756 Bump eslint-plugin-jest from 24.1.8 to 24.3.1 (#297)
eaf8d876 Bump @babel/plugin-transform-runtime from 7.13.6 to 7.13.10 (#302)
