### PR TITLE
Create buttons component to paginate user orders table

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@storybook/addon-knobs": "^6.2.9",
     "@storybook/addon-links": "^6.2.9",
     "@storybook/react": "^6.2.9",
+    "@testing-library/react-hooks": "^7.0.2",
     "@truffle/hdwallet-provider": "^1.2.0",
     "@types/bn.js": "^4.11.6",
     "@types/combine-reducers": "^1.0.0",

--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -1,15 +1,33 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import OrdersTable from 'components/orders/OrdersUserDetailsTable'
 import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
 import { OrdersTableContext } from './context/OrdersTableContext'
+import useFirstRender from 'hooks/useFirstRender'
 
 export const OrdersTableWithData: React.FC = () => {
-  const { orders, isFirstLoading } = useContext(OrdersTableContext)
+  const { orders } = useContext(OrdersTableContext)
+  const isFirstRender = useFirstRender()
+  const [isFirstLoading, setIsFirstLoading] = useState(true)
 
-  return isFirstLoading ? (
+  useEffect(() => {
+    let timeOutSeconds = 0
+    if (!orders.length) {
+      timeOutSeconds = 3
+    }
+
+    const timeOutId: NodeJS.Timeout = setTimeout(() => {
+      setIsFirstLoading(false)
+    }, timeOutSeconds * 1000)
+
+    return (): void => {
+      clearTimeout(timeOutId)
+    }
+  }, [orders.length])
+
+  return isFirstRender || isFirstLoading ? (
     <EmptyItemWrapper>
       <FontAwesomeIcon icon={faSpinner} spin size="3x" />
     </EmptyItemWrapper>

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -37,6 +37,9 @@ const PaginationDropdownButton = styled.button`
     opacity: 0.5;
     pointer-events: none;
   }
+  &:hover span {
+    color: ${({ theme }): string => theme.textActive1};
+  }
 `
 
 const PaginationText = styled.p`
@@ -81,32 +84,63 @@ const PaginationButton = styled.button`
       color: ${({ theme }): string => theme.textActive1};
     }
   }
+
   &[disabled],
   &[disabled]:hover {
     cursor: not-allowed;
     opacity: 0.5;
-
     .fill {
       color: ${({ theme }): string => theme.textSecondary1};
     }
   }
 `
+PaginationButton.defaultProps = { disabled: true }
 
 const PaginationOrdersTable: React.FC = () => {
   const {
-    isFirstLoading,
-    tableState: { pageSize, pageOffset },
+    isOrdersLoading: isLoading,
+    tableState: { pageSize, pageOffset, canNextPage },
     setPageSize,
-    orders,
+    setPageOffset,
+    orders: rows,
   } = useContext(OrdersTableContext)
   const quantityPerPage = [10, 20, 30, 50]
+
+  const handleNextPage = (): void => {
+    const newOffset = pageOffset + pageSize
+    setPageOffset(newOffset)
+  }
+  const handlePreviousPage = (): void => {
+    const newOffset = pageOffset - pageSize
+    setPageOffset(newOffset < 0 ? 0 : newOffset)
+  }
+  const renderPageLegend = (): string => {
+    if (isLoading && !rows.length) return '.. - ..'
+
+    let startPageCount = 0
+    let endPageCount = 0
+    if (rows.length) {
+      startPageCount = pageOffset + 1
+      endPageCount = pageOffset + rows.length
+    }
+
+    return `${startPageCount} - ${endPageCount}`
+  }
+  const canPreviousPage = (): boolean => {
+    if (isLoading) return false
+    return pageOffset > 0 ? true : false
+  }
 
   return (
     <PaginationWrapper>
       <PaginationText>Rows per page:</PaginationText>
       <DropdownPagination
-        disabled={isFirstLoading}
-        dropdownButtonContent={<PaginationDropdownButton>{pageSize} ▼</PaginationDropdownButton>}
+        disabled={isLoading}
+        dropdownButtonContent={
+          <PaginationDropdownButton>
+            {pageSize} <span>▼</span>
+          </PaginationDropdownButton>
+        }
         dropdownButtonContentOpened={
           <PaginationDropdownButton className="selected">{pageSize} ▲</PaginationDropdownButton>
         }
@@ -117,13 +151,11 @@ const PaginationOrdersTable: React.FC = () => {
           </PaginationItem>
         ))}
       />
-      <PaginationText className="legend">
-        {pageOffset + 1 === 1 ? 1 : pageOffset * pageSize + 1} - {orders.length && pageOffset + orders.length}
-      </PaginationText>{' '}
-      <PaginationButton disabled={true} onClick={(): void => console.log('Left')}>
+      <PaginationText className="legend">{renderPageLegend()}</PaginationText>{' '}
+      <PaginationButton disabled={!canPreviousPage()} onClick={handlePreviousPage}>
         <Icon icon={faChevronLeft} className="fill" />
       </PaginationButton>
-      <PaginationButton disabled={!true} onClick={(): void => console.log('Right')}>
+      <PaginationButton disabled={!canNextPage} onClick={handleNextPage}>
         <Icon icon={faChevronRight} className="fill" />
       </PaginationButton>
     </PaginationWrapper>

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react'
 import styled, { css } from 'styled-components'
+// import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons'
+// import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { Dropdown, DropdownOption } from 'apps/explorer/components/common/Dropdown'
 import { OrdersTableContext } from './context/OrdersTableContext'
@@ -49,6 +51,9 @@ const PaginationItem = styled(DropdownOption)`
   padding: 0 1rem;
   white-space: nowrap;
 `
+// const Icon = styled(FontAwesomeIcon)`
+//   padding-left: 5rem;
+// `
 
 const PaginationOrdersTable: React.FC = () => {
   const {

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -99,7 +99,7 @@ PaginationButton.defaultProps = { disabled: true }
 const PaginationOrdersTable: React.FC = () => {
   const {
     isOrdersLoading: isLoading,
-    tableState: { pageSize, pageOffset, canNextPage },
+    tableState: { pageSize, pageOffset, hasNextPage },
     setPageSize,
     setPageOffset,
     orders: rows,
@@ -126,7 +126,7 @@ const PaginationOrdersTable: React.FC = () => {
 
     return `${startPageCount} - ${endPageCount}`
   }
-  const canPreviousPage = (): boolean => {
+  const hasPreviousPage = (): boolean => {
     if (isLoading) return false
     return pageOffset > 0 ? true : false
   }
@@ -152,10 +152,10 @@ const PaginationOrdersTable: React.FC = () => {
         ))}
       />
       <PaginationText className="legend">{renderPageLegend()}</PaginationText>{' '}
-      <PaginationButton disabled={!canPreviousPage()} onClick={handlePreviousPage}>
+      <PaginationButton disabled={!hasPreviousPage()} onClick={handlePreviousPage}>
         <Icon icon={faChevronLeft} className="fill" />
       </PaginationButton>
-      <PaginationButton disabled={!canNextPage} onClick={handleNextPage}>
+      <PaginationButton disabled={!hasNextPage} onClick={handleNextPage}>
         <Icon icon={faChevronRight} className="fill" />
       </PaginationButton>
     </PaginationWrapper>

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -101,19 +101,12 @@ const PaginationOrdersTable: React.FC = () => {
     isOrdersLoading: isLoading,
     tableState: { pageSize, pageOffset, hasNextPage },
     setPageSize,
-    setPageOffset,
+    handleNextPage,
+    handlePreviousPage,
     orders: rows,
   } = useContext(OrdersTableContext)
   const quantityPerPage = [10, 20, 30, 50]
 
-  const handleNextPage = (): void => {
-    const newOffset = pageOffset + pageSize
-    setPageOffset(newOffset)
-  }
-  const handlePreviousPage = (): void => {
-    const newOffset = pageOffset - pageSize
-    setPageOffset(newOffset < 0 ? 0 : newOffset)
-  }
   const renderPageLegend = (): string => {
     if (isLoading && !rows.length) return '.. - ..'
 

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import styled, { css } from 'styled-components'
-// import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons'
-// import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { Dropdown, DropdownOption } from 'apps/explorer/components/common/Dropdown'
 import { OrdersTableContext } from './context/OrdersTableContext'
@@ -41,6 +41,9 @@ const PaginationDropdownButton = styled.button`
 
 const PaginationText = styled.p`
   margin-right: 0.8rem;
+  &.legend {
+    margin-left: 2rem;
+  }
 `
 
 const PaginationItem = styled(DropdownOption)`
@@ -51,15 +54,50 @@ const PaginationItem = styled(DropdownOption)`
   padding: 0 1rem;
   white-space: nowrap;
 `
-// const Icon = styled(FontAwesomeIcon)`
-//   padding-left: 5rem;
-// `
+const Icon = styled(FontAwesomeIcon)`
+  width: 2rem !important;
+  height: 2rem;
+  color: ${({ theme }): string => theme.textSecondary1};
+  .fill {
+    color: ${({ theme }): string => theme.textActive1};
+  }
+`
+const PaginationButton = styled.button`
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  height: auto;
+  outline: none;
+  padding: 0;
+  user-select: none;
+  width: 3.5rem;
+  white-space: nowrap;
+
+  &:hover {
+    .fill {
+      color: ${({ theme }): string => theme.textActive1};
+    }
+  }
+  &[disabled],
+  &[disabled]:hover {
+    cursor: not-allowed;
+    opacity: 0.5;
+
+    .fill {
+      color: ${({ theme }): string => theme.textSecondary1};
+    }
+  }
+`
 
 const PaginationOrdersTable: React.FC = () => {
   const {
     isFirstLoading,
-    tableState: { pageSize },
+    tableState: { pageSize, pageOffset },
     setPageSize,
+    orders,
   } = useContext(OrdersTableContext)
   const quantityPerPage = [10, 20, 30, 50]
 
@@ -79,6 +117,15 @@ const PaginationOrdersTable: React.FC = () => {
           </PaginationItem>
         ))}
       />
+      <PaginationText className="legend">
+        {pageOffset + 1 === 1 ? 1 : pageOffset * pageSize + 1} - {orders.length && pageOffset + orders.length}
+      </PaginationText>{' '}
+      <PaginationButton disabled={true} onClick={(): void => console.log('Left')}>
+        <Icon icon={faChevronLeft} className="fill" />
+      </PaginationButton>
+      <PaginationButton disabled={!true} onClick={(): void => console.log('Right')}>
+        <Icon icon={faChevronRight} className="fill" />
+      </PaginationButton>
     </PaginationWrapper>
   )
 }

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -119,7 +119,7 @@ const PaginationOrdersTable: React.FC = () => {
 
     return `${startPageCount} - ${endPageCount}`
   }
-  const hasPreviousPage = !isLoading && Boolean(pageOffset > 0)
+  const hasPreviousPage = !isLoading && pageOffset > 0
 
   return (
     <PaginationWrapper>

--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -119,10 +119,7 @@ const PaginationOrdersTable: React.FC = () => {
 
     return `${startPageCount} - ${endPageCount}`
   }
-  const hasPreviousPage = (): boolean => {
-    if (isLoading) return false
-    return pageOffset > 0 ? true : false
-  }
+  const hasPreviousPage = !isLoading && Boolean(pageOffset > 0)
 
   return (
     <PaginationWrapper>
@@ -145,7 +142,7 @@ const PaginationOrdersTable: React.FC = () => {
         ))}
       />
       <PaginationText className="legend">{renderPageLegend()}</PaginationText>{' '}
-      <PaginationButton disabled={!hasPreviousPage()} onClick={handlePreviousPage}>
+      <PaginationButton disabled={!hasPreviousPage} onClick={handlePreviousPage}>
         <Icon icon={faChevronLeft} className="fill" />
       </PaginationButton>
       <PaginationButton disabled={!hasNextPage} onClick={handleNextPage}>

--- a/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
@@ -6,9 +6,10 @@ import { TableState } from 'apps/explorer/components/OrdersTableWidget/useTable'
 interface CommonState {
   orders: Order[]
   error: string
-  isFirstLoading: boolean
-  setPageSize: (pageSize: number) => void
+  isOrdersLoading: boolean
   tableState: TableState
+  setPageSize: (pageSize: number) => void
+  setPageOffset: (pageOffset: number) => void
 }
 
 export const OrdersTableContext = React.createContext({} as CommonState)

--- a/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/context/OrdersTableContext.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
 
 import { Order } from 'api/operator'
-import { TableState } from 'apps/explorer/components/OrdersTableWidget/useTable'
+import { TableState, TableStateSetters } from 'apps/explorer/components/OrdersTableWidget/useTable'
 
-interface CommonState {
+type CommonState = {
   orders: Order[]
   error: string
   isOrdersLoading: boolean
   tableState: TableState
-  setPageSize: (pageSize: number) => void
-  setPageOffset: (pageOffset: number) => void
-}
+} & TableStateSetters
 
 export const OrdersTableContext = React.createContext({} as CommonState)

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -47,17 +47,24 @@ interface Props {
 }
 
 const OrdersTableWidget: React.FC<Props> = ({ ownerAddress }) => {
-  const { state: tableState, setPageSize, setPageOffset } = useTable({ initialState: { pageOffset: 0, pageSize: 20 } })
+  const {
+    state: tableState,
+    setPageSize,
+    handleNextPage,
+    handlePreviousPage,
+  } = useTable({ initialState: { pageOffset: 0, pageSize: 20 } })
   const {
     orders,
     isLoading: isOrdersLoading,
     error,
     isThereNext: isThereNextOrder,
-  } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageOffset)
+  } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageOffset, tableState.pageIndex)
   tableState['hasNextPage'] = isThereNextOrder
 
   return (
-    <OrdersTableContext.Provider value={{ orders, error, isOrdersLoading, tableState, setPageSize, setPageOffset }}>
+    <OrdersTableContext.Provider
+      value={{ orders, error, isOrdersLoading, tableState, setPageSize, handleNextPage, handlePreviousPage }}
+    >
       <ExplorerTabs tabItems={tabItems(isOrdersLoading)} extra={ExtraComponentNode} />
     </OrdersTableContext.Provider>
   )

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -54,7 +54,7 @@ const OrdersTableWidget: React.FC<Props> = ({ ownerAddress }) => {
     error,
     isThereNext: isThereNextOrder,
   } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageOffset)
-  tableState['canNextPage'] = isThereNextOrder
+  tableState['hasNextPage'] = isThereNextOrder
 
   return (
     <OrdersTableContext.Provider value={{ orders, error, isOrdersLoading, tableState, setPageSize, setPageOffset }}>

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -47,8 +47,8 @@ interface Props {
 }
 
 const OrdersTableWidget: React.FC<Props> = ({ ownerAddress }) => {
-  const { state: tableState, setPageSize } = useTable({ initialState: { pageIndex: 0, pageSize: 20 } })
-  const { orders, isLoading, error } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageIndex)
+  const { state: tableState, setPageSize } = useTable({ initialState: { pageOffset: 0, pageSize: 20 } })
+  const { orders, isLoading, error } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageOffset)
 
   const isFirstLoading = useMemo(() => {
     if (isLoading && orders.length === 0) return true

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -47,18 +47,18 @@ interface Props {
 }
 
 const OrdersTableWidget: React.FC<Props> = ({ ownerAddress }) => {
-  const { state: tableState, setPageSize } = useTable({ initialState: { pageOffset: 0, pageSize: 20 } })
-  const { orders, isLoading, error } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageOffset)
-
-  const isFirstLoading = useMemo(() => {
-    if (isLoading && orders.length === 0) return true
-
-    return false
-  }, [isLoading, orders.length])
+  const { state: tableState, setPageSize, setPageOffset } = useTable({ initialState: { pageOffset: 0, pageSize: 20 } })
+  const {
+    orders,
+    isLoading: isOrdersLoading,
+    error,
+    isThereNext: isThereNextOrder,
+  } = useGetOrders(ownerAddress, tableState.pageSize, tableState.pageOffset)
+  tableState['canNextPage'] = isThereNextOrder
 
   return (
-    <OrdersTableContext.Provider value={{ orders, error, isFirstLoading, setPageSize, tableState }}>
-      <ExplorerTabs tabItems={tabItems(isLoading)} extra={ExtraComponentNode} />
+    <OrdersTableContext.Provider value={{ orders, error, isOrdersLoading, tableState, setPageSize, setPageOffset }}>
+      <ExplorerTabs tabItems={tabItems(isOrdersLoading)} extra={ExtraComponentNode} />
     </OrdersTableContext.Provider>
   )
 }

--- a/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
@@ -23,7 +23,7 @@ type Result = {
   isThereNext: boolean
 }
 
-export function useGetOrders(ownerAddress: string, limit = 1000, offset = 0): Result {
+export function useGetOrders(ownerAddress: string, limit = 1000, offset = 0, pageIndex?: number): Result {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [orders, setOrders] = useState<Order[]>([])
@@ -83,6 +83,8 @@ export function useGetOrders(ownerAddress: string, limit = 1000, offset = 0): Re
     setIsThereNext(false)
     fetchOrders(networkId, ownerAddress)
 
+    if (pageIndex && pageIndex > 1) return
+
     const intervalId: NodeJS.Timeout = setInterval(() => {
       fetchOrders(networkId, ownerAddress)
     }, ORDERS_QUERY_INTERVAL)
@@ -90,7 +92,7 @@ export function useGetOrders(ownerAddress: string, limit = 1000, offset = 0): Re
     return (): void => {
       clearInterval(intervalId)
     }
-  }, [fetchOrders, networkId, ownerAddress])
+  }, [fetchOrders, networkId, ownerAddress, pageIndex])
 
   useEffect(() => {
     if (areErc20Loading || isObjectEmpty(valueErc20s) || !mountNewOrders) {

--- a/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useGetOrders.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react'
 
 import { Network } from 'types'
 import { useMultipleErc20 } from 'hooks/useErc20'
-import { getAccountOrders, Order, RawOrder } from 'api/operator'
+import { getAccountOrders, Order } from 'api/operator'
 import { useNetworkId } from 'state/network'
 import { transformOrder } from 'utils'
 import { ORDERS_QUERY_INTERVAL } from 'apps/explorer/const'
@@ -38,16 +38,13 @@ export function useGetOrders(ownerAddress: string, limit = 1000, offset = 0, pag
       setIsLoading(true)
       setError('')
       const limitPlusOne = limit + 1
-      const checkForNext = (_orders: RawOrder[]): void => {
-        if (_orders.length === limitPlusOne) {
-          setIsThereNext(true)
-          _orders.pop()
-        }
-      }
 
       try {
         const ordersFetched = await getAccountOrders({ networkId: network, owner, offset, limit: limitPlusOne })
-        checkForNext(ordersFetched)
+        if (ordersFetched.length === limitPlusOne) {
+          setIsThereNext(true)
+          ordersFetched.pop()
+        }
         const newErc20Addresses = ordersFetched.reduce((accumulator: string[], element) => {
           const updateAccumulator = (tokenAddress: string): void => {
             if (accumulator.indexOf(tokenAddress) === -1) {

--- a/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 export interface TableState {
   pageSize: number
   pageOffset: number
+  canNextPage?: boolean
 }
 
 export interface TableOptions {
@@ -12,7 +13,7 @@ export interface TableOptions {
 interface TableStateAndSetters {
   state: TableState
   setPageSize: (pageSize: number) => void
-  setPageOffset: (pageOffset: number) => void
+  setPageOffset: (pageOffset: number) => void | number
 }
 
 export function useTable(options: TableOptions): TableStateAndSetters {
@@ -22,7 +23,7 @@ export function useTable(options: TableOptions): TableStateAndSetters {
   const [pageSize, setPageSize] = useState(initialPageSize)
   const [pageOffset, setPageOffset] = useState(initialOffset)
 
-  const state: TableState = { pageSize, pageOffset }
+  const state = { pageSize, pageOffset }
 
   return { state, setPageSize, setPageOffset }
 }

--- a/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 export interface TableState {
   pageSize: number
   pageOffset: number
-  canNextPage?: boolean
+  hasNextPage?: boolean
 }
 
 export interface TableOptions {
@@ -20,10 +20,15 @@ export function useTable(options: TableOptions): TableStateAndSetters {
   const {
     initialState: { pageSize: initialPageSize, pageOffset: initialOffset },
   } = options
-  const [pageSize, setPageSize] = useState(initialPageSize)
+  const [pageSize, _setPageSize] = useState(initialPageSize)
   const [pageOffset, setPageOffset] = useState(initialOffset)
 
   const state = { pageSize, pageOffset }
+
+  const setPageSize = (newValue: number): void => {
+    _setPageSize(newValue)
+    setPageOffset(0)
+  }
 
   return { state, setPageSize, setPageOffset }
 }

--- a/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
@@ -35,10 +35,12 @@ export function useTable(options: TableOptions): TableStateAndSetters {
   })
 
   const setPageSize = (newValue: number): void => {
+    const offsetRestarted = 0
     setState({
       ...state,
       pageSize: newValue,
-      pageOffset: 0,
+      pageOffset: offsetRestarted,
+      pageIndex: getPageIndex(offsetRestarted, newValue),
     })
   }
 

--- a/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useTable.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 export interface TableState {
   pageSize: number
-  pageIndex: number
+  pageOffset: number
 }
 
 export interface TableOptions {
@@ -12,15 +12,17 @@ export interface TableOptions {
 interface TableStateAndSetters {
   state: TableState
   setPageSize: (pageSize: number) => void
+  setPageOffset: (pageOffset: number) => void
 }
 
 export function useTable(options: TableOptions): TableStateAndSetters {
   const {
-    initialState: { pageSize: initialPageSize },
+    initialState: { pageSize: initialPageSize, pageOffset: initialOffset },
   } = options
   const [pageSize, setPageSize] = useState(initialPageSize)
-  const pageIndex = 0
-  const state: TableState = { pageSize, pageIndex }
+  const [pageOffset, setPageOffset] = useState(initialOffset)
 
-  return { state, setPageSize }
+  const state: TableState = { pageSize, pageOffset }
+
+  return { state, setPageSize, setPageOffset }
 }

--- a/src/hooks/useFirstRender.tsx
+++ b/src/hooks/useFirstRender.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function useFirstRender(): boolean {
+  const firstRender = React.useRef(true)
+
+  React.useEffect(() => {
+    firstRender.current = false
+  }, [])
+
+  return firstRender.current
+}

--- a/test/hooks/useTable.test.tsx
+++ b/test/hooks/useTable.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import { useTable } from 'apps/explorer/components/OrdersTableWidget/useTable'
+
+describe('when rendered', () => {
+  it('returns current initial value', () => {
+    const { result } = renderHook(() => useTable({ initialState: { pageOffset: 0, pageSize: 50 } }))
+
+    expect(result.current.state.pageSize).toEqual(50)
+    expect(result.current.state.pageOffset).toEqual(0)
+    expect(result.current.state.pageIndex).toEqual(1)
+  })
+
+  it('should restarted tableState when setPage is used', () => {
+    const { result } = renderHook(() => useTable({ initialState: { pageOffset: 20, pageSize: 20 } }))
+    // Given
+    expect(result.current.state).toMatchObject({ pageIndex: 2, pageOffset: 20, pageSize: 20 })
+
+    // When
+    act(() => {
+      result.current.setPageSize(50)
+    })
+
+    // Result
+    expect(result.current.state).toMatchObject({ pageIndex: 1, pageOffset: 0, pageSize: 50 })
+  })
+
+  it('should increase pageOffset, pageIndex when handleNextPage', () => {
+    const { result } = renderHook(() => useTable({ initialState: { pageOffset: 0, pageSize: 20 } }))
+
+    act(() => {
+      result.current.handleNextPage()
+    })
+
+    expect(result.current.state).toMatchObject({ pageIndex: 2, pageOffset: 20, pageSize: 20 })
+  })
+
+  it('should  decrease pageOffset, pageIndex when handlePreviousPage', () => {
+    const { result } = renderHook(() => useTable({ initialState: { pageOffset: 60, pageSize: 20 } }))
+    expect(result.current.state).toMatchObject({ pageIndex: 4, pageOffset: 60, pageSize: 20 })
+
+    act(() => {
+      result.current.handlePreviousPage()
+    })
+
+    expect(result.current.state).toMatchObject({ pageIndex: 3, pageOffset: 40, pageSize: 20 })
+  })
+})

--- a/test/utils/paginationHelper.test.ts
+++ b/test/utils/paginationHelper.test.ts
@@ -1,0 +1,19 @@
+import { getPageIndex } from 'apps/explorer/components/OrdersTableWidget/useTable'
+
+describe('Is token an ERC20', () => {
+  test('should return 1 when offset is smaller than the page size', () => {
+    expect(getPageIndex(0, 10)).toEqual(1)
+  })
+
+  test('should return 2 when offsets is equals than the page size', () => {
+    expect(getPageIndex(20, 20)).toEqual(2)
+  })
+
+  test('should return 3 when offsets is between one half and one quarter of 100/20', () => {
+    expect(getPageIndex(59, 20)).toEqual(3)
+  })
+
+  test('should return 4 when offsets is one quarter of 100/20', () => {
+    expect(getPageIndex(60, 20)).toEqual(4)
+  })
+})

--- a/test/utils/paginationHelper.test.ts
+++ b/test/utils/paginationHelper.test.ts
@@ -1,6 +1,6 @@
 import { getPageIndex } from 'apps/explorer/components/OrdersTableWidget/useTable'
 
-describe('Is token an ERC20', () => {
+describe('Calculate pageIndex from offsets through pageSize', () => {
   test('should return 1 when offset is smaller than the page size', () => {
     expect(getPageIndex(0, 10)).toEqual(1)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3617,6 +3617,17 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -4053,7 +4064,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@*":
+"@types/react-dom@*", "@types/react-dom@>=16.9.0":
   version "17.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.9.tgz#441a981da9d7be117042e1a6fd3dac4b30f55add"
   integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
@@ -4107,6 +4118,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@*", "@types/react-transition-group@^4.2.0":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.2.tgz#38890fd9db68bf1f2252b99a942998dc7877c5b3"
@@ -4118,6 +4136,15 @@
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.17.tgz#1772d3d5425128e0635a716f49ef57c2955df055"
   integrity sha512-nrfi7I13cAmrd0wje8czYpf5SFbryczCtPzFc6ijqvdjKcyA3tCvGxwchOUlxb2ucBPuJ9Y3oUqKrRqZvrz0lw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.27"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.27.tgz#6498ed9b3ad117e818deb5525fa1946c09f2e0e6"
+  integrity sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -16317,6 +16344,13 @@ react-element-to-jsx-string@^14.3.2:
   dependencies:
     "@base2/pretty-print-object" "1.0.0"
     is-plain-object "3.0.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
+  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
# Summary

Closes #687, #684 

- [x] Create a button component with arrows.
- [x] Use a component in top tab header with a legend of page count.
- [x] Handle button click to paginate the next or previous page.

## To Test
1. (687-Pager) -> Go to  https://pr694--gpui.review.gnosisdev.com/rinkeby/address/0xFF714b8b0e2700303eC912BD40496C3997ceEa2b/

2. (684-EmptyTable) Go to  https://pr694--gpui.review.gnosisdev.com/address/0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9/

### Reference

- [Figma proposal](https://www.figma.com/file/m7obOydxAhGNmlFYvxTk3Z/GP-Explorer?node-id=683%3A1280)

