### PR TITLE
Retry endpoint when it does not return

### DIFF
--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -137,6 +137,13 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async name({ tokenAddress, networkId }: NameParams): Promise<string> {
+    if (Math.floor(Math.random() * 10) < 3) {
+      return new Promise(function (_resolve, reject) {
+        setTimeout(() => {
+          return reject(new Error('setTimeout Error'))
+        }, 1000)
+      })
+    }
     const name = this._getLocalErc20Property(tokenAddress, 'name')
     if (name) {
       return name
@@ -151,6 +158,13 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async symbol({ tokenAddress, networkId }: SymbolParams): Promise<string> {
+    if (Math.floor(Math.random() * 10) < 3) {
+      return new Promise(function (_resolve, reject) {
+        setTimeout(() => {
+          return reject(new Error('setTimeout Error'))
+        }, 1000)
+      })
+    }
     const symbol = this._getLocalErc20Property(tokenAddress, 'symbol')
     if (symbol) {
       return symbol
@@ -165,6 +179,13 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async decimals({ tokenAddress, networkId }: DecimalsParams): Promise<number> {
+    if (Math.floor(Math.random() * 10) < 3) {
+      return new Promise(function (_resolve, reject) {
+        setTimeout(() => {
+          return reject(new Error('setTimeout Error'))
+        }, 1000)
+      })
+    }
     const decimals = this._getLocalErc20Property(tokenAddress, 'decimals')
     if (decimals) {
       return decimals

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -137,13 +137,6 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async name({ tokenAddress, networkId }: NameParams): Promise<string> {
-    if (Math.floor(Math.random() * 10) < 3) {
-      return new Promise(function (_resolve, reject) {
-        setTimeout(() => {
-          return reject(new Error('setTimeout Error'))
-        }, 1000)
-      })
-    }
     const name = this._getLocalErc20Property(tokenAddress, 'name')
     if (name) {
       return name
@@ -158,13 +151,6 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async symbol({ tokenAddress, networkId }: SymbolParams): Promise<string> {
-    if (Math.floor(Math.random() * 10) < 3) {
-      return new Promise(function (_resolve, reject) {
-        setTimeout(() => {
-          return reject(new Error('setTimeout Error'))
-        }, 1000)
-      })
-    }
     const symbol = this._getLocalErc20Property(tokenAddress, 'symbol')
     if (symbol) {
       return symbol
@@ -179,13 +165,6 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async decimals({ tokenAddress, networkId }: DecimalsParams): Promise<number> {
-    if (Math.floor(Math.random() * 10) < 3) {
-      return new Promise(function (_resolve, reject) {
-        setTimeout(() => {
-          return reject(new Error('setTimeout Error'))
-        }, 1000)
-      })
-    }
     const decimals = this._getLocalErc20Property(tokenAddress, 'decimals')
     if (decimals) {
       return decimals

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -17,7 +17,19 @@ export function createWeb3Api(provider?: string): Web3 {
     return web3cache[_provider]
   }
   // TODO: Create an `EthereumApi` https://github.com/gnosis/gp-v1-ui/issues/331
-  const web3 = new Web3(_provider)
+  const web3 = new Web3(
+    _provider.startsWith('wss:')
+      ? new Web3.providers.WebsocketProvider(_provider, {
+          reconnect: {
+            auto: true,
+            delay: 5000,
+            maxAttempts: 5,
+            onTimeout: false,
+          },
+        })
+      : _provider,
+  )
+
   // `handleRevert = true` makes `require` failures to throw
   // For more details see https://github.com/gnosis/gp-v1-ui/issues/511
   web3.eth['handleRevert'] = true

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -16,7 +16,7 @@ import { getErc20Info } from 'services/helpers'
 import { web3, erc20Api } from 'apps/explorer/api'
 
 import { NATIVE_TOKEN_PER_NETWORK } from 'const'
-import { isNativeToken } from 'utils'
+import { isNativeToken, retry } from 'utils'
 
 async function _fetchErc20FromNetwork(params: {
   address: string
@@ -34,7 +34,7 @@ async function _fetchErc20FromNetwork(params: {
   }
 
   try {
-    return getErc20Info({ tokenAddress: address, networkId, web3, erc20Api })
+    return await retry(() => getErc20Info({ tokenAddress: address, networkId, web3, erc20Api }))
   } catch (e) {
     const msg = `Failed to fetch erc20 details for ${address} on network ${networkId}`
     console.error(msg, e)

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -16,13 +16,6 @@ interface Params {
  * Fetches info for an arbitrary ERC20 token from given address
  */
 export async function getErc20Info({ tokenAddress, networkId, erc20Api, web3 }: Params): Promise<TokenErc20 | null> {
-  if (Math.floor(Math.random() * 10) < 3) {
-    return new Promise(function (_resolve, reject) {
-      setTimeout(() => {
-        return reject(new Error('setTimeout Error'))
-      }, 1000)
-    })
-  }
   // First check whether given address is a contract
   const code = await web3.eth.getCode(tokenAddress)
   if (code === '0x') {

--- a/test/services/getErc20Info.test.ts
+++ b/test/services/getErc20Info.test.ts
@@ -1,0 +1,25 @@
+import BN from 'bn.js'
+
+import { getErc20Info } from 'services/helpers'
+import { web3, erc20Api } from 'apps/explorer/api'
+
+describe('getErc20Info', () => {
+  test('Get null when the address is not a contract', async () => {
+    const tokenAddress = '0xe4A09175F943783525b8161243205fc62467C367'
+    const networkId = 4
+    web3.eth.getCode = async (): Promise<string> => '0x'
+
+    const result = await getErc20Info({ tokenAddress, networkId, web3, erc20Api })
+
+    expect(result).toEqual(null)
+  })
+  test('Get null when the ERC20 specification is not met', async () => {
+    const tokenAddress = '0xe4A09175F943783525b8161243205fc62467C367'
+    const networkId = 4
+    web3.eth.getCode = async (address: string): Promise<string> => address
+    erc20Api.totalSupply = (): Promise<BN> => Promise.reject('fail')
+    const result = await getErc20Info({ tokenAddress, networkId, web3, erc20Api })
+
+    expect(result).toEqual(null)
+  })
+})


### PR DESCRIPTION
# Summary

Closes #685 

When the infura node does not respond with the tokenErc20 information, the order table lists incomplete.
![Selection_299](https://user-images.githubusercontent.com/4270166/136206789-cbaa77ff-739f-477b-b3bd-0fe2c3a4a0f6.png)

:spiral_notepad: **Proposals**:
Having a [list of endpoints](https://github.com/gnosis/gp-ui/blob/685-toggle-xdai-nodes/src/api/web3/index.ts#L13), when one does not return the information, it will be toggled.


 1. :heavy_check_mark: **(Implemented)** Use [retry](https://github.com/gnosis/gp-ui/blob/869-address-page-by-ens/src/utils/miscellaneous.ts#L194) function when `getErc20Info` fails to request the Erc20 token information in the hook [`useMultipleErc20`](https://github.com/gnosis/gp-ui/blob/685-toggle-xdai-nodes/src/hooks/useErc20.ts#L111).
 
 ❗In addition, parameters are added to auto reconnect the socket when creating a websocketProvider instance.


 2. **(:bulb: To be evaluated for #792)** It could be applied at Web3 level like as [`createWeb3Api` function](https://github.com/gnosis/gp-ui/blob/869-address-page-by-ens/src/api/web3/index.ts#L13), could add a provider refresher or switch between different endpoints when there is **on('error')**.
For example:
```typescript
let indexProvider = 0
let attemp = 0

export function createErc20Api(injectedDependencies: Erc20ApiDependencies): Erc20Api {
  let erc20Api

  injectedDependencies.web3.givenProvider.on('error', () => {
    indexProvider = indexProvider + 1
    attemp = attemp + 1
    if (attemp < 4){
      updateWeb3Provider(...)
    }

  })
  if (process.env.MOCK_ERC20 === 'true') {
  ...
```

## :memo: Notes about [Web3v1.x](https://github.com/ChainSafe/web3.js/tree/1.x)  
I  have found that this [`reconnectOptions` parameters](https://github.com/ChainSafe/web3.js/blob/ecc5c306e0baf9af0860940fce7328c4e47d9566/packages/web3-providers-ws/src/index.js#L45) `auto:false` **by default**, this may have influenced the disconnection of the `websocket` node to disconnect over time.

## To Test:
- Go to: https://pr723--gpui.review.gnosisdev.com/xdai/address/0xFF714b8b0e2700303eC912BD40496C3997ceEa2b/