### PR TITLE
[Explorer] Orders table responsive

### DIFF
--- a/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/PaginationOrdersTable.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import styled, { css } from 'styled-components'
 import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { media } from 'theme/styles/media'
 
 import { Dropdown, DropdownOption } from 'apps/explorer/components/common/Dropdown'
 import { OrdersTableContext } from './context/OrdersTableContext'
@@ -46,6 +47,11 @@ const PaginationText = styled.p`
   margin-right: 0.8rem;
   &.legend {
     margin-left: 2rem;
+  }
+  ${media.mediumDown} {
+    &:not(.legend) {
+      display: none;
+    }
   }
 `
 

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -38,10 +38,15 @@ const StyledTabs = styled.div`
 
   .tab-extra-content {
     width: 100%;
-
     @media ${MEDIA.mobile} {
       display: none; /* for now we can hide the extra-content on mobiles */
     }
+  }
+  @media ${MEDIA.mobile} {
+    > div > div.tab-content {
+      padding: 0;
+    }
+    border: none;
   }
 `
 const tabCustomThemeConfig = getTabTheme({

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTab.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import Tabs, { getTabTheme, Props as TabsProps, IndicatorTabSize } from 'components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, Props as TabsProps, IndicatorTabSize, TabList } from 'components/common/Tabs/Tabs'
 import { DARK_COLOURS } from 'theme'
-import { MEDIA } from 'const'
+import { media } from 'theme/styles/media'
 
 const StyledTabs = styled.div`
   display: flex;
@@ -13,13 +13,13 @@ const StyledTabs = styled.div`
   border-radius: 4px;
   min-height: 33rem;
 
-  > div > div.tablist {
+  ${TabList} {
     justify-content: flex-start;
     border-bottom: ${({ theme }): string => `1px solid ${theme.borderPrimary}`};
     box-sizing: border-box;
   }
 
-  > div > div.tablist > button {
+  ${TabList} > button {
     flex: 0 0 auto;
     min-width: 96px;
     padding: 12px 0.8rem;
@@ -32,20 +32,17 @@ const StyledTabs = styled.div`
     height: 100%;
   }
 
-  > div > div.tab-content {
+  .tab-content {
     padding: 20px 16px;
+    ${media.mediumDown} {
+      padding: 0;
+    }
   }
 
   .tab-extra-content {
     width: 100%;
-    @media ${MEDIA.mobile} {
-      display: none; /* for now we can hide the extra-content on mobiles */
-    }
   }
-  @media ${MEDIA.mobile} {
-    > div > div.tab-content {
-      padding: 0;
-    }
+  ${media.mediumDown} {
     border: none;
   }
 `

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -64,7 +64,8 @@ export function CopyButton(props: Props): JSX.Element {
   return (
     <CopyToClipboard text={text} onCopy={handleOnCopy}>
       <span>
-        <Icon icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} /> {copied && <span>Copied</span>}
+        <Icon icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} />{' '}
+        {copied && <span className="copy-text">Copied</span>}
       </span>
     </CopyToClipboard>
   )

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -53,7 +53,9 @@ const Wrapper = styled.div`
   }
 `
 
-export const TabList = styled.div
+export const TabList = styled.div`
+  /* stylelint-disable no-empty-block */
+`
 
 export const DEFAULT_TAB_THEME: TabTheme = {
   activeBg: 'var(--color-transparent)',

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -53,6 +53,8 @@ const Wrapper = styled.div`
   }
 `
 
+export const TabList = styled.div
+
 export const DEFAULT_TAB_THEME: TabTheme = {
   activeBg: 'var(--color-transparent)',
   activeBgAlt: 'initial',
@@ -85,7 +87,7 @@ const Tabs: React.FC<Props> = (props) => {
 
   return (
     <Wrapper>
-      <div role="tablist" className="tablist">
+      <TabList role="tablist" className="tablist">
         {tabItems.map(({ tab, id }) => (
           <TabItem
             key={id}
@@ -97,7 +99,7 @@ const Tabs: React.FC<Props> = (props) => {
           />
         ))}
         <ExtraContent extra={tabBarExtraContent} />
-      </div>
+      </TabList>
       <TabContent tabItems={tabItems} activeTab={activeTab} />
     </Wrapper>
   )

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
+import { MEDIA } from 'const'
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { Order } from 'api/operator'
@@ -21,6 +22,45 @@ const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
     grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) repeat(2, minmax(18rem, 2fr)) 1fr;
+  }
+
+  .header-title {
+    display: none;
+  }
+
+  @media ${MEDIA.mobile} {
+    > thead > tr {
+      display: none;
+    }
+    > tbody > tr {
+      border: 0.1rem solid rgb(151 151 184 / 10%);
+      border-radius: 6px;
+      margin-top: 16px;
+    }
+    tr > td:first-of-type {
+      margin: 0;
+    }
+    tr > td {
+      display: flex;
+      flex: 1;
+      width: 100%;
+      justify-content: space-between;
+      margin: 0;
+      line-height: 2;
+    }
+    .header-title {
+      font-weight: 600;
+      align-items: center;
+      display: flex;
+      svg {
+        margin-left: 5px;
+      }
+    }
+    .span-copybtn-wrap {
+      span {
+        display: inline-flex;
+      }
+    }
   }
   overflow: auto;
 `
@@ -48,41 +88,61 @@ export type Props = StyledUserDetailsTableProps & {
 
 interface RowProps {
   order: Order
-  isPriceInverted: boolean
+  _isPriceInverted: boolean
 }
 
-const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
+const RowOrder: React.FC<RowProps> = ({ order, _isPriceInverted }) => {
   const { creationDate, buyToken, buyAmount, sellToken, sellAmount, kind, partiallyFilled, shortId, uid } = order
+  const [isPriceInverted, setIsPriceInverted] = useState(_isPriceInverted)
+
+  useEffect(() => {
+    setIsPriceInverted(_isPriceInverted)
+  }, [_isPriceInverted])
+
+  const invertLimitPrice = (): void => {
+    setIsPriceInverted((previousValue) => !previousValue)
+  }
 
   return (
     <tr key={shortId}>
       <td>
-        {
-          <RowWithCopyButton
-            className="span-copybtn-wrap"
-            textToCopy={uid}
-            contentsToDisplay={
-              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
-                {shortId}
-              </LinkWithPrefixNetwork>
-            }
-          />
-        }
+        <span className="header-title">
+          Order ID <HelpTooltip tooltip={tooltip.orderID} />
+        </span>
+        <RowWithCopyButton
+          className="span-copybtn-wrap"
+          textToCopy={uid}
+          contentsToDisplay={
+            <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
+              {shortId}
+            </LinkWithPrefixNetwork>
+          }
+        />
       </td>
       <td>
+        <span className="header-title">Type</span>
         <TradeOrderType kind={kind} />
       </td>
       <td>
+        <span className="header-title">Sell Amount</span>
         {formattedAmount(sellToken, sellAmount.plus(order.feeAmount))} {sellToken?.symbol}
       </td>
       <td>
+        <span className="header-title">Buy amount</span>
         {formattedAmount(buyToken, buyAmount)} {buyToken?.symbol}
       </td>
-      <td>{getLimitPrice(order, isPriceInverted)}</td>
       <td>
+        <span className="header-title">
+          Limit price <Icon icon={faExchangeAlt} onClick={invertLimitPrice} />
+        </span>
+        {getLimitPrice(order, isPriceInverted)}
+      </td>
+      <td>
+        <span className="header-title">Created</span>
         <DateDisplay date={creationDate} showIcon={true} />
       </td>
       <td>
+        <span className="header-title">Status</span>
         <StatusLabel status={order.status} partiallyFilled={partiallyFilled} />
       </td>
     </tr>
@@ -110,7 +170,7 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
     return (
       <>
         {items.map((item) => (
-          <RowOrder key={item.shortId} order={item} isPriceInverted={isPriceInverted} />
+          <RowOrder key={item.shortId} order={item} _isPriceInverted={isPriceInverted} />
         ))}
       </>
     )

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -40,16 +40,13 @@ const Wrapper = styled(StyledUserDetailsTable)`
         backdrop-filter: none;
       }
     }
-    tr > td:first-of-type {
-      margin: 0;
-    }
     tr > td {
       display: flex;
       flex: 1;
       width: 100%;
       justify-content: space-between;
       margin: 0;
-      line-height: 2.75;
+      margin-bottom: 18px;
     }
     .header-value {
       flex-wrap: wrap;
@@ -76,7 +73,7 @@ const HeaderTitle = styled.span`
     font-weight: 600;
     align-items: center;
     display: flex;
-    margin-right: 5rem;
+    margin-right: 3rem;
     svg {
       margin-left: 5px;
     }


### PR DESCRIPTION
# Summary

Closes #693 

Updated styles and some markup in order to support new design for Orders table to be responsive.


![image](https://user-images.githubusercontent.com/11525018/135931148-5e7e1d9f-3bcf-418c-a245-d8cb0b6bdbb7.png)

# To Test

1. Open the page `/rinkeby/address/<any address with orders>/` (i.e [0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9](https://pr721--gpui.review.gnosisdev.com/rinkeby/address/0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9/))
* View it in mobile view
* Design will change in order tu support responsive behavior 

