### PR TITLE
1046 load from api orderstable

### DIFF
--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -193,16 +193,24 @@ export async function getOrder(params: GetOrderParams): Promise<RawOrder | null>
  *  - owner: address
  *  - sellToken: address
  *  - buyToken: address
+ *  - minValidTo: number
  */
 export async function getOrders(params: GetOrdersParams): Promise<RawOrder[]> {
   const { networkId, ...searchParams } = params
-  const { owner, sellToken, buyToken } = searchParams
+  const { owner, sellToken, buyToken, minValidTo } = searchParams
+  const defaultValues = {
+    includeFullyExecuted: 'true',
+    includeInvalidated: 'true',
+    includeInsufficientBalance: 'true',
+    includePresignaturePending: 'true',
+    includeUnsupportedTokens: 'true',
+  }
 
   console.log(
     `[getOrders] Fetching orders on network ${networkId} with filters: owner=${owner} sellToken=${sellToken} buyToken=${buyToken}`,
   )
 
-  const searchString = buildSearchString({ ...searchParams })
+  const searchString = buildSearchString({ ...searchParams, ...defaultValues, minValidTo: String(minValidTo) })
 
   const queryString = '/orders/' + searchString
 

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -119,7 +119,8 @@ export type GetOrderParams = WithNetworkId & {
 }
 
 export type GetOrdersParams = WithNetworkId & {
-  owner?: string
+  owner: string
+  minValidTo: number
   sellToken?: string
   buyToken?: string
 }

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -118,7 +118,7 @@ const AppContent = (): JSX.Element => {
 }
 
 const Wrapper = styled.div`
-  max-width: 140rem;
+  max-width: 118rem;
   margin: 0 auto;
 
   ${media.mediumDown} {

--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -4,12 +4,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import OrdersTable from 'components/orders/OrdersUserDetailsTable'
 import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
-import { OrdersTableContext, OrdersTableState } from './context/OrdersTableContext'
+import { OrdersTableContext } from './context/OrdersTableContext'
 
 export const OrdersTableWithData: React.FC = () => {
-  const { orders, kind } = useContext(OrdersTableContext)
+  const { orders, isFirstLoading } = useContext(OrdersTableContext)
 
-  return kind === OrdersTableState.Loading ? (
+  return isFirstLoading ? (
     <EmptyItemWrapper>
       <FontAwesomeIcon icon={faSpinner} spin size="3x" />
     </EmptyItemWrapper>

--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+import OrdersTable from 'components/orders/OrdersUserDetailsTable'
+import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
+import { OrdersTableContext, OrdersTableState } from './context/OrdersTableContext'
+
+export const OrdersTableWithData: React.FC = () => {
+  const { orders, kind } = useContext(OrdersTableContext)
+
+  return kind === OrdersTableState.Loading ? (
+    <EmptyItemWrapper>
+      <FontAwesomeIcon icon={faSpinner} spin size="3x" />
+    </EmptyItemWrapper>
+  ) : (
+    <OrdersTable orders={orders} />
+  )
+}

--- a/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
@@ -2,16 +2,10 @@ import React from 'react'
 
 import { Order } from 'api/operator'
 
-export enum OrdersTableState {
-  Loading,
-  Loaded,
-  Error,
-}
-
 interface CommonState {
   orders: Order[]
   error: string
-  kind: OrdersTableState
+  isFirstLoading: boolean
 }
 
 export const OrdersTableContext = React.createContext({} as CommonState)

--- a/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { Order } from 'api/operator'
+
+export enum OrdersTableState {
+  Loading,
+  Loaded,
+  Error,
+}
+
+interface CommonState {
+  orders: Order[]
+  error: string
+  kind: OrdersTableState
+}
+
+export const OrdersTableContext = React.createContext({} as CommonState)

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -3,74 +3,30 @@ import styled from 'styled-components'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import { media } from 'theme/styles/media'
-
 import ExplorerTabs from 'apps/explorer/components/common/ExplorerTabs/ExplorerTab'
 import { OrdersTableWithData } from './OrdersTableWithData'
-import { OrdersTableContext, OrdersTableState } from './context/OrdersTableContext'
+import { OrdersTableContext } from './context/OrdersTableContext'
 import { useGetOrders } from './useGetOrders'
 import { TabItemInterface } from 'components/common/Tabs/Tabs'
-import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
-
-const Wrapper = styled.div`
-  padding: 1.6rem;
-  margin: 0 auto;
-  width: 100%;
-  max-width: 140rem;
-
-  ${media.mediumDown} {
-    max-width: 94rem;
-  }
-
-  ${media.mobile} {
-    max-width: 100%;
-  }
-  > h1 {
-    display: flex;
-    padding: 2.4rem 0 3rem;
-    align-items: center;
-    font-weight: ${({ theme }): string => theme.fontBold};
-  }
-`
 
 const StyledTabLoader = styled.span`
   padding-left: 4px;
 `
 
-const tabItems = (ordersTableState: OrdersTableState): TabItemInterface[] => {
+const tabItems = (isLoadingOrders: boolean): TabItemInterface[] => {
   return [
     {
       id: 1,
       tab: (
         <>
           Orders
-          <StyledTabLoader>
-            {ordersTableState === OrdersTableState.Loading && <FontAwesomeIcon icon={faSpinner} spin size="1x" />}
-          </StyledTabLoader>
+          <StyledTabLoader>{isLoadingOrders && <FontAwesomeIcon icon={faSpinner} spin size="1x" />}</StyledTabLoader>
         </>
       ),
       content: <OrdersTableWithData />,
     },
-    {
-      id: 2,
-      tab: 'Trades',
-      content: (
-        <>
-          <h2>Trades Content</h2>
-        </>
-      ),
-    },
   ]
 }
-
-const TitleAddress = styled(RowWithCopyButton)`
-  color: ${({ theme }): string => theme.grey};
-  font-size: ${({ theme }): string => theme.fontSizeDefault};
-  font-weight: ${({ theme }): string => theme.fontNormal};
-  margin: 0 0 0 1rem;
-  display: flex;
-  align-items: center;
-`
 
 interface Props {
   ownerAddress: string
@@ -78,22 +34,16 @@ interface Props {
 
 const OrdersTableWidget: React.FC<Props> = ({ ownerAddress }) => {
   const { orders, isLoading, error } = useGetOrders(ownerAddress)
-  const ordersTableState = useMemo(() => {
-    if (isLoading && orders.length === 0) return OrdersTableState.Loading
-    else if (error) return OrdersTableState.Error
 
-    return OrdersTableState.Loaded
-  }, [isLoading, orders.length, error])
+  const isFirstLoading = useMemo(() => {
+    if (isLoading && orders.length === 0) return true
+
+    return false
+  }, [isLoading, orders.length])
 
   return (
-    <OrdersTableContext.Provider value={{ orders, kind: ordersTableState, error }}>
-      <Wrapper>
-        <h1>
-          User details
-          {<TitleAddress textToCopy={ownerAddress} contentsToDisplay={ownerAddress} />}
-        </h1>
-        <ExplorerTabs tabItems={tabItems(isLoading ? OrdersTableState.Loading : OrdersTableState.Loaded)} />
-      </Wrapper>
+    <OrdersTableContext.Provider value={{ orders, error, isFirstLoading }}>
+      <ExplorerTabs tabItems={tabItems(isLoading)} />
     </OrdersTableContext.Provider>
   )
 }

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { useParams } from 'react-router'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+import { media } from 'theme/styles/media'
+
+import ExplorerTabs from 'apps/explorer/components/common/ExplorerTabs/ExplorerTab'
+import { OrdersTableWithData } from './OrdersTableWithData'
+import { OrdersTableContext, OrdersTableState } from './context/OrdersTableContext'
+import { useGetOrders } from './useGetOrders'
+import { TabItemInterface } from 'components/common/Tabs/Tabs'
+
+const Wrapper = styled.div`
+  padding: 1.6rem;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 140rem;
+
+  ${media.mediumDown} {
+    max-width: 94rem;
+  }
+
+  ${media.mobile} {
+    max-width: 100%;
+  }
+`
+
+const StyledTabLoader = styled.span`
+  padding-left: 4px;
+`
+
+const tabItems = (ordersTableState: OrdersTableState): TabItemInterface[] => {
+  return [
+    {
+      id: 1,
+      tab: (
+        <>
+          Orders
+          <StyledTabLoader>
+            {ordersTableState === OrdersTableState.Loading && <FontAwesomeIcon icon={faSpinner} spin size="1x" />}
+          </StyledTabLoader>
+        </>
+      ),
+      content: <OrdersTableWithData />,
+    },
+    {
+      id: 2,
+      tab: 'Trades',
+      content: (
+        <>
+          <h2>Trades Content</h2>
+        </>
+      ),
+    },
+  ]
+}
+
+function useAddressParam(): string {
+  const { address } = useParams<{ address: string }>()
+
+  return address
+}
+
+const OrdersTableWidget: React.FC = () => {
+  const ownerAddress = useAddressParam()
+  const { orders, isLoading, error } = useGetOrders(ownerAddress)
+  const ordersTableState = useMemo(() => {
+    if (isLoading && orders.length === 0) return OrdersTableState.Loading
+    else if (error) return OrdersTableState.Error
+
+    return OrdersTableState.Loaded
+  }, [isLoading, orders.length, error])
+
+  return (
+    <OrdersTableContext.Provider value={{ orders, kind: ordersTableState, error }}>
+      <Wrapper>
+        <ExplorerTabs tabItems={tabItems(isLoading ? OrdersTableState.Loading : OrdersTableState.Loaded)} />
+      </Wrapper>
+    </OrdersTableContext.Provider>
+  )
+}
+
+export default OrdersTableWidget

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
-import { useParams } from 'react-router'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -11,6 +10,7 @@ import { OrdersTableWithData } from './OrdersTableWithData'
 import { OrdersTableContext, OrdersTableState } from './context/OrdersTableContext'
 import { useGetOrders } from './useGetOrders'
 import { TabItemInterface } from 'components/common/Tabs/Tabs'
+import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 
 const Wrapper = styled.div`
   padding: 1.6rem;
@@ -24,6 +24,12 @@ const Wrapper = styled.div`
 
   ${media.mobile} {
     max-width: 100%;
+  }
+  > h1 {
+    display: flex;
+    padding: 2.4rem 0 3rem;
+    align-items: center;
+    font-weight: ${({ theme }): string => theme.fontBold};
   }
 `
 
@@ -57,14 +63,20 @@ const tabItems = (ordersTableState: OrdersTableState): TabItemInterface[] => {
   ]
 }
 
-function useAddressParam(): string {
-  const { address } = useParams<{ address: string }>()
+const TitleAddress = styled(RowWithCopyButton)`
+  color: ${({ theme }): string => theme.grey};
+  font-size: ${({ theme }): string => theme.fontSizeDefault};
+  font-weight: ${({ theme }): string => theme.fontNormal};
+  margin: 0 0 0 1rem;
+  display: flex;
+  align-items: center;
+`
 
-  return address
+interface Props {
+  ownerAddress: string
 }
 
-const OrdersTableWidget: React.FC = () => {
-  const ownerAddress = useAddressParam()
+const OrdersTableWidget: React.FC<Props> = ({ ownerAddress }) => {
   const { orders, isLoading, error } = useGetOrders(ownerAddress)
   const ordersTableState = useMemo(() => {
     if (isLoading && orders.length === 0) return OrdersTableState.Loading
@@ -76,6 +88,10 @@ const OrdersTableWidget: React.FC = () => {
   return (
     <OrdersTableContext.Provider value={{ orders, kind: ordersTableState, error }}>
       <Wrapper>
+        <h1>
+          User details
+          {<TitleAddress textToCopy={ownerAddress} contentsToDisplay={ownerAddress} />}
+        </h1>
         <ExplorerTabs tabItems={tabItems(isLoading ? OrdersTableState.Loading : OrdersTableState.Loaded)} />
       </Wrapper>
     </OrdersTableContext.Provider>

--- a/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
@@ -20,7 +20,7 @@ export function mergeNewOrders(previousOrders: Order[], newOrdersFetched: RawOrd
 
   // find the order up to which it is to be replaced
   const lastOrder = newOrdersFetched[newOrdersFetched.length - 1]
-  const positionLastOrder = previousOrders.map((o) => o.uid).indexOf(lastOrder.uid)
+  const positionLastOrder = previousOrders.findIndex((o) => o.uid === lastOrder.uid)
   if (positionLastOrder === -1) {
     return newOrdersFetched.map((order) => transformOrder(order)).concat(previousOrders)
   }
@@ -73,7 +73,7 @@ export function useGetOrders(ownerAddress: string): Result {
         }, [])
 
         setErc20Addresses(newErc20Addresses)
-        // For the moment it is neccesary to sort by date
+        // TODO -> For the moment it is neccesary to sort by date
         ordersFetched.sort((a, b) => +new Date(b.creationDate) - +new Date(a.creationDate))
 
         setOrders((previousOrders) => mergeNewOrders(previousOrders, ordersFetched))

--- a/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
@@ -1,0 +1,128 @@
+import { useState, useCallback, useEffect } from 'react'
+import { subMinutes, getTime } from 'date-fns'
+
+import { Network } from 'types'
+import { useMultipleErc20 } from 'hooks/useErc20'
+import { getOrders, Order, RawOrder } from 'api/operator'
+import { useNetworkId } from 'state/network'
+import { transformOrder } from 'utils'
+import { ORDERS_HISTORY_MINUTES_AGO, ORDERS_QUERY_INTERVAL } from 'apps/explorer/const'
+
+/**
+ *
+ * Merge new RawOrders consulted, that may have changed status
+ *
+ * @param previousOrders List of orders
+ * @param newOrdersFetched List of fetched block order that could have changed
+ */
+export function mergeNewOrders(previousOrders: Order[], newOrdersFetched: RawOrder[]): Order[] {
+  if (newOrdersFetched.length === 0) return previousOrders
+
+  // find the order up to which it is to be replaced
+  const lastOrder = newOrdersFetched[newOrdersFetched.length - 1]
+  const positionLastOrder = previousOrders.map((o) => o.uid).indexOf(lastOrder.uid)
+  if (positionLastOrder === -1) {
+    return newOrdersFetched.map((order) => transformOrder(order)).concat(previousOrders)
+  }
+
+  const slicedOrders: Order[] = previousOrders.slice(positionLastOrder + 1)
+  return newOrdersFetched.map((order) => transformOrder(order)).concat(slicedOrders)
+}
+
+function isObjectEmpty(object: Record<string, unknown>): boolean {
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  for (const key in object) {
+    if (key) return false
+  }
+
+  return true
+}
+
+type Result = {
+  orders: Order[]
+  error: string
+  isLoading: boolean
+}
+
+export function useGetOrders(ownerAddress: string): Result {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [orders, setOrders] = useState<Order[]>([])
+  const networkId = useNetworkId() || undefined
+  const [erc20Addresses, setErc20Addresses] = useState<string[]>([])
+  const { value: valueErc20s, isLoading: areErc20Loading } = useMultipleErc20({ networkId, addresses: erc20Addresses })
+  const [mountNewOrders, setMountNewOrders] = useState(false)
+
+  const fetchOrders = useCallback(
+    async (network: Network, owner: string, minTimeHistoryTimeStamp = 0): Promise<void> => {
+      setIsLoading(true)
+      setError('')
+
+      try {
+        const ordersFetched = await getOrders({ networkId: network, owner, minValidTo: minTimeHistoryTimeStamp })
+        const newErc20Addresses = ordersFetched.reduce((accumulator: string[], element) => {
+          const updateAccumulator = (tokenAddress: string): void => {
+            if (accumulator.indexOf(tokenAddress) === -1) {
+              accumulator.push(tokenAddress)
+            }
+          }
+          updateAccumulator(element.buyToken)
+          updateAccumulator(element.sellToken)
+
+          return accumulator
+        }, [])
+
+        setErc20Addresses(newErc20Addresses)
+        // For the moment it is neccesary to sort by date
+        ordersFetched.sort((a, b) => +new Date(b.creationDate) - +new Date(a.creationDate))
+
+        setOrders((previousOrders) => mergeNewOrders(previousOrders, ordersFetched))
+        setMountNewOrders(true)
+      } catch (e) {
+        const msg = `Failed to fetch orders`
+        console.error(msg, e)
+        setError(msg)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!networkId) {
+      return
+    }
+    const getOrUpdateOrders = (minHistoryTime?: number): Promise<void> =>
+      fetchOrders(networkId, ownerAddress, minHistoryTime)
+
+    getOrUpdateOrders()
+
+    const intervalId: NodeJS.Timeout = setInterval(() => {
+      const minutesAgoTimestamp = getTime(subMinutes(new Date(), ORDERS_HISTORY_MINUTES_AGO))
+      getOrUpdateOrders(Math.floor(minutesAgoTimestamp / 1000))
+    }, ORDERS_QUERY_INTERVAL)
+
+    return (): void => {
+      clearInterval(intervalId)
+    }
+  }, [fetchOrders, networkId, ownerAddress])
+
+  useEffect(() => {
+    if (areErc20Loading || isObjectEmpty(valueErc20s) || !mountNewOrders) {
+      return
+    }
+
+    const newOrders = orders.map((order) => {
+      order.buyToken = valueErc20s[order.buyTokenAddress] || order.buyToken
+      order.sellToken = valueErc20s[order.sellTokenAddress] || order.sellToken
+
+      return order
+    })
+
+    setOrders(newOrders)
+    setMountNewOrders(false)
+  }, [valueErc20s, networkId, areErc20Loading, mountNewOrders, orders])
+
+  return { orders, error, isLoading }
+}

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -11,6 +11,7 @@ const StyledTabs = styled.div`
   padding: 0;
   border: ${({ theme }): string => `1px solid ${theme.borderPrimary}`};
   border-radius: 4px;
+  min-height: 33rem;
 
   > div > div.tablist {
     justify-content: flex-start;

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -2,6 +2,8 @@ import { AnalyticsDimension } from 'types'
 
 /** Explorer app constants */
 export const ORDER_QUERY_INTERVAL = 10000 // in ms
+export const ORDERS_QUERY_INTERVAL = 10000 // in ms
+export const ORDERS_HISTORY_MINUTES_AGO = 10 // in minutes
 
 export const DISPLAY_TEXT_COPIED_CHECK = 1000 // in ms
 

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -2,7 +2,7 @@ import { AnalyticsDimension } from 'types'
 
 /** Explorer app constants */
 export const ORDER_QUERY_INTERVAL = 10000 // in ms
-export const ORDERS_QUERY_INTERVAL = 10000 // in ms
+export const ORDERS_QUERY_INTERVAL = 30000 // in ms
 export const ORDERS_HISTORY_MINUTES_AGO = 10 // in minutes
 
 export const DISPLAY_TEXT_COPIED_CHECK = 1000 // in ms

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -1,18 +1,62 @@
 import React from 'react'
 import { useParams } from 'react-router'
+import styled from 'styled-components'
 
 import { isAddress } from 'web3-utils'
 
+import { media } from 'theme/styles/media'
 import NotFound from './NotFound'
 import OrdersTableWidget from '../components/OrdersTableWidget'
+import { useNetworkId } from 'state/network'
+import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
+import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 
+const Wrapper = styled.div`
+  padding: 1.6rem;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 140rem;
+
+  ${media.mediumDown} {
+    max-width: 94rem;
+  }
+
+  ${media.mobile} {
+    max-width: 100%;
+  }
+  > h1 {
+    display: flex;
+    padding: 2.4rem 0 3rem;
+    align-items: center;
+    font-weight: ${({ theme }): string => theme.fontBold};
+  }
+`
+const TitleAddress = styled(RowWithCopyButton)`
+  font-size: ${({ theme }): string => theme.fontSizeDefault};
+  font-weight: ${({ theme }): string => theme.fontNormal};
+  margin: 0 0 0 1.5rem;
+  display: flex;
+  align-items: center;
+`
 const UserDetails: React.FC = () => {
   const { address } = useParams<{ address: string }>()
+  const networkId = useNetworkId() || undefined
 
   if (!isAddress(address)) {
     return <NotFound />
   } else {
-    return <OrdersTableWidget ownerAddress={address} />
+    return (
+      <Wrapper>
+        <h1>
+          User details
+          <TitleAddress
+            textToCopy={address}
+            contentsToDisplay={<BlockExplorerLink type="address" networkId={networkId} identifier={address} />}
+          />
+        </h1>
+        <OrdersTableWidget ownerAddress={address} />
+      </Wrapper>
+    )
   }
 }
 

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
-const UserDetails: React.FC = () => <h3>Placeholder Page</h3>
+import OrdersTableWidget from '../components/OrdersTableWidget'
+
+const UserDetails: React.FC = () => <OrdersTableWidget />
 
 export default UserDetails

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -15,7 +15,6 @@ const Wrapper = styled.div`
   padding: 1.6rem;
   margin: 0 auto;
   width: 100%;
-  max-width: 140rem;
 
   ${media.mediumDown} {
     max-width: 94rem;

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
   }
   > h1 {
     display: flex;
-    padding: 2.4rem 0 3rem;
+    padding: 2.4rem 0 2.35rem;
     align-items: center;
     font-weight: ${({ theme }): string => theme.fontBold};
   }

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -1,7 +1,19 @@
 import React from 'react'
+import { useParams } from 'react-router'
 
+import { isAddress } from 'web3-utils'
+
+import NotFound from './NotFound'
 import OrdersTableWidget from '../components/OrdersTableWidget'
 
-const UserDetails: React.FC = () => <OrdersTableWidget />
+const UserDetails: React.FC = () => {
+  const { address } = useParams<{ address: string }>()
+
+  if (!isAddress(address)) {
+    return <NotFound />
+  } else {
+    return <OrdersTableWidget ownerAddress={address} />
+  }
+}
 
 export default UserDetails

--- a/src/components/common/StyledUserDetailsTable.tsx
+++ b/src/components/common/StyledUserDetailsTable.tsx
@@ -60,6 +60,14 @@ const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
 
   tbody tr td.row-td-empty {
     grid-column: 1 / span all;
+
+    :hover {
+      background-color: ${({ theme }): string => theme.bg1};
+    }
+  }
+
+  tbody tr.row-empty {
+    padding: 0;
   }
 `
 

--- a/src/components/common/StyledUserDetailsTable.tsx
+++ b/src/components/common/StyledUserDetailsTable.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import { SimpleTable, Props as SimpleTableProps } from 'components/common/SimpleTable'
 
-interface Props {
+export interface Props {
   showBorderTable?: boolean
 }
 
@@ -11,6 +11,7 @@ export type StyledUserDetailsTableProps = SimpleTableProps & Props
 const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
   border: ${({ theme, showBorderTable }): string => (showBorderTable ? `0.1rem solid ${theme.borderPrimary}` : 'none')};
   border-radius: 0.4rem;
+  margin-top: 0;
 
   tr td {
     &:not(:first-of-type) {
@@ -38,6 +39,9 @@ const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
     gap: 6px;
   }
 
+  thead {
+    position: inherit;
+  }
   thead tr {
     width: 100%;
   }
@@ -53,6 +57,10 @@ const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
   span.wrap-datedisplay > span:last-of-type {
     display: flex;
   }
+
+  tbody tr td.row-td-empty {
+    grid-column: 1 / span all;
+  }
 `
 
 export const EmptyItemWrapper = styled.div`
@@ -62,6 +70,8 @@ export const EmptyItemWrapper = styled.div`
   align-items: center;
   justify-content: center;
   display: flex;
+  width: 100%;
+  font-size: ${({ theme }): string => theme.fontSizeDefault};
 `
 
 export default StyledUserDetailsTable

--- a/src/components/common/StyledUserDetailsTable.tsx
+++ b/src/components/common/StyledUserDetailsTable.tsx
@@ -46,6 +46,10 @@ const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
     width: 100%;
   }
 
+  tbody {
+    overflow: unset;
+  }
+
   tbody tr:hover {
     backdrop-filter: contrast(0.9);
   }

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -11,7 +11,7 @@ import { getOrderLimitPrice, formatCalculatedPriceToDisplay, formattedAmount } f
 import { StatusLabel } from '../StatusLabel'
 import { HelpTooltip } from 'components/Tooltip'
 import StyledUserDetailsTable, {
-  StyledUserDetailsTableProps,
+  Props as StyledUserDetailsTableProps,
   EmptyItemWrapper,
 } from '../../common/StyledUserDetailsTable'
 import Icon from 'components/Icon'
@@ -23,7 +23,6 @@ const Wrapper = styled(StyledUserDetailsTable)`
     grid-template-columns: 12rem 7rem repeat(2, 16rem) repeat(2, minmax(18rem, 24rem)) 1fr;
   }
 `
-
 function getLimitPrice(order: Order, isPriceInverted: boolean): string {
   if (!order.buyToken || !order.sellToken) return '-'
 
@@ -59,9 +58,13 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
       <td>
         {
           <RowWithCopyButton
-            className="wrap-copybtn"
+            className="span-copybtn-wrap"
             textToCopy={uid}
-            contentsToDisplay={<Link to={`/orders/${order.uid}`}>{shortId}</Link>}
+            contentsToDisplay={
+              <Link to={`/orders/${order.uid}`} target="_blank">
+                {shortId}
+              </Link>
+            }
           />
         }
       </td>
@@ -94,7 +97,14 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
   }
 
   const orderItems = (items: Order[]): JSX.Element => {
-    if (items.length === 0) return <EmptyItemWrapper>No Orders.</EmptyItemWrapper>
+    if (items.length === 0)
+      return (
+        <tr>
+          <td className="row-td-empty">
+            <EmptyItemWrapper>No Orders.</EmptyItemWrapper>
+          </td>
+        </tr>
+      )
 
     return (
       <>

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -100,7 +100,7 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
   const orderItems = (items: Order[]): JSX.Element => {
     if (items.length === 0)
       return (
-        <tr>
+        <tr className="row-empty">
           <td className="row-td-empty">
             <EmptyItemWrapper>No Orders.</EmptyItemWrapper>
           </td>

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -20,7 +20,7 @@ import TradeOrderType from 'components/common/TradeOrderType'
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, 16rem) repeat(2, minmax(18rem, 24rem)) 1fr;
+    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) repeat(2, minmax(18rem, 2fr)) 1fr;
   }
 `
 function getLimitPrice(order: Order, isPriceInverted: boolean): string {

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -22,6 +22,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
   > tbody > tr {
     grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) repeat(2, minmax(18rem, 2fr)) 1fr;
   }
+  overflow: auto;
 `
 function getLimitPrice(order: Order, isPriceInverted: boolean): string {
   if (!order.buyToken || !order.sellToken) return '-'

--- a/src/hooks/useOperatorOrder.ts
+++ b/src/hooks/useOperatorOrder.ts
@@ -60,7 +60,7 @@ async function _getOrder(
   }
 }
 
-export function useOrderByNetwork(orderId: string, updateInterval = 0, networkId: Network | null): UseOrderResult {
+export function useOrderByNetwork(orderId: string, networkId: Network | null, updateInterval = 0): UseOrderResult {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [order, setOrder] = useState<Order | null>(null)
@@ -121,7 +121,7 @@ export function useOrderByNetwork(orderId: string, updateInterval = 0, networkId
 
 export function useOrder(orderId: string, updateInterval?: number): UseOrderResult {
   const networkId = useNetworkId()
-  return useOrderByNetwork(orderId, updateInterval, networkId)
+  return useOrderByNetwork(orderId, networkId, updateInterval)
 }
 
 type UseOrderAndErc20sResult = {

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -238,7 +238,7 @@ function isZeroAddress(address: string): boolean {
 }
 
 export function isTokenErc20(token: TokenErc20 | null | undefined): token is TokenErc20 {
-  return (token as TokenErc20).address !== undefined
+  return (token as TokenErc20)?.address !== undefined
 }
 
 export function formattedAmount(erc20: TokenErc20 | null | undefined, amount: BigNumber): string {

--- a/test/utils/operator/orderFormatAmount.test.ts
+++ b/test/utils/operator/orderFormatAmount.test.ts
@@ -4,20 +4,16 @@ import { isTokenErc20, formattedAmount } from 'utils'
 
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 
-const factoryToken = (): TokenErc20 => {
-  return {
-    symbol: 'WETH',
-    name: 'Wrapped Ether',
-    address: '0xc778417e063141139fce010982780140aa0cd5ab',
-    decimals: 2,
-  }
+const WEthToken: TokenErc20 = {
+  symbol: 'WETH',
+  name: 'Wrapped Ether',
+  address: '0xc778417e063141139fce010982780140aa0cd5ab',
+  decimals: 2,
 }
 
 describe('Is token an ERC20', () => {
   test('should return true when it complies with TokenERC20 interface', () => {
-    const token = factoryToken()
-
-    expect(isTokenErc20(token)).toBe(true)
+    expect(isTokenErc20(WEthToken)).toBe(true)
   })
 
   test('should return false when object is undefined', () => {
@@ -29,7 +25,7 @@ describe('Is token an ERC20', () => {
 
 describe('format amount', () => {
   test('should return a string when input is a erc20 and amount', () => {
-    const amount = formattedAmount(factoryToken(), new BigNumber('1'))
+    const amount = formattedAmount(WEthToken, new BigNumber('1'))
 
     expect(amount).toEqual('0.01')
   })

--- a/test/utils/operator/orderFormatAmount.test.ts
+++ b/test/utils/operator/orderFormatAmount.test.ts
@@ -1,0 +1,42 @@
+import BigNumber from 'bignumber.js'
+
+import { isTokenErc20, formattedAmount } from 'utils'
+
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+
+const factoryToken = (): TokenErc20 => {
+  return {
+    symbol: 'WETH',
+    name: 'Wrapped Ether',
+    address: '0xc778417e063141139fce010982780140aa0cd5ab',
+    decimals: 2,
+  }
+}
+
+describe('Is token an ERC20', () => {
+  test('should return true when it complies with TokenERC20 interface', () => {
+    const token = factoryToken()
+
+    expect(isTokenErc20(token)).toBe(true)
+  })
+
+  test('should return false when object is undefined', () => {
+    const token = undefined
+
+    expect(isTokenErc20(token)).toBe(false)
+  })
+})
+
+describe('format amount', () => {
+  test('should return a string when input is a erc20 and amount', () => {
+    const amount = formattedAmount(factoryToken(), new BigNumber('1'))
+
+    expect(amount).toEqual('0.01')
+  })
+
+  test('should return dash(-) when erc20 is null', () => {
+    const amount = formattedAmount(null, new BigNumber('0.1'))
+
+    expect(amount).toEqual('-')
+  })
+})


### PR DESCRIPTION
Closes gnosis/cowswap#1046

Load orders from a wallet address.

:spiral_notepad: **Summary**:
- [x] Get the API to fetch data.
- [x] Refresh orders every 30s on the background.
- [x] Filter by time ago to save on calls. 
- [x] Orders Loader


## To Test
1. Go to  https://pr611--gpui.review.gnosisdev.com/rinkeby/address/0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9/
2. No orders. https://pr611--gpui.review.gnosisdev.com/address/0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9/