### PR TITLE
685/xdai rpc endpoint

### DIFF
--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -47,7 +47,7 @@ export function getProviderByNetwork(networkId: Network | null): string | undefi
     case Network.Rinkeby:
       return infuraProvider(networkId)
     case Network.xDAI:
-      return 'wss://xdai.poanetwork.dev/wss'
+      return 'https://dai.poa.network'
     default:
       return undefined
   }

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -47,7 +47,7 @@ export function getProviderByNetwork(networkId: Network | null): string | undefi
     case Network.Rinkeby:
       return infuraProvider(networkId)
     case Network.xDAI:
-      return 'wss://rpc.xdaichain.com/wss'
+      return 'wss://xdai.poanetwork.dev/wss'
     default:
       return undefined
   }


### PR DESCRIPTION
# Summary

Part of #685 

Quick fix using HTTPS Cloudflare's xDai endpoint instead of default WSS one

# To Test

1. Using the PR's link, load `/xdai/address/0x5B0ABE214aB7875562ADeE331dEfF0Fe1912FE42`
2. All information should be available

# Background

Right now, we have reports that there's no data for xDai. It seems that `wss://rpc.xdaichain.com/wss` is the culprit.
A more resilient solution is being worked on by @henrypalacios 

