### PR TITLE
Add base components for UserDetails tables on Explorer

### DIFF
--- a/src/components/orders/OrdersUserDetailsTable/styled.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/styled.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components'
+
+import { SimpleTable, Props as SimpleTableProps } from 'components/common/SimpleTable'
+
+interface Props {
+  showBorderTable?: boolean
+}
+
+export type StyledUserDetailsTableProps = SimpleTableProps & Props
+
+const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
+  border: ${({ theme, showBorderTable }): string => (showBorderTable ? `0.1rem solid ${theme.borderPrimary}` : 'none')};
+  border-radius: 0.4rem;
+
+  tr td {
+    &:not(:first-of-type) {
+      text-align: right;
+    }
+
+    &.long {
+      border-left: 0.2rem solid var(--color-long);
+    }
+
+    &.short {
+      color: var(--color-short);
+      border-left: 0.2rem solid var(--color-short);
+    }
+  }
+
+  thead tr th {
+    color: white;
+    font-style: normal;
+    font-weight: 800;
+    font-size: 13px;
+    line-height: 16px;
+    height: 50px;
+    border-bottom: ${({ theme }): string => `1px solid ${theme.borderPrimary}`};
+  }
+
+  tbody tr:hover {
+    backdrop-filter: contrast(0.9);
+  }
+
+  .span-copybtn-wrap {
+    display: block;
+  }
+`
+
+export default StyledUserDetailsTable


### PR DESCRIPTION
Deprecated

:warning: Working In Progress...

:spiral_notepad:   TODO:
- [x] Create base for orders and trades tables (@henrypalacios)
- [ ] Create utility for display the `limit price` in both table (@stackseeder)
- [ ] Crete a component to display column Type 
![Selection_299](https://user-images.githubusercontent.com/4270166/129092677-f40347a6-84e9-44d2-aed3-5921c9cca44a.png)
, in both table (@henrypalacios)
