### PR TITLE
Updating trades whenever the order's executed amounts change

### DIFF
--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -97,8 +97,10 @@ export function useOrderTrades(order: Order | null): Result {
 
     fetchTrades(networkId, order)
     // Depending on order UID to avoid re-fetching when obj changes but ID remains the same
+    // Depending on `executedBuy/SellAmount`s string to force a refetch when there are new trades
+    // using the string version because hooks are bad at detecting Object changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchTrades, networkId, order?.uid])
+  }, [fetchTrades, networkId, order?.uid, order?.executedSellAmount.toString(), order?.executedBuyAmount.toString()])
 
   return { trades, error, isLoading }
 }


### PR DESCRIPTION
# Summary

Closes #407

Updating tx hash whenever trade happens

# Testing

1. Using a local CowSwap version, or cowswap.dev.gnosisdev.com (Staging/Prod version won't work), place an order
2. Open the Explorer link and copy the order id
3. Open this PR's Explorer app and load the order id
4. Observe the order details page until a match happens
- [ ] When the trade happens, the tx hash field should auto-populate without the need for a page refresh