### PR TITLE
Allow partially fillable orders

### DIFF
--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -233,42 +233,44 @@ export function DetailsTable(props: Props): JSX.Element | null {
               />
             </td>
           </tr>
-          {!partiallyFillable && (
-            <>
-              <tr>
-                <td>
-                  <HelpTooltip tooltip={tooltip.priceExecution} /> Execution price
-                </td>
-                <td>
-                  {!filledAmount.isZero() ? (
-                    <OrderPriceDisplay
-                      buyAmount={executedBuyAmount}
-                      buyToken={buyToken}
-                      sellAmount={executedSellAmount}
-                      sellToken={sellToken}
-                      showInvertButton
-                    />
-                  ) : (
-                    '-'
-                  )}
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <HelpTooltip tooltip={tooltip.filled} /> Filled
-                </td>
-                <td>
-                  <FilledProgress order={order} />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <HelpTooltip tooltip={tooltip.surplus} /> Order surplus
-                </td>
-                <td>{!surplusAmount.isZero() ? <OrderSurplusDisplay order={order} /> : '-'}</td>
-              </tr>
-            </>
-          )}
+          {/*TODO: uncomment when fills tab is implemented */}
+          {/*{!partiallyFillable && (*/}
+          <>
+            <tr>
+              <td>
+                <HelpTooltip tooltip={tooltip.priceExecution} /> Execution price
+              </td>
+              <td>
+                {!filledAmount.isZero() ? (
+                  <OrderPriceDisplay
+                    buyAmount={executedBuyAmount}
+                    buyToken={buyToken}
+                    sellAmount={executedSellAmount}
+                    sellToken={sellToken}
+                    showInvertButton
+                  />
+                ) : (
+                  '-'
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <HelpTooltip tooltip={tooltip.filled} /> Filled
+              </td>
+              <td>
+                <FilledProgress order={order} />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <HelpTooltip tooltip={tooltip.surplus} /> Order surplus
+              </td>
+              <td>{!surplusAmount.isZero() ? <OrderSurplusDisplay order={order} /> : '-'}</td>
+            </tr>
+          </>
+          {/*TODO: uncomment when fills tab is implemented */}
+          {/*)}*/}
           <tr>
             <td>
               <HelpTooltip tooltip={tooltip.fees} /> Fees

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -127,7 +127,7 @@ export function getOrderSurplus(order: RawOrder): Surplus {
 
   if (partiallyFillable) {
     // TODO: calculate how much was matched based on the type and check whether there was any surplus
-    throw Error('Not implemented')
+    return { amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER }
   }
 
   if (kind === 'buy') {

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 
-import { ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
+import { ONE_BIG_NUMBER, TEN_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
 import { RawOrder } from 'api/operator'
 
@@ -9,7 +9,7 @@ import { getOrderSurplus } from 'utils'
 import { RAW_ORDER } from '../../data'
 
 const ZERO_DOT_ZERO_ONE = new BigNumber('0.01')
-// const TWENTY_PERCENT = new BigNumber('0.2')
+const TWENTY_PERCENT = new BigNumber('0.2')
 
 describe('getOrderSurplus', () => {
   describe('Buy order', () => {
@@ -63,7 +63,7 @@ describe('getOrderSurplus', () => {
         expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
       })
     })
-    test('partiallyFillable', () => {
+    test.skip('partiallyFillable', () => {
       const order: RawOrder = {
         ...RAW_ORDER,
         kind: 'buy',
@@ -73,9 +73,7 @@ describe('getOrderSurplus', () => {
         executedBuyAmount: '40',
         partiallyFillable: true,
       }
-      // TODO: uncomment when implemented
-      // expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
-      expect(() => getOrderSurplus(order)).toThrow('Not implemented')
+      expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
     })
   })
 
@@ -130,7 +128,7 @@ describe('getOrderSurplus', () => {
         expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
       })
     })
-    test('partiallyFillable', () => {
+    test.skip('partiallyFillable', () => {
       const order: RawOrder = {
         ...RAW_ORDER,
         kind: 'sell',
@@ -140,9 +138,7 @@ describe('getOrderSurplus', () => {
         executedSellAmount: '40',
         partiallyFillable: true,
       }
-      // TODO: uncomment when implemented
-      // expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
-      expect(() => getOrderSurplus(order)).toThrow('Not implemented')
+      expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
     })
   })
 })


### PR DESCRIPTION
# Summary

Unblocks display of partially fillable orders.

This PR simply removes the blocker preventing partial fills orders to be displayed.
There are still missing parts to fully represent this kind of order.
![screenshot_2021-08-25_15-35-01](https://user-images.githubusercontent.com/43217/130873104-a01aeb0d-fa88-459c-b6d9-26d50a15ebbc.png)


# To Test

There's one order placed by Martin on xDai where this can be tested with:
`0xc8be23d8b87390c4ab102c38979ab3af06018dc98b359b9392be9c0f6e603bb2518db068841c093d4f36bd2d6c5c263e151a1c226126ab28`
It requires prod backend endpoints, which are not available on PRs.
Thus, it can only be tested locally (by setting the end vars) or prod.

# Out of scope

Implement full support for partial fills