### PR TITLE
revert to BlockExplorerLink passed in 554

### DIFF
--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
-import { Link } from 'react-router-dom'
 
 import { Order } from 'api/operator'
 
@@ -142,7 +141,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <RowWithCopyButton
                 textToCopy={owner}
                 onCopy={(): void => onCopy('ownerAddress')}
-                contentsToDisplay={<Link to={`/address/${owner}`}>{owner}</Link>}
+                contentsToDisplay={<BlockExplorerLink identifier={owner} type="address" label={owner} />}
               />
             </td>
           </tr>
@@ -154,7 +153,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <RowWithCopyButton
                 textToCopy={receiver}
                 onCopy={(): void => onCopy('receiverAddress')}
-                contentsToDisplay={<Link to={`/address/${receiver}`}>{receiver}</Link>}
+                contentsToDisplay={<BlockExplorerLink identifier={receiver} type="address" label={receiver} />}
               />
             </td>
           </tr>


### PR DESCRIPTION
# Summary

I have made a change in [`DetailsTable`](https://github.com/gnosis/gp-ui/blob/hotfix-avoid-page-not-ready/src/components/orders/DetailsTable/index.tsx#L89) that was not convenient because it can go to production without the `UserDetailsPage` being finished.
