### PR TITLE
305/hide partial amounts when fully filled

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -67,6 +67,7 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
   cancelled: boolean
   status: OrderStatus
   partiallyFilled: boolean
+  fullyFilled: boolean
   filledAmount: BigNumber
   filledPercentage: BigNumber
   surplusAmount: BigNumber

--- a/src/components/orders/FilledProgress/FilledProgress.stories.tsx
+++ b/src/components/orders/FilledProgress/FilledProgress.stories.tsx
@@ -42,13 +42,19 @@ Default.args = { ...defaultArgs }
 export const FullyFilledSellOrder = Template.bind({})
 FullyFilledSellOrder.args = {
   ...defaultArgs,
-  order: { ...order, kind: 'sell', filledAmount: order.sellAmount, filledPercentage: ONE_BIG_NUMBER },
+  order: {
+    ...order,
+    kind: 'sell',
+    filledAmount: order.sellAmount,
+    filledPercentage: ONE_BIG_NUMBER,
+    fullyFilled: true,
+  },
 }
 
 export const FullyFilledBuyOrder = Template.bind({})
 FullyFilledBuyOrder.args = {
   ...defaultArgs,
-  order: { ...order, kind: 'buy', filledAmount: order.buyAmount, filledPercentage: ONE_BIG_NUMBER },
+  order: { ...order, kind: 'buy', filledAmount: order.buyAmount, filledPercentage: ONE_BIG_NUMBER, fullyFilled: true },
 }
 
 export const PartiallyFilledSellOrder = Template.bind({})

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -37,6 +37,7 @@ export function FilledProgress(props: Props): JSX.Element {
     order: {
       filledAmount,
       filledPercentage,
+      fullyFilled,
       kind,
       sellAmount,
       buyAmount,
@@ -92,10 +93,14 @@ export function FilledProgress(props: Props): JSX.Element {
         <b>
           {formattedFilledAmount} {mainSymbol}
         </b>{' '}
-        of{' '}
-        <b>
-          {formattedMainAmount} {mainSymbol}
-        </b>{' '}
+        {!fullyFilled && (
+          <>
+            of{' '}
+            <b>
+              {formattedMainAmount} {mainSymbol}
+            </b>{' '}
+          </>
+        )}
         {action} for a total of{' '}
         <b>
           {formattedSwappedAmount} {swappedSymbol}

--- a/src/components/orders/GasFeeDisplay/GasFeeDisplay.stories.tsx
+++ b/src/components/orders/GasFeeDisplay/GasFeeDisplay.stories.tsx
@@ -38,7 +38,7 @@ export const PartialFee = Template.bind({})
 PartialFee.args = { ...defaultProps, order: { ...order, executedFeeAmount: new BigNumber('100000') } }
 
 export const FullFee = Template.bind({})
-FullFee.args = { ...defaultProps, order: { ...order, executedFeeAmount: order.feeAmount } }
+FullFee.args = { ...defaultProps, order: { ...order, executedFeeAmount: order.feeAmount, fullyFilled: true } }
 
 export const TinyFee6DecimalsToken = Template.bind({})
 TinyFee6DecimalsToken.args = { ...defaultProps, order: { ...order, executedFeeAmount: new BigNumber('1') } }

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -19,7 +19,7 @@ export type Props = { order: Order }
 
 export function GasFeeDisplay(props: Props): JSX.Element | null {
   const {
-    order: { feeAmount, executedFeeAmount, sellToken, sellTokenAddress },
+    order: { feeAmount, executedFeeAmount, sellToken, sellTokenAddress, fullyFilled },
   } = props
 
   // TODO: fetch amount in USD
@@ -45,10 +45,14 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
         {formattedExecutedFee} {quoteSymbol}
       </span>
       {/* <UsdAmount>(~${totalFeeUSD})</UsdAmount> */}
-      <span>
-        of {formattedTotalFee} {quoteSymbol}
-      </span>
-      {/* <UsdAmount>(~${executedFeeUSD})</UsdAmount> */}
+      {!fullyFilled && (
+        <>
+          <span>
+            of {formattedTotalFee} {quoteSymbol}
+          </span>
+          {/* <UsdAmount>(~${executedFeeUSD})</UsdAmount> */}
+        </>
+      )}
     </Wrapper>
   )
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -248,6 +248,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(rawOrder)
   const status = getOrderStatus(rawOrder)
   const partiallyFilled = isOrderPartiallyFilled(rawOrder)
+  const fullyFilled = isOrderFilled(rawOrder)
   const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(rawOrder)
   const { amount: surplusAmount, percentage: surplusPercentage } = getOrderSurplus(rawOrder)
 
@@ -272,6 +273,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
     cancelled: invalidated,
     status,
     partiallyFilled,
+    fullyFilled,
     filledAmount,
     filledPercentage,
     surplusAmount,

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -45,6 +45,7 @@ export const RICH_ORDER: Order = {
   cancelled: RAW_ORDER.invalidated,
   status: 'open',
   partiallyFilled: false,
+  fullyFilled: false,
   filledAmount: ZERO_BIG_NUMBER,
   filledPercentage: ZERO_BIG_NUMBER,
   buyToken: WETH,


### PR DESCRIPTION
# Summary

Closes #305 

## Before
![screenshot_2021-04-28_11-19-00](https://user-images.githubusercontent.com/43217/116453236-7bcfe800-a813-11eb-95a5-101e8b813862.png)

## After
![screenshot_2021-04-28_11-18-06](https://user-images.githubusercontent.com/43217/116453253-7ffc0580-a813-11eb-933b-16c06cec9b06.png)

# Testing

## Storybook
Check the stories:
- Filled Progress
- Gas Fee Display

![screenshot_2021-04-28_11-19-51](https://user-images.githubusercontent.com/43217/116453363-a1f58800-a813-11eb-9892-5b75fda22dd7.png)

## App

1. Open a matched order
- [ ] Verify the `Filled` row only shows the first token amount once
- [ ] Verify the `Fees` row only shows the amount once

2. Open an order that have not yet been matched
- [ ] Verify the `Filled` row shows the first token amount twice: matched and full
- [ ] Verify the `Fees` row only shows the amount twice: used and full