### PR TITLE
Create / Stylize Explorer-UserDetails Tab component

### DIFF
--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import Tabs, { getTabTheme, Props as TabsProps, IndicatorTabSize } from 'components/common/Tabs/Tabs'
 import { DARK_COLOURS } from 'theme'
+import { MEDIA } from 'const'
 
 const StyledTabs = styled.div`
   display: flex;
@@ -32,6 +33,14 @@ const StyledTabs = styled.div`
 
   > div > div.tab-content {
     padding: 20px 16px;
+  }
+
+  .tab-extra-content {
+    width: 100%;
+
+    @media ${MEDIA.mobile} {
+      display: none; /* for now we can hide the extra-content on mobiles */
+    }
   }
 `
 const tabCustomThemeConfig = getTabTheme({

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import Tabs, { getTabTheme, Props as TabsProps } from 'components/common/Tabs/Tabs'
+import { DARK_COLOURS } from 'theme'
+
+const StyledTabs = styled.div`
+  display: flex;
+  width: 100%;
+  padding: 0;
+  border: 1px solid rgba(151, 151, 184, 0.3);
+  border-radius: 4px;
+
+  > div > div.tablist {
+    justify-content: flex-start;
+    border-bottom: 1px solid rgba(151, 151, 184, 0.3);
+    box-sizing: border-box;
+  }
+
+  > div > div.tablist > button {
+    flex: 0 0 auto;
+    min-width: 96px;
+    padding: 12px 0.8rem;
+    line-height: 2;
+    height: auto;
+    font-family: var(--font-default);
+  }
+
+  > div > div:last-of-type {
+    height: 100%;
+  }
+
+  > div > div.tab-content {
+    padding: 20px 16px;
+  }
+`
+const tabCustomThemeConfig = getTabTheme({
+  activeBg: 'var(--color-transparent)',
+  activeBgAlt: 'initial',
+  inactiveBg: 'var(--color-transparent)',
+  activeText: DARK_COLOURS.textPrimary1,
+  inactiveText: 'var(--color-text-secondary2)',
+  activeBorder: DARK_COLOURS.orange,
+  inactiveBorder: 'none',
+  fontSize: 'var(--font-size-large)',
+  fontWeight: 'var(--font-weight-bold)',
+  letterSpacing: 'initial',
+  borderRadius: false,
+})
+
+const ExplorerTabs: React.FC<Omit<TabsProps, 'tabTheme'>> = (props) => {
+  return (
+    <StyledTabs>
+      <Tabs tabTheme={tabCustomThemeConfig} {...props} />
+    </StyledTabs>
+  )
+}
+
+export default ExplorerTabs

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import Tabs, { getTabTheme, Props as TabsProps } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, Props as TabsProps, IndicatorTabSize } from 'components/common/Tabs/Tabs'
 import { DARK_COLOURS } from 'theme'
 
 const StyledTabs = styled.div`
@@ -46,9 +46,12 @@ const tabCustomThemeConfig = getTabTheme({
   fontWeight: 'var(--font-weight-bold)',
   letterSpacing: 'initial',
   borderRadius: false,
+  indicatorTabSize: IndicatorTabSize.big,
 })
 
-const ExplorerTabs: React.FC<Omit<TabsProps, 'tabTheme'>> = (props) => {
+type ExplorerTabsProps = Omit<TabsProps, 'tabTheme'>
+
+const ExplorerTabs: React.FC<ExplorerTabsProps> = (props) => {
   return (
     <StyledTabs>
       <Tabs tabTheme={tabCustomThemeConfig} {...props} />

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -8,12 +8,12 @@ const StyledTabs = styled.div`
   display: flex;
   width: 100%;
   padding: 0;
-  border: 1px solid rgba(151, 151, 184, 0.3);
+  border: ${({ theme }): string => `1px solid ${theme.borderPrimary}`};
   border-radius: 4px;
 
   > div > div.tablist {
     justify-content: flex-start;
-    border-bottom: 1px solid rgba(151, 151, 184, 0.3);
+    border-bottom: ${({ theme }): string => `1px solid ${theme.borderPrimary}`};
     box-sizing: border-box;
   }
 

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Meta, Story } from '@storybook/react/types-6-0'
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
+
+import StyledTabs from './ExplorerTab'
+import { Props as TabsProps } from '../../../../../components/common/Tabs/Tabs'
+
+export default {
+  title: 'ExplorerApp/ExplorerTabs',
+  component: StyledTabs,
+  decorators: [GlobalStyles, ThemeToggler],
+} as Meta
+
+const tabItems = [
+  {
+    id: 1,
+    tab: 'Orders',
+    content: <h2>Orders Content</h2>,
+  },
+  {
+    id: 2,
+    tab: 'Trades',
+    content: <h2>Trades Content</h2>,
+  },
+]
+
+const Template: Story<TabsProps> = (args) => <StyledTabs {...args} />
+
+export const DefaultTabs = Template.bind({})
+DefaultTabs.args = { tabItems }

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
@@ -49,17 +49,10 @@ const tabItems = [
 ]
 
 const Wrapper = styled.div`
-  width: 500px;
   padding: 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border: 1px dashed darkorange;
-
-  .tab-extra-content {
-    width: 100%;
-    display: flex;
-  }
 `
 
 interface SProps {

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Meta, Story } from '@storybook/react/types-6-0'
@@ -47,7 +48,35 @@ const tabItems = [
   },
 ]
 
+const Wrapper = styled.div`
+  width: 500px;
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px dashed darkorange;
+
+  .tab-extra-content {
+    width: 100%;
+    display: flex;
+  }
+`
+
+interface SProps {
+  text: string
+}
+const SimpleComponent: React.FC<SProps> = (props) => {
+  return <h2>{props.text}</h2>
+}
+
+const ExtraComponentNode: React.ReactNode = (
+  <Wrapper>
+    <SimpleComponent text="ExtraComponent_1" />
+    <SimpleComponent text="ExtraComponent_2" />
+  </Wrapper>
+)
+
 const Template: Story<TabsProps> = (args) => <StyledTabs {...args} />
 
 export const DefaultTabs = Template.bind({})
-DefaultTabs.args = { tabItems }
+DefaultTabs.args = { tabItems, extra: ExtraComponentNode }

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.stories.tsx
@@ -17,12 +17,33 @@ const tabItems = [
   {
     id: 1,
     tab: 'Orders',
-    content: <h2>Orders Content</h2>,
+    content: (
+      <div>
+        <h2>Orders Content</h2>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In libero mauris, dictum a orci ac, congue commodo
+          quam. Fusce ac accumsan diam. Nulla facilisi. Pellentesque ullamcorper ullamcorper metus, at viverra turpis
+          tristique vulputate. Ut dictum ac elit sit amet ultricies. Aliquam ultricies ante arcu, maximus malesuada leo
+          dignissim vitae. Nulla facilisi. Quisque sit amet arcu sed nulla hendrerit euismod. Donec gravida sollicitudin
+          libero, a auctor tortor convallis non. Nullam malesuada enim eu sollicitudin sodales. Nullam accumsan, nunc
+          sed ultrices elementum, lorem diam vulputate turpis, a ultrices tortor mauris id mauris. Pellentesque a
+          commodo libero, et convallis leo. Aenean facilisis arcu id magna scelerisque feugiat. Sed accumsan arcu vel
+          consequat lobortis. Proin gravida lacinia massa eu fringilla. Nulla venenatis sodales tempus. Nam convallis
+          justo vitae sollicitudin iaculis. Ut vehicula enim vel interdum varius. Aliquam erat volutpat. Pellentesque
+          sed tellus in dui pulvinar blandit et et elit. Quisque nec metus fringilla, laoreet orci id, scelerisque
+          velit.
+        </p>
+      </div>
+    ),
   },
   {
     id: 2,
     tab: 'Trades',
-    content: <h2>Trades Content</h2>,
+    content: (
+      <>
+        <h2>Trades Content</h2>
+      </>
+    ),
   },
 ]
 

--- a/src/components/common/Tabs/TabContent.tsx
+++ b/src/components/common/Tabs/TabContent.tsx
@@ -12,7 +12,7 @@ const TabContent: React.FC<Props> = (props) => {
 
   if (!displayTab) return null
 
-  return <div>{displayTab.content}</div>
+  return <div className="tab-content">{displayTab.content}</div>
 }
 
 export default TabContent

--- a/src/components/common/Tabs/TabItem.tsx
+++ b/src/components/common/Tabs/TabItem.tsx
@@ -38,7 +38,7 @@ const TabItemWrapper = styled(TabItemBase)<TabItemWrapperProps>`
   letter-spacing: ${({ tabTheme }): string => tabTheme.letterSpacing};
 
   border-bottom: ${({ isActive, tabTheme }): string =>
-    `.1rem solid ${isActive ? tabTheme.activeBorder : tabTheme.inactiveBorder}`};
+    `${tabTheme.indicatorTabSize}rem solid ${isActive ? tabTheme.activeBorder : tabTheme.inactiveBorder}`};
 
   /* TODO: Provide alternative :focus styling because of using outline: 0; */
 

--- a/src/components/common/Tabs/Tabs.stories.tsx
+++ b/src/components/common/Tabs/Tabs.stories.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+
+import { Meta, Story } from '@storybook/react'
+import { GlobalStyles, NetworkDecorator, ThemeToggler } from 'storybook/decorators'
+
+import Tabs, { getTabTheme, Props as TabsProps } from './Tabs'
+import { DARK_COLOURS } from 'theme'
+
+export default {
+  title: 'Common/Tabs',
+  component: Tabs,
+  decorators: [GlobalStyles, NetworkDecorator, ThemeToggler],
+} as Meta
+
+const tabItems = [
+  {
+    id: 1,
+    tab: 'Tab one',
+    content: <h3>Tab One</h3>,
+  },
+  {
+    id: 2,
+    tab: 'Tab two',
+    content: <h3>Tab Two</h3>,
+  },
+  {
+    id: 3,
+    tab: 'Tab three',
+    content: <h3>Tab Three</h3>,
+  },
+]
+
+const tabDefaultThemeConfig = getTabTheme()
+
+const Template: Story<TabsProps> = (args) => <Tabs {...args} />
+
+export const DefaultTabs = Template.bind({})
+DefaultTabs.args = { tabItems, tabTheme: tabDefaultThemeConfig }
+
+const tabItemsWithoutChild = [
+  {
+    id: 1,
+    tab: 'Orders',
+    content: null,
+  },
+  {
+    id: 2,
+    tab: 'Trades',
+    content: null,
+  },
+]
+
+const tabCustomThemeConfig = getTabTheme({
+  activeBg: 'var(--color-transparent)',
+  activeBgAlt: 'initial',
+  inactiveBg: 'var(--color-transparent)',
+  activeText: DARK_COLOURS.textPrimary1,
+  inactiveText: 'var(--color-text-secondary2)',
+  activeBorder: DARK_COLOURS.orange,
+  inactiveBorder: 'none',
+  fontSize: 'var(--font-size-large)',
+  fontWeight: 'var(--font-weight-bold)',
+  letterSpacing: 'initial',
+  borderRadius: false,
+})
+
+export const CustomizedThemeTabs = Template.bind({})
+CustomizedThemeTabs.args = { tabItems: tabItemsWithoutChild, tabTheme: tabCustomThemeConfig }

--- a/src/components/common/Tabs/Tabs.stories.tsx
+++ b/src/components/common/Tabs/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { Meta, Story } from '@storybook/react'
-import { GlobalStyles, NetworkDecorator, ThemeToggler } from 'storybook/decorators'
+import { Meta, Story } from '@storybook/react/types-6-0'
+import { GlobalStyles, ThemeToggler } from 'storybook/decorators'
 
 import Tabs, { getTabTheme, Props as TabsProps } from './Tabs'
 import { DARK_COLOURS } from 'theme'
@@ -9,7 +9,7 @@ import { DARK_COLOURS } from 'theme'
 export default {
   title: 'Common/Tabs',
   component: Tabs,
-  decorators: [GlobalStyles, NetworkDecorator, ThemeToggler],
+  decorators: [GlobalStyles, ThemeToggler],
 } as Meta
 
 const tabItems = [

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -26,7 +26,7 @@ export interface TabTheme {
   readonly fontSize: string
   readonly borderRadius: boolean
 }
-interface Props {
+export interface Props {
   readonly tabItems: TabItemInterface[]
   readonly tabTheme: TabTheme
   readonly defaultTab?: TabId
@@ -45,7 +45,6 @@ const Wrapper = styled.div`
     width: 100%;
   }
 `
-
 export const DEFAULT_TAB_THEME: TabTheme = {
   activeBg: 'var(--color-transparent)',
   activeBgAlt: 'initial',

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -75,7 +75,6 @@ interface ExtraContentProps {
 const ExtraContent = ({ extra }: ExtraContentProps): JSX.Element | null => {
   if (!extra) return null
 
-  console.log('ExtraContent', extra)
   return <div className="tab-extra-content">{extra}</div>
 }
 

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -6,6 +6,10 @@ import TabItem from 'components/common/Tabs/TabItem'
 import TabContent from 'components/common/Tabs/TabContent'
 
 type TabId = number
+export enum IndicatorTabSize {
+  small = 0.1,
+  big = 0.2,
+}
 
 export interface TabItemInterface {
   readonly tab: React.ReactNode
@@ -25,6 +29,7 @@ export interface TabTheme {
   readonly fontWeight: string
   readonly fontSize: string
   readonly borderRadius: boolean
+  readonly indicatorTabSize: IndicatorTabSize
 }
 export interface Props {
   readonly tabItems: TabItemInterface[]
@@ -45,6 +50,7 @@ const Wrapper = styled.div`
     width: 100%;
   }
 `
+
 export const DEFAULT_TAB_THEME: TabTheme = {
   activeBg: 'var(--color-transparent)',
   activeBgAlt: 'initial',
@@ -57,6 +63,7 @@ export const DEFAULT_TAB_THEME: TabTheme = {
   fontWeight: 'var(--font-weight-normal)',
   letterSpacing: 'initial',
   borderRadius: false,
+  indicatorTabSize: IndicatorTabSize.small,
 }
 
 const Tabs: React.FC<Props> = (props) => {

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -51,6 +51,14 @@ const Wrapper = styled.div`
     justify-content: space-between;
     width: 100%;
   }
+  .tab-extra-content {
+    width: 100%;
+
+    @media ${MEDIA.mobile} {
+      font-size: 1.4rem;
+      min-height: 20rem;
+    }
+  }
 `
 
 export const DEFAULT_TAB_THEME: TabTheme = {

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { MEDIA } from 'const'
 
 // Components
 import TabItem from 'components/common/Tabs/TabItem'
@@ -51,13 +50,6 @@ const Wrapper = styled.div`
     padding: 0;
     justify-content: space-between;
     width: 100%;
-  }
-  .tab-extra-content {
-    width: 100%;
-
-    @media ${MEDIA.mobile} {
-      color: red; /* mobile css here */
-    }
   }
 `
 

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -10,6 +10,7 @@ export enum IndicatorTabSize {
   small = 0.1,
   big = 0.2,
 }
+export type TabBarExtraContent = React.ReactNode
 
 export interface TabItemInterface {
   readonly tab: React.ReactNode
@@ -35,6 +36,7 @@ export interface Props {
   readonly tabItems: TabItemInterface[]
   readonly tabTheme: TabTheme
   readonly defaultTab?: TabId
+  readonly extra?: TabBarExtraContent
 }
 
 const Wrapper = styled.div`
@@ -66,8 +68,19 @@ export const DEFAULT_TAB_THEME: TabTheme = {
   indicatorTabSize: IndicatorTabSize.small,
 }
 
+interface ExtraContentProps {
+  extra?: TabBarExtraContent
+}
+
+const ExtraContent = ({ extra }: ExtraContentProps): JSX.Element | null => {
+  if (!extra) return null
+
+  console.log('ExtraContent', extra)
+  return <div className="tab-extra-content">{extra}</div>
+}
+
 const Tabs: React.FC<Props> = (props) => {
-  const { tabTheme = DEFAULT_TAB_THEME, tabItems, defaultTab = 1 } = props
+  const { tabTheme = DEFAULT_TAB_THEME, tabItems, defaultTab = 1, extra: tabBarExtraContent } = props
 
   const [activeTab, setActiveTab] = useState(defaultTab)
 
@@ -84,6 +97,7 @@ const Tabs: React.FC<Props> = (props) => {
             tabTheme={tabTheme}
           />
         ))}
+        <ExtraContent extra={tabBarExtraContent} />
       </div>
       <TabContent tabItems={tabItems} activeTab={activeTab} />
     </Wrapper>

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
+import { MEDIA } from 'const'
 
 // Components
 import TabItem from 'components/common/Tabs/TabItem'
@@ -55,8 +56,7 @@ const Wrapper = styled.div`
     width: 100%;
 
     @media ${MEDIA.mobile} {
-      font-size: 1.4rem;
-      min-height: 20rem;
+      color: red; /* mobile css here */
     }
   }
 `


### PR DESCRIPTION
closes: #1043

- Create a new component that uses the [Tabs](https://github.com/gnosis/gp-ui/blob/styling-tab-1043/src/components/common/Tabs/Tabs.tsx#L62) as a Base and style it. **(path taken)**
    - [x] Use theme Provider variables.
    - [x]  Ability to use some variants of the [thickness](https://github.com/gnosis/gp-ui/blob/styling-tab-1043/src/components/common/Tabs/TabItem.tsx#L41) of the tab indicator
    - [x] Add an extra content to Tabs.