### PR TITLE
Deploy tags automatically

### DIFF
--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -16,4 +16,5 @@ then
   #     $PROD_DEPLOYMENT_HOOK_URL
 else
   echo  >&2 "[ERROR] Deployment to production could not be prepared. Some Environment variables are missing"
+  exit 100
 fi

--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -31,7 +31,8 @@ fi
 
 if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
 then
-  echo "Calling hook" 
+  echo "Calling hook"
+  exit $?
   # curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
   #    -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
   #    -F ref=master \

--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -8,12 +8,11 @@ echo "🚀 Preparing deploy for version $VERSION_TAG. Calling hook Url: $PROD_DE
 
 if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
 then
-  echo "Calling hook"
-  # curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
-  #    -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
-  #    -F ref=master \
-  #    -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
-  #     $PROD_DEPLOYMENT_HOOK_URL
+  curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
+     -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
+     -F ref=master \
+     -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
+      $PROD_DEPLOYMENT_HOOK_URL
 else
   echo  >&2 "[ERROR] Deployment to production could not be prepared. Some Environment variables are missing"
   exit 100

--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -5,13 +5,38 @@ set -ev
 # Only:
 # - Tagged commits
 # - Security env variables are available.
+echo "🚀 Preparing deploy for version $VERSION_TAG. Calling hook Url: $PROD_DEPLOYMENT_HOOK_URL"
+
+if [ -n "$VERSION_TAG" ]
+then
+  echo "VERSION_TAG is set" 
+else
+  echo "VERSION_TAG is not set"
+fi
+
+if [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ]
+then
+  echo "PROD_DEPLOYMENT_HOOK_TOKEN is set" 
+else
+  echo "PROD_DEPLOYMENT_HOOK_TOKEN is not set"
+fi
+
+if [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
+then
+  echo "PROD_DEPLOYMENT_HOOK_URL is set" 
+else
+  echo "PROD_DEPLOYMENT_HOOK_URL is not set"
+fi
+
+
 if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
 then
-  curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
-     -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
-     -F ref=master \
-     -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
-      $PROD_DEPLOYMENT_HOOK_URL
+  echo "Calling hook" 
+  # curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
+  #    -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
+  #    -F ref=master \
+  #    -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
+  #     $PROD_DEPLOYMENT_HOOK_URL
 else
   echo "[ERROR] Deployment to production could not be prepared"
 fi

--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -ev
+set -e
 
 # Only:
 # - Tagged commits
@@ -16,5 +15,5 @@ then
   #    -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
   #     $PROD_DEPLOYMENT_HOOK_URL
 else
-  echo  >&2 "Deployment to production could not be prepared. Some Environment variables are missing"
+  echo  >&2 "[ERROR] Deployment to production could not be prepared. Some Environment variables are missing"
 fi

--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -7,37 +7,14 @@ set -ev
 # - Security env variables are available.
 echo "🚀 Preparing deploy for version $VERSION_TAG. Calling hook Url: $PROD_DEPLOYMENT_HOOK_URL"
 
-if [ -n "$VERSION_TAG" ]
-then
-  echo "VERSION_TAG is set" 
-else
-  echo "VERSION_TAG is not set"
-fi
-
-if [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ]
-then
-  echo "PROD_DEPLOYMENT_HOOK_TOKEN is set" 
-else
-  echo "PROD_DEPLOYMENT_HOOK_TOKEN is not set"
-fi
-
-if [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
-then
-  echo "PROD_DEPLOYMENT_HOOK_URL is set" 
-else
-  echo "PROD_DEPLOYMENT_HOOK_URL is not set"
-fi
-
-
 if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
 then
   echo "Calling hook"
-  exit $?
   # curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
   #    -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
   #    -F ref=master \
   #    -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
   #     $PROD_DEPLOYMENT_HOOK_URL
 else
-  echo "[ERROR] Deployment to production could not be prepared"
+  echo  >&2 "Deployment to production could not be prepared. Some Environment variables are missing"
 fi

--- a/.github/scripts/prepare_production_deployment.sh
+++ b/.github/scripts/prepare_production_deployment.sh
@@ -4,7 +4,7 @@ set -e
 # Only:
 # - Tagged commits
 # - Security env variables are available.
-echo "🚀 Preparing deploy for version $VERSION_TAG. Calling hook Url: $PROD_DEPLOYMENT_HOOK_URL"
+echo "🚀 Preparing version $VERSION_TAG for deployment"
 
 if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
 then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,140 +15,140 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  # setup:
-  #   name: Setup
-  #   runs-on: ubuntu-latest
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Set output of cache
-  #       id: yarn-cache
-  #       run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Set output of cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-  #     - name: Cache yarn cache
-  #       uses: actions/cache@v2
-  #       id: cache-yarn-cache
-  #       with:
-  #         path: ${{ steps.yarn-cache.outputs.dir }}
-  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-yarn-
+      - name: Cache yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-  # test:
-  #   name: Test
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  test:
+    name: Test
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Coverage
-  #       run: yarn test:coverage
+      - name: Coverage
+        run: yarn test:coverage
 
-  #     - name: Coveralls
-  #       uses: coverallsapp/github-action@v1.1.2
-  #       with:
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coveralls
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # build:
-  #   name: Build apps
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  build:
+    name: Build apps
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Build Web Apps
-  #       run: yarn build
-  #       env:
-  #         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+      - name: Build Web Apps
+        run: yarn build
+        env:
+          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
-  #     - name: Upload websites artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: website
-  #         path: dist
+      - name: Upload websites artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: website
+          path: dist
 
-  # storybook:
-  #   name: Build storybook
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  storybook:
+    name: Build storybook
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Build Storybook
-  #       run: yarn build-storybook -o dist-storybook;
+      - name: Build Storybook
+        run: yarn build-storybook -o dist-storybook;
 
-  #     - name: Upload storybook artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: storybook
-  #         path: dist-storybook
+      - name: Upload storybook artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: storybook
+          path: dist-storybook
 
   deploy:
     name: Deploy
@@ -159,52 +159,52 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # - name: Download website
-      #   uses: actions/download-artifact@v2
+      - name: Download website
+        uses: actions/download-artifact@v2
 
-      # - name: Move storybook inside dist
-      #   run: mv storybook website/storybook
+      - name: Move storybook inside dist
+        run: mv storybook website/storybook
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # - name: 'Deploy to S3: PRaul'
-      #   if: success() && env.PR_NUMBER
-      #   run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
+      - name: 'Deploy to S3: PRaul'
+        if: success() && env.PR_NUMBER
+        run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
 
-      # - name: 'PRaul: Comment PR with app URLs'
-      #   uses: mshick/add-pr-comment@v1
-      #   with:
-      #     message: |
-      #       * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
-      #       * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
-      #       * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
-      #       * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
-      #     repo-token-user-login: 'github-actions[bot]'
-      #   if: success() && env.PR_NUMBER
-      #   env:
-      #     REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
+      - name: 'PRaul: Comment PR with app URLs'
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
+            * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
+            * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
+            * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'
+        if: success() && env.PR_NUMBER
+        env:
+          REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
 
-      # - name: 'Deploy to S3: Develop'
-      #   if: github.ref == 'refs/heads/develop'
-      #   run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
+      - name: 'Deploy to S3: Develop'
+        if: github.ref == 'refs/heads/develop'
+        run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
 
-      # - name: 'Deploy to S3: Staging'
-      #   if: github.ref == 'refs/heads/master'
-      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
+      - name: 'Deploy to S3: Staging'
+        if: github.ref == 'refs/heads/master'
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
 
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
-      # - name: 'Production deployment: Upload release build files to be deployed'
-      #   if: startsWith(github.ref, 'refs/tags/v')
-      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete
+      - name: 'Production deployment: Upload release build files to be deployed'
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')
@@ -212,7 +212,7 @@ jobs:
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          # VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
+          VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
 
       
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,202 +15,193 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  # setup:
-  #   name: Setup
-  #   runs-on: ubuntu-latest
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Set output of cache
-  #       id: yarn-cache
-  #       run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Set output of cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-  #     - name: Cache yarn cache
-  #       uses: actions/cache@v2
-  #       id: cache-yarn-cache
-  #       with:
-  #         path: ${{ steps.yarn-cache.outputs.dir }}
-  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-yarn-
+      - name: Cache yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-  # test:
-  #   name: Test
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  test:
+    name: Test
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Coverage
-  #       run: yarn test:coverage
+      - name: Coverage
+        run: yarn test:coverage
 
-  #     - name: Coveralls
-  #       uses: coverallsapp/github-action@v1.1.2
-  #       with:
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coveralls
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # build:
-  #   name: Build apps
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  build:
+    name: Build apps
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Build Web Apps
-  #       run: yarn build
-  #       env:
-  #         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+      - name: Build Web Apps
+        run: yarn build
+        env:
+          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
-  #     - name: Upload websites artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: website
-  #         path: dist
+      - name: Upload websites artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: website
+          path: dist
 
-  # storybook:
-  #   name: Build storybook
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  storybook:
+    name: Build storybook
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Build Storybook
-  #       run: yarn build-storybook -o dist-storybook;
+      - name: Build Storybook
+        run: yarn build-storybook -o dist-storybook;
 
-  #     - name: Upload storybook artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: storybook
-  #         path: dist-storybook
+      - name: Upload storybook artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: storybook
+          path: dist-storybook
 
   deploy:
     name: Deploy
-    # needs: [build, storybook]
+    needs: [build, storybook]
     runs-on: ubuntu-latest
 
     steps:      
-  #     - name: Download website
-  #       uses: actions/download-artifact@v2
+      - name: Download website
+        uses: actions/download-artifact@v2
 
-  #     - name: Move storybook inside dist
-  #       run: mv storybook website/storybook
+      - name: Move storybook inside dist
+        run: mv storybook website/storybook
 
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-  #     - name: 'Deploy to S3: PRaul'
-  #       if: success() && env.PR_NUMBER
-  #       run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
+      - name: 'Deploy to S3: PRaul'
+        if: success() && env.PR_NUMBER
+        run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
 
-  #     - name: 'PRaul: Comment PR with app URLs'
-  #       uses: mshick/add-pr-comment@v1
-  #       with:
-  #         message: |
-  #           * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
-  #           * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
-  #           * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
-  #           * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #         repo-token-user-login: 'github-actions[bot]'
-  #       if: success() && env.PR_NUMBER
-  #       env:
-  #         REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
+      - name: 'PRaul: Comment PR with app URLs'
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
+            * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
+            * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
+            * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'
+        if: success() && env.PR_NUMBER
+        env:
+          REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
 
-  #     - name: 'Deploy to S3: Develop'
-  #       if: github.ref == 'refs/heads/develop'
-  #       run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
+      - name: 'Deploy to S3: Develop'
+        if: github.ref == 'refs/heads/develop'
+        run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
 
-  #     - name: 'Deploy to S3: Staging'
-  #       if: github.ref == 'refs/heads/master'
-  #       run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
+      - name: 'Deploy to S3: Staging'
+        if: github.ref == 'refs/heads/master'
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
 
-  #     - name: 'Production deployment: Upload release build files to be deployed'
-  #       if: startsWith(github.ref, 'refs/tags/v')
-  #       run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
+      - name: 'Production deployment: Upload release build files to be deployed'
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: 'where I am???'
-        run: pwd && ls -la
-
-      - name: 'github dir???'
-        run: ls -la .github/scripts/
-
-      - name: 'scripts dir???'
-        run: ls -la .github/scripts/
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     needs: [build, storybook]
     runs-on: ubuntu-latest
 
-    steps:      
+    steps:
       - name: Download website
         uses: actions/download-artifact@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,16 @@ jobs:
   #       if: startsWith(github.ref, 'refs/tags/v')
   #       run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
+
+      - name: 'where I am???'
+        run: pwd && ls -la
+
+      - name: 'github dir???'
+        run: ls -la .github/scripts/
+
+      - name: 'scripts dir???'
+        run: ls -la .github/scripts/
+
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')
         run: bash .github/scripts/prepare_production_deployment.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,6 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
-      - name: Test print website
-        run: ls -la website
-
       - name: 'Production deployment: Upload release build files to be deployed'
         if: startsWith(github.ref, 'refs/tags/v')
         run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,196 +15,196 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
+  # setup:
+  #   name: Setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Set output of cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+  #     - name: Set output of cache
+  #       id: yarn-cache
+  #       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache yarn cache
-        uses: actions/cache@v2
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+  #     - name: Cache yarn cache
+  #       uses: actions/cache@v2
+  #       id: cache-yarn-cache
+  #       with:
+  #         path: ${{ steps.yarn-cache.outputs.dir }}
+  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-yarn-
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
 
-  test:
-    name: Test
-    needs: setup
-    runs-on: ubuntu-latest
+  # test:
+  #   name: Test
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Coverage
-        run: yarn test:coverage
+  #     - name: Coverage
+  #       run: yarn test:coverage
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Coveralls
+  #       uses: coverallsapp/github-action@v1.1.2
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  build:
-    name: Build apps
-    needs: setup
-    runs-on: ubuntu-latest
+  # build:
+  #   name: Build apps
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Build Web Apps
-        run: yarn build
-        env:
-          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+  #     - name: Build Web Apps
+  #       run: yarn build
+  #       env:
+  #         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
-      - name: Upload websites artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: website
-          path: dist
+  #     - name: Upload websites artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: website
+  #         path: dist
 
-  storybook:
-    name: Build storybook
-    needs: setup
-    runs-on: ubuntu-latest
+  # storybook:
+  #   name: Build storybook
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Build Storybook
-        run: yarn build-storybook -o dist-storybook;
+  #     - name: Build Storybook
+  #       run: yarn build-storybook -o dist-storybook;
 
-      - name: Upload storybook artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: storybook
-          path: dist-storybook
+  #     - name: Upload storybook artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: storybook
+  #         path: dist-storybook
 
   deploy:
     name: Deploy
-    needs: [build, storybook]
+    # needs: [build, storybook]
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Download website
-        uses: actions/download-artifact@v2
+      # - name: Download website
+      #   uses: actions/download-artifact@v2
 
-      - name: Move storybook inside dist
-        run: mv storybook website/storybook
+      # - name: Move storybook inside dist
+      #   run: mv storybook website/storybook
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: 'Deploy to S3: PRaul'
-        if: success() && env.PR_NUMBER
-        run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
+      # - name: 'Deploy to S3: PRaul'
+      #   if: success() && env.PR_NUMBER
+      #   run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
 
-      - name: 'PRaul: Comment PR with app URLs'
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
-            * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
-            * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
-            * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
-        if: success() && env.PR_NUMBER
-        env:
-          REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
+      # - name: 'PRaul: Comment PR with app URLs'
+      #   uses: mshick/add-pr-comment@v1
+      #   with:
+      #     message: |
+      #       * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
+      #       * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
+      #       * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
+      #       * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     repo-token-user-login: 'github-actions[bot]'
+      #   if: success() && env.PR_NUMBER
+      #   env:
+      #     REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
 
-      - name: 'Deploy to S3: Develop'
-        if: github.ref == 'refs/heads/develop'
-        run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
+      # - name: 'Deploy to S3: Develop'
+      #   if: github.ref == 'refs/heads/develop'
+      #   run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
 
-      - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
+      # - name: 'Deploy to S3: Staging'
+      #   if: github.ref == 'refs/heads/master'
+      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      # - name: Get the version
+      #   id: get_version
+      #   run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
-      - name: 'Production deployment: Upload release build files to be deployed'
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete
+      # - name: 'Production deployment: Upload release build files to be deployed'
+      #   if: startsWith(github.ref, 'refs/tags/v')
+      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        run: bash ../.github/scripts/prepare_production_deployment.sh
+        run: bash .github/scripts/prepare_production_deployment.sh
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,9 @@ jobs:
       #   if: github.ref == 'refs/heads/master'
       #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
 
-      # - name: Get the version
-      #   id: get_version
-      #   run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
       # - name: 'Production deployment: Upload release build files to be deployed'
       #   if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,7 @@ jobs:
     # needs: [build, storybook]
     runs-on: ubuntu-latest
 
-    steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
-
+    steps:      
   #     - name: Download website
   #       uses: actions/download-artifact@v2
 
@@ -202,6 +199,9 @@ jobs:
   #       if: startsWith(github.ref, 'refs/tags/v')
   #       run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
+
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: 'where I am???'
         run: pwd && ls -la

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,19 @@ jobs:
       #     PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
       #     PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
       #     VERSION_TAG: ${{ github.event.release.tag_name }}
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
           
       - name: Test
-        run: echo ${{ env.REVIEW_FEATURE_URL }}
+        run: echo ${{ steps.get_version.outputs.VERSION }}
         env: 
             PROD_DEPLOYMENT_HOOK_TOKEN: ${GITHUB_REF##*/}
+
+      - name: Test 2
+        run: echo ${{ env.PROD_DEPLOYMENT_HOOK_TOKEN }}
+        env: 
+            PROD_DEPLOYMENT_HOOK_TOKEN: ${{ steps.get_version.outputs.VERSION }}
 
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+
   #     - name: Download website
   #       uses: actions/download-artifact@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
     types: [opened, synchronize]
   push:
     branches: [master, develop]
-  release:
-    types: [published]
+    tags: [v*]
 
 env:
   APP_ID: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
+          # VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
 
       
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,198 +15,204 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
+  # setup:
+  #   name: Setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Set output of cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+  #     - name: Set output of cache
+  #       id: yarn-cache
+  #       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache yarn cache
-        uses: actions/cache@v2
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+  #     - name: Cache yarn cache
+  #       uses: actions/cache@v2
+  #       id: cache-yarn-cache
+  #       with:
+  #         path: ${{ steps.yarn-cache.outputs.dir }}
+  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-yarn-
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
 
-  test:
-    name: Test
-    needs: setup
-    runs-on: ubuntu-latest
+  # test:
+  #   name: Test
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Coverage
-        run: yarn test:coverage
+  #     - name: Coverage
+  #       run: yarn test:coverage
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Coveralls
+  #       uses: coverallsapp/github-action@v1.1.2
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  build:
-    name: Build apps
-    needs: setup
-    runs-on: ubuntu-latest
+  # build:
+  #   name: Build apps
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Build Web Apps
-        run: yarn build
-        env:
-          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+  #     - name: Build Web Apps
+  #       run: yarn build
+  #       env:
+  #         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
-      - name: Upload websites artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: website
-          path: dist
+  #     - name: Upload websites artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: website
+  #         path: dist
 
-  storybook:
-    name: Build storybook
-    needs: setup
-    runs-on: ubuntu-latest
+  # storybook:
+  #   name: Build storybook
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Build Storybook
-        run: yarn build-storybook -o dist-storybook;
+  #     - name: Build Storybook
+  #       run: yarn build-storybook -o dist-storybook;
 
-      - name: Upload storybook artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: storybook
-          path: dist-storybook
+  #     - name: Upload storybook artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: storybook
+  #         path: dist-storybook
 
   deploy:
     name: Deploy
-    needs: [build, storybook]
+    # needs: [build, storybook]
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download website
-        uses: actions/download-artifact@v2
+      # - name: Download website
+      #   uses: actions/download-artifact@v2
 
-      - name: Move storybook inside dist
-        run: mv storybook website/storybook
+      # - name: Move storybook inside dist
+      #   run: mv storybook website/storybook
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: 'Deploy to S3: PRaul'
-        if: success() && env.PR_NUMBER
-        run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
+      # - name: 'Deploy to S3: PRaul'
+      #   if: success() && env.PR_NUMBER
+      #   run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
 
-      - name: 'PRaul: Comment PR with app URLs'
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
-            * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
-            * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
-            * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
-        if: success() && env.PR_NUMBER
-        env:
-          REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
+      # - name: 'PRaul: Comment PR with app URLs'
+      #   uses: mshick/add-pr-comment@v1
+      #   with:
+      #     message: |
+      #       * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
+      #       * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
+      #       * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
+      #       * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     repo-token-user-login: 'github-actions[bot]'
+      #   if: success() && env.PR_NUMBER
+      #   env:
+      #     REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
 
-      - name: 'Deploy to S3: Develop'
-        if: github.ref == 'refs/heads/develop'
-        run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
+      # - name: 'Deploy to S3: Develop'
+      #   if: github.ref == 'refs/heads/develop'
+      #   run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
 
-      - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
+      # - name: 'Deploy to S3: Staging'
+      #   if: github.ref == 'refs/heads/master'
+      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
 
-      - name: 'Production deployment: Upload release build files to be deployed'
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
+      # - name: 'Production deployment: Upload release build files to be deployed'
+      #   if: startsWith(github.ref, 'refs/tags/v')
+      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
+      # - name: Checkout code
+      #   uses: actions/checkout@v2
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+      # - name: 'Production deployment: Enable production deployment'
+      #   if: success() && startsWith(github.ref, 'refs/tags/v')
+      #   run: bash .github/scripts/prepare_production_deployment.sh
+      #   env:
+      #     PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
+      #     PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
+      #     VERSION_TAG: ${{ github.event.release.tag_name }}
+          
+      - name: Test
+        run: echo ${{ env.REVIEW_FEATURE_URL }}
+        env: 
+            PROD_DEPLOYMENT_HOOK_TOKEN: ${GITHUB_REF##*/}
 
-      - name: 'Production deployment: Enable production deployment'
-        if: success() && startsWith(github.ref, 'refs/tags/v')
-        run: bash .github/scripts/prepare_production_deployment.sh
-        env:
-          PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
-          PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          VERSION_TAG: ${{ github.event.release.tag_name }}
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,29 +199,21 @@ jobs:
       #   if: startsWith(github.ref, 'refs/tags/v')
       #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
-      # - name: Checkout code
-      #   uses: actions/checkout@v2
-
-      # - name: 'Production deployment: Enable production deployment'
-      #   if: success() && startsWith(github.ref, 'refs/tags/v')
-      #   run: bash .github/scripts/prepare_production_deployment.sh
-      #   env:
-      #     PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
-      #     PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-      #     VERSION_TAG: ${{ github.event.release.tag_name }}
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      - name: 'Production deployment: Enable production deployment'
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        run: bash .github/scripts/prepare_production_deployment.sh
+        env:
+          PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
+          PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
+          VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
+
+      
           
-      - name: Test
-        run: echo ${{ steps.get_version.outputs.VERSION }}
-        env: 
-            PROD_DEPLOYMENT_HOOK_TOKEN: ${GITHUB_REF##*/}
-
-      - name: Test 2
-        run: echo ${{ env.PROD_DEPLOYMENT_HOOK_TOKEN }}
-        env: 
-            PROD_DEPLOYMENT_HOOK_TOKEN: ${{ steps.get_version.outputs.VERSION }}
-
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Download website
         uses: actions/download-artifact@v2
 
@@ -194,9 +197,6 @@ jobs:
       - name: 'Deploy to S3: Staging'
         if: github.ref == 'refs/heads/master'
         run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
-
-      - name: Checkout code
-        uses: actions/checkout@v2
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,193 +15,193 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
+  # setup:
+  #   name: Setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Set output of cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+  #     - name: Set output of cache
+  #       id: yarn-cache
+  #       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache yarn cache
-        uses: actions/cache@v2
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+  #     - name: Cache yarn cache
+  #       uses: actions/cache@v2
+  #       id: cache-yarn-cache
+  #       with:
+  #         path: ${{ steps.yarn-cache.outputs.dir }}
+  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-yarn-
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
 
-  test:
-    name: Test
-    needs: setup
-    runs-on: ubuntu-latest
+  # test:
+  #   name: Test
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Coverage
-        run: yarn test:coverage
+  #     - name: Coverage
+  #       run: yarn test:coverage
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Coveralls
+  #       uses: coverallsapp/github-action@v1.1.2
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  build:
-    name: Build apps
-    needs: setup
-    runs-on: ubuntu-latest
+  # build:
+  #   name: Build apps
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Build Web Apps
-        run: yarn build
-        env:
-          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+  #     - name: Build Web Apps
+  #       run: yarn build
+  #       env:
+  #         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
-      - name: Upload websites artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: website
-          path: dist
+  #     - name: Upload websites artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: website
+  #         path: dist
 
-  storybook:
-    name: Build storybook
-    needs: setup
-    runs-on: ubuntu-latest
+  # storybook:
+  #   name: Build storybook
+  #   needs: setup
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
+  #     - name: Set up node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+  #     - name: Load dependencies
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - name: Build Storybook
-        run: yarn build-storybook -o dist-storybook;
+  #     - name: Build Storybook
+  #       run: yarn build-storybook -o dist-storybook;
 
-      - name: Upload storybook artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: storybook
-          path: dist-storybook
+  #     - name: Upload storybook artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: storybook
+  #         path: dist-storybook
 
   deploy:
     name: Deploy
-    needs: [build, storybook]
+    # needs: [build, storybook]
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Download website
-        uses: actions/download-artifact@v2
+  #   steps:
+  #     - name: Download website
+  #       uses: actions/download-artifact@v2
 
-      - name: Move storybook inside dist
-        run: mv storybook website/storybook
+  #     - name: Move storybook inside dist
+  #       run: mv storybook website/storybook
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: 'Deploy to S3: PRaul'
-        if: success() && env.PR_NUMBER
-        run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
+  #     - name: 'Deploy to S3: PRaul'
+  #       if: success() && env.PR_NUMBER
+  #       run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
 
-      - name: 'PRaul: Comment PR with app URLs'
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
-            * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
-            * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
-            * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
-        if: success() && env.PR_NUMBER
-        env:
-          REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
+  #     - name: 'PRaul: Comment PR with app URLs'
+  #       uses: mshick/add-pr-comment@v1
+  #       with:
+  #         message: |
+  #           * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
+  #           * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
+  #           * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
+  #           * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #         repo-token-user-login: 'github-actions[bot]'
+  #       if: success() && env.PR_NUMBER
+  #       env:
+  #         REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
 
-      - name: 'Deploy to S3: Develop'
-        if: github.ref == 'refs/heads/develop'
-        run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
+  #     - name: 'Deploy to S3: Develop'
+  #       if: github.ref == 'refs/heads/develop'
+  #       run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
 
-      - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
+  #     - name: 'Deploy to S3: Staging'
+  #       if: github.ref == 'refs/heads/master'
+  #       run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
 
-      - name: 'Production deployment: Upload release build files to be deployed'
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
+  #     - name: 'Production deployment: Upload release build files to be deployed'
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        run: bash ./.github/scripts/prepare_production_deployment.sh
+        run: bash ../.github/scripts/prepare_production_deployment.sh
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     # needs: [build, storybook]
     runs-on: ubuntu-latest
 
-  #   steps:
+    steps:
   #     - name: Download website
   #       uses: actions/download-artifact@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
 
   deploy:
     name: Deploy
-    # needs: [build, storybook]
+    needs: [build, storybook]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,140 +15,140 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  # setup:
-  #   name: Setup
-  #   runs-on: ubuntu-latest
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Set output of cache
-  #       id: yarn-cache
-  #       run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Set output of cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-  #     - name: Cache yarn cache
-  #       uses: actions/cache@v2
-  #       id: cache-yarn-cache
-  #       with:
-  #         path: ${{ steps.yarn-cache.outputs.dir }}
-  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-yarn-
+      - name: Cache yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-  # test:
-  #   name: Test
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  test:
+    name: Test
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Coverage
-  #       run: yarn test:coverage
+      - name: Coverage
+        run: yarn test:coverage
 
-  #     - name: Coveralls
-  #       uses: coverallsapp/github-action@v1.1.2
-  #       with:
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coveralls
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # build:
-  #   name: Build apps
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  build:
+    name: Build apps
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Build Web Apps
-  #       run: yarn build
-  #       env:
-  #         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+      - name: Build Web Apps
+        run: yarn build
+        env:
+          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
 
-  #     - name: Upload websites artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: website
-  #         path: dist
+      - name: Upload websites artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: website
+          path: dist
 
-  # storybook:
-  #   name: Build storybook
-  #   needs: setup
-  #   runs-on: ubuntu-latest
+  storybook:
+    name: Build storybook
+    needs: setup
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 12
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-  #     - name: Load dependencies
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: node_modules
-  #         key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-  #     - name: Build Storybook
-  #       run: yarn build-storybook -o dist-storybook;
+      - name: Build Storybook
+        run: yarn build-storybook -o dist-storybook;
 
-  #     - name: Upload storybook artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: storybook
-  #         path: dist-storybook
+      - name: Upload storybook artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: storybook
+          path: dist-storybook
 
   deploy:
     name: Deploy
@@ -156,48 +156,44 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - name: Download website
-      #   uses: actions/download-artifact@v2
+      - name: Download website
+        uses: actions/download-artifact@v2
 
-      # - name: Move storybook inside dist
-      #   run: mv storybook website/storybook
+      - name: Move storybook inside dist
+        run: mv storybook website/storybook
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # - name: 'Deploy to S3: PRaul'
-      #   if: success() && env.PR_NUMBER
-      #   run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
+      - name: 'Deploy to S3: PRaul'
+        if: success() && env.PR_NUMBER
+        run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
 
-      # - name: 'PRaul: Comment PR with app URLs'
-      #   uses: mshick/add-pr-comment@v1
-      #   with:
-      #     message: |
-      #       * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
-      #       * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
-      #       * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
-      #       * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
-      #     repo-token-user-login: 'github-actions[bot]'
-      #   if: success() && env.PR_NUMBER
-      #   env:
-      #     REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
+      - name: 'PRaul: Comment PR with app URLs'
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            * **🔭 [Explorer](${{ env.REVIEW_FEATURE_URL }})**: Explorer test app
+            * **🔒 [Safe Swap App](${{ env.REVIEW_FEATURE_URL }}/safe.html)**: Trade test app (add to your safe apps)
+            * **📈 [Trade](${{ env.REVIEW_FEATURE_URL }}/trade.html)**: Trade test app
+            * **📚 [Storybook](${{ env.REVIEW_FEATURE_URL }}/storybook/)**: Component stories
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'
+        if: success() && env.PR_NUMBER
+        env:
+          REVIEW_FEATURE_URL: https://pr${{ env.PR_NUMBER }}--${{ env.REPO_NAME_SLUG }}.review.gnosisdev.com
 
-      # - name: 'Deploy to S3: Develop'
-      #   if: github.ref == 'refs/heads/develop'
-      #   run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
+      - name: 'Deploy to S3: Develop'
+        if: github.ref == 'refs/heads/develop'
+        run: aws s3 sync website s3://${{ secrets.AWS_DEV_BUCKET_NAME }} --delete
 
-      # - name: 'Deploy to S3: Staging'
-      #   if: github.ref == 'refs/heads/master'
-      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
-
-      # - name: 'Production deployment: Upload release build files to be deployed'
-      #   if: startsWith(github.ref, 'refs/tags/v')
-      #   run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
+      - name: 'Deploy to S3: Staging'
+        if: github.ref == 'refs/heads/master'
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete      
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -205,6 +201,13 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      - name: Test print website
+        run: ls -la website
+
+      - name: 'Production deployment: Upload release build files to be deployed'
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: aws s3 sync website s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.get_version.outputs.VERSION }} --delete
 
       - name: 'Production deployment: Enable production deployment'
         if: success() && startsWith(github.ref, 'refs/tags/v')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.4",
+  "version": "2.1.0-rc.5",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.10",
+  "version": "2.1.0-rc.11",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.16",
+  "version": "2.1.0-rc.17",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.22",
+  "version": "2.1.0-rc.23",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.21",
+  "version": "2.1.0-rc.22",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.5",
+  "version": "2.1.0-rc.6",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.14",
+  "version": "2.1.0-rc.15",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.12",
+  "version": "2.1.0-rc.13",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.7",
+  "version": "2.1.0-rc.8",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.8",
+  "version": "2.1.0-rc.9",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.17",
+  "version": "2.1.0-rc.18",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.11",
+  "version": "2.1.0-rc.12",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.3",
+  "version": "2.1.0-rc.4",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.9",
+  "version": "2.1.0-rc.10",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.2",
+  "version": "2.1.0-rc.3",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.18",
+  "version": "2.1.0-rc.19",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.20",
+  "version": "2.1.0-rc.21",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.13",
+  "version": "2.1.0-rc.14",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.15",
+  "version": "2.1.0-rc.16",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.19",
+  "version": "2.1.0-rc.20",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.6",
+  "version": "2.1.0-rc.7",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.23",
+  "version": "2.1.0-rc.24",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.1.0-rc.0",
+  "version": "2.1.0-rc.1",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,


### PR DESCRIPTION
**Description**
Prepare PRODUCTION deploy automatically on every tag.

**Why**
Because before we needed to tag, and then create a new release. We want to prepare for deployment every tag.

Also, there were some small errors explained in the details

**Details**
Now it gives better output. It prints the current version (so we also make sure the env var is correctly set)

Also, it will inform about the passed parameters. If they are not available:
![image](https://user-images.githubusercontent.com/2352112/116233083-2cc67c00-a75b-11eb-8412-61b4167ae49e.png)

Additionally, now returns an error in that case. Before this PR it was just printing the error, and showing success (ends with a 0 error code). So now, if any param is missing, now it returns the `100` error code.

The error message, now is printed in stderr, instead of stdout (more correct, but also GA understand it and display it better)