### PR TITLE
[Sentry] source-maps support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ AUTOCONNECT=true
 # Sentry
 #REACT_APP_SENTRY_DSN='https://<url>'
 #REACT_APP_SENTRY_TRACES_SAMPLE_RATE="1.0"
+#REACT_APP_SENTRY_AUTH_TOKEN='<sentry_auth_token>'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
   REPO_NAME_SLUG: gpui
   PR_NUMBER: ${{ github.event.number }}
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  REACT_APP_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
   setup:

--- a/getWebpackConfig.js
+++ b/getWebpackConfig.js
@@ -1,5 +1,6 @@
 const assert = require('assert').strict
 const path = require('path')
+const { version } = require('./package.json')
 
 const webpack = require('webpack')
 const HtmlWebPackPlugin = require('html-webpack-plugin')
@@ -8,6 +9,7 @@ const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const PreloadWebpackPlugin = require('preload-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
+const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const markdownIt = require('markdown-it')
 const linkAttributes = require('markdown-it-link-attributes')
 
@@ -111,6 +113,26 @@ function _getPlugins({ apps, config, envVars, stats, defineVars, publicPaths, is
 
   // Production only plugins
   if (isProduction) {
+    // Sentry source-maps plugin
+    const SENTRY_RELEASE = 'gp-explorer@v' + version
+    const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN
+
+    if (SENTRY_AUTH_TOKEN) {
+      plugins.push(
+        new SentryWebpackPlugin({
+          // sentry-cli configuration - can also be done directly through sentry-cli
+          // see https://docs.sentry.io/product/cli/configuration/ for details
+          authToken: SENTRY_AUTH_TOKEN,
+          org: 'gnosis-protocol',
+          project: 'gp-explorer',
+          release: SENTRY_RELEASE,
+          // other SentryWebpackPlugin configuration
+          include: './dist',
+          ignore: ['node_modules', 'webpack.config.js'],
+        }),
+      )
+    }
+
     // Inline chunk html plugin: Inlines script chunks into index.html
     plugins.push(new InlineChunkHtmlPlugin(HtmlWebPackPlugin, [/runtime/]))
 

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@babel/register": "^7.8.3",
     "@fortawesome/fontawesome-common-types": "^0.2.26",
     "@hookform/devtools": "^2.2.1",
+    "@sentry/webpack-plugin": "^1.17.1",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-essentials": "^6.2.9",
     "@storybook/addon-knobs": "^6.2.9",

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -27,7 +27,7 @@ const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RAT
 
 if (SENTRY_DSN) {
   Sentry.init({
-    dsn: process.env.REACT_APP_SENTRY_DSN,
+    dsn: SENTRY_DSN,
     integrations: [new Integrations.BrowserTracing()],
     release: 'gp-explorer@v' + version,
     environment: environmentName,

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -29,7 +29,7 @@ if (SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     integrations: [new Integrations.BrowserTracing()],
-    release: 'gp-explorer@' + version,
+    release: 'gp-explorer@v' + version,
     environment: environmentName,
 
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ const EXPLORER_APP = {
     OPERATOR_URL_PROD_XDAI: 'https://protocol-xdai.gnosis.io/api',
 
     GOOGLE_ANALYTICS_ID: undefined,
+    REACT_APP_SENTRY_DSN: undefined,
   },
 }
 const SAFE_SWAP_APP = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,7 +2821,6 @@
     "@sentry/types" "6.12.0"
     tslib "^1.9.3"
 
-<<<<<<< HEAD
 "@sentry/utils@6.13.2":
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.13.2.tgz#fb8010e7b67cc8c084d8067d64ef25289269cda5"
@@ -2829,14 +2828,13 @@
   dependencies:
     "@sentry/types" "6.13.2"
     tslib "^1.9.3"
-=======
+
 "@sentry/webpack-plugin@^1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.17.1.tgz#1b3ebbe9991e4d77125ace2b24594059a088268a"
   integrity sha512-L47a0hxano4a+9jbvQSBzHCT1Ph8fYAvGGUvFg8qc69yXS9si5lXRNIH/pavN6mqJjhQjAcEsEp+vxgvT4xZDQ==
   dependencies:
     "@sentry/cli" "^1.68.0"
->>>>>>> added source-maps for sentry
 
 "@sideway/address@^4.1.0":
   version "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,6 +2721,18 @@
     "@sentry/utils" "6.12.0"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.68.0":
+  version "1.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.68.0.tgz#2ced8fac67ee01e746a45e8ee45a518d4526937e"
+  integrity sha512-zc7+cxKDqpHLREGJKRH6KwE8fZW8bnczg3OLibJ0czleXoWPdAuOK1Xm1BTMcOnaXfg3VKAh0rI7S1PTdj+SrQ==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    npmlog "^4.1.2"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@sentry/core@6.12.0":
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.12.0.tgz#bc7c5f0785b6a392d9ad47bd9b1fae3f5389996c"
@@ -2809,6 +2821,7 @@
     "@sentry/types" "6.12.0"
     tslib "^1.9.3"
 
+<<<<<<< HEAD
 "@sentry/utils@6.13.2":
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.13.2.tgz#fb8010e7b67cc8c084d8067d64ef25289269cda5"
@@ -2816,6 +2829,14 @@
   dependencies:
     "@sentry/types" "6.13.2"
     tslib "^1.9.3"
+=======
+"@sentry/webpack-plugin@^1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.17.1.tgz#1b3ebbe9991e4d77125ace2b24594059a088268a"
+  integrity sha512-L47a0hxano4a+9jbvQSBzHCT1Ph8fYAvGGUvFg8qc69yXS9si5lXRNIH/pavN6mqJjhQjAcEsEp+vxgvT4xZDQ==
+  dependencies:
+    "@sentry/cli" "^1.68.0"
+>>>>>>> added source-maps for sentry
 
 "@sideway/address@^4.1.0":
   version "4.1.2"


### PR DESCRIPTION
# Summary
This will provide source maps support in sentry console which will make easier to debug errors in production.

![131670516-1d3644ea-8ce5-4a55-9dfd-7b4e127ad6c5](https://user-images.githubusercontent.com/34926005/133283725-0c08a23e-bd5a-49bc-9bd8-3f04998f8b62.png)

# To Test
- source maps support should be visible in the sentry console after the deployment of source code with this valid sentry authToken

# Background
- the sentry-webpack-plugin will only be added if the REACT_APP_SENTRY_AUTH_TOKEN is defined as a env variable. The value of this variable is the authToken provided by sentry.
