### PR TITLE
Adding LinkWithPrefixNetwork

### DIFF
--- a/src/components/common/LinkWithPrefixNetwork/index.tsx
+++ b/src/components/common/LinkWithPrefixNetwork/index.tsx
@@ -1,17 +1,12 @@
 import React from 'react'
 import { Link, LinkProps } from 'react-router-dom'
 
-import { MatchPrefixNetworkOnPathname } from 'state/network'
+import { useGetPathPrefix } from 'state/network'
 
 export function LinkWithPrefixNetwork(props: LinkProps): JSX.Element {
   const { to, children, ...otherParams } = props
-  const pathMatchArray = MatchPrefixNetworkOnPathname()
-  const prefixNetwork = pathMatchArray && pathMatchArray[1]
-  let _to = to
-
-  if (prefixNetwork) {
-    _to = `/${prefixNetwork}` + _to
-  }
+  const [prefix] = useGetPathPrefix()
+  const _to = prefix ? `/${prefix}${to}` : to
 
   return (
     <Link to={_to} {...otherParams}>

--- a/src/components/common/LinkWithPrefixNetwork/index.tsx
+++ b/src/components/common/LinkWithPrefixNetwork/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Link, LinkProps } from 'react-router-dom'
 
-import { useGetPathPrefix } from 'state/network'
+import { usePathPrefix } from 'state/network'
 
 export function LinkWithPrefixNetwork(props: LinkProps): JSX.Element {
   const { to, children, ...otherParams } = props
-  const [prefix] = useGetPathPrefix()
+  const prefix = usePathPrefix()
   const _to = prefix ? `/${prefix}${to}` : to
 
   return (

--- a/src/components/common/LinkWithPrefixNetwork/index.tsx
+++ b/src/components/common/LinkWithPrefixNetwork/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Link, LinkProps } from 'react-router-dom'
+
+import { MatchPrefixNetworkOnPathname } from 'state/network'
+
+export function LinkWithPrefixNetwork(props: LinkProps): JSX.Element {
+  const { to, children, ...otherParams } = props
+  const pathMatchArray = MatchPrefixNetworkOnPathname()
+  const prefixNetwork = pathMatchArray && pathMatchArray[1]
+  let _to = to
+
+  if (prefixNetwork) {
+    _to = `/${prefixNetwork}` + _to
+  }
+
+  return (
+    <Link to={_to} {...otherParams}>
+      {children}
+    </Link>
+  )
+}

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
-import { Link } from 'react-router-dom'
 
 import { Order } from 'api/operator'
 
@@ -22,6 +21,7 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { StatusLabel } from 'components/orders/StatusLabel'
 import { GasFeeDisplay } from 'components/orders/GasFeeDisplay'
 import { triggerEvent } from 'api/analytics'
+import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 
 const Table = styled(SimpleTable)`
   border: 0.1rem solid ${({ theme }): string => theme.borderPrimary};
@@ -142,7 +142,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <RowWithCopyButton
                 textToCopy={owner}
                 onCopy={(): void => onCopy('ownerAddress')}
-                contentsToDisplay={<Link to={`/address/${owner}`}>{owner}</Link>}
+                contentsToDisplay={<LinkWithPrefixNetwork to={`/address/${owner}`}>{owner}</LinkWithPrefixNetwork>}
               />
             </td>
           </tr>
@@ -154,7 +154,9 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <RowWithCopyButton
                 textToCopy={receiver}
                 onCopy={(): void => onCopy('receiverAddress')}
-                contentsToDisplay={<Link to={`/address/${receiver}`}>{receiver}</Link>}
+                contentsToDisplay={
+                  <LinkWithPrefixNetwork to={`/address/${receiver}`}>{receiver}</LinkWithPrefixNetwork>
+                }
               />
             </td>
           </tr>

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -28,16 +28,21 @@ function getNetworkPrefix(network: Network): string {
   return prefix || MAINNET_PREFIX
 }
 
+export const MatchPrefixNetworkOnPathname = (): RegExpMatchArray | null => {
+  const { pathname } = useLocation()
+
+  return pathname.match('/(rinkeby|xdai|mainnet)?/?(.*)')
+}
+
 /** Redirects to the canonnical URL for mainnet */
 export const RedirectToNetwork = (props: { networkId: Network }): JSX.Element | null => {
-  const { networkId } = props
-  const { pathname } = useLocation()
-  const prefix = getNetworkPrefix(networkId)
-
-  const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet)?/?(.*)')
+  const pathMatchArray = MatchPrefixNetworkOnPathname()
   if (pathMatchArray == null) {
     return null
   }
+
+  const { networkId } = props
+  const prefix = getNetworkPrefix(networkId)
 
   const prefixPath = prefix ? `/${prefix}` : ''
   const newPath = prefixPath + '/' + pathMatchArray[2]

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -28,17 +28,25 @@ function getNetworkPrefix(network: Network): string {
   return prefix || MAINNET_PREFIX
 }
 
-export const useGetPathPrefix = (): [string, string] | [] => {
+/**
+ * Decompose URL pathname like /xdai/orders/123
+ *
+ * @returns ['xdai', 'orders/123']
+ */
+export const useDecomposedPath = (): [string, string] | [] => {
   const { pathname } = useLocation()
   const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet)?/?(.*)')
 
   return pathMatchArray == null ? [] : [pathMatchArray[1], pathMatchArray[2]]
 }
 
+export const usePathPrefix = (): string | undefined => useDecomposedPath()[0]
+export const usePathSuffix = (): string | undefined => useDecomposedPath()[1]
+
 /** Redirects to the canonnical URL for mainnet */
 export const RedirectToNetwork = (props: { networkId: Network }): JSX.Element | null => {
-  const [, pathWithouPrefix] = useGetPathPrefix()
-  if (pathWithouPrefix === undefined) {
+  const pathnameSuffix = usePathSuffix()
+  if (pathnameSuffix === undefined) {
     return null
   }
 
@@ -46,7 +54,7 @@ export const RedirectToNetwork = (props: { networkId: Network }): JSX.Element | 
   const prefix = getNetworkPrefix(networkId)
 
   const prefixPath = prefix ? `/${prefix}` : ''
-  const newPath = prefixPath + '/' + pathWithouPrefix
+  const newPath = prefixPath + '/' + pathnameSuffix
 
   return <Redirect push={false} to={newPath} />
 }

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -28,16 +28,17 @@ function getNetworkPrefix(network: Network): string {
   return prefix || MAINNET_PREFIX
 }
 
-export const MatchPrefixNetworkOnPathname = (): RegExpMatchArray | null => {
+export const useGetPathPrefix = (): [string, string] | [] => {
   const { pathname } = useLocation()
+  const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet)?/?(.*)')
 
-  return pathname.match('/(rinkeby|xdai|mainnet)?/?(.*)')
+  return pathMatchArray == null ? [] : [pathMatchArray[1], pathMatchArray[2]]
 }
 
 /** Redirects to the canonnical URL for mainnet */
 export const RedirectToNetwork = (props: { networkId: Network }): JSX.Element | null => {
-  const pathMatchArray = MatchPrefixNetworkOnPathname()
-  if (pathMatchArray == null) {
+  const [, pathWithouPrefix] = useGetPathPrefix()
+  if (pathWithouPrefix === undefined) {
     return null
   }
 
@@ -45,7 +46,7 @@ export const RedirectToNetwork = (props: { networkId: Network }): JSX.Element | 
   const prefix = getNetworkPrefix(networkId)
 
   const prefixPath = prefix ? `/${prefix}` : ''
-  const newPath = prefixPath + '/' + pathMatchArray[2]
+  const newPath = prefixPath + '/' + pathWithouPrefix
 
   return <Redirect push={false} to={newPath} />
 }

--- a/test/hooks/useDecomposedPath.test.tsx
+++ b/test/hooks/useDecomposedPath.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useDecomposedPath, usePathPrefix, usePathSuffix } from 'state/network'
+import { MemoryRouter } from 'react-router'
+
+interface Props {
+  children?: React.ReactNode
+  mockLocation: string
+}
+
+function wrapperMemoryRouter(props: Props): JSX.Element {
+  return (
+    <>
+      <MemoryRouter initialEntries={[props.mockLocation]}>{props.children}</MemoryRouter>
+    </>
+  )
+}
+
+describe('useDecomposedPath', () => {
+  it('get prefix network and suffix of pathname on react-router', () => {
+    // given
+    const networkPrefix = '/rinkeby'
+    const pathSuffix = '/address/123'
+    const mockLocation = networkPrefix + pathSuffix
+
+    //when
+    const { result } = renderHook(() => useDecomposedPath(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, mockLocation }),
+    })
+
+    expect(result.current[0]).toBe(networkPrefix.substr(1)) // rinkeby
+    expect(result.current[1]).toBe(pathSuffix.substr(1)) // addrres...
+  })
+
+  it('should return an empty array when the regex does not match', () => {
+    const mockLocation = 'badpathname'
+
+    //when
+    const { result } = renderHook(() => useDecomposedPath(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, mockLocation }),
+    })
+
+    expect(result.current).toEqual([])
+  })
+})
+
+describe('usePathPrefix', () => {
+  it('should return network prefix when it matches the regex', () => {
+    const networkPrefix = '/xdai'
+    const pathSuffix = '/address/123'
+    const mockLocation = networkPrefix + pathSuffix
+
+    const { result } = renderHook(() => usePathPrefix(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, mockLocation }),
+    })
+
+    expect(result.current).toBe(networkPrefix.substr(1))
+  })
+
+  it('should return undefined when it does not match regex', () => {
+    const mockLocation = '/address/123'
+
+    //when
+    const { result } = renderHook(() => usePathPrefix(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, mockLocation }),
+    })
+
+    expect(result.current).toBe(undefined)
+  })
+})
+
+describe('usePathSuffix', () => {
+  it('should return paht suffix', () => {
+    const networkPrefix = '/xdai'
+    const pathSuffix = '/address/123'
+    const mockLocation = networkPrefix + pathSuffix
+
+    const { result } = renderHook(() => usePathSuffix(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, mockLocation }),
+    })
+
+    expect(result.current).toBe(pathSuffix.substr(1))
+  })
+
+  it('should return undefined when it does not match regex', () => {
+    const mockLocation = '/xdai'
+
+    //when
+    const { result } = renderHook(() => usePathSuffix(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, mockLocation }),
+    })
+
+    expect(result.current).toBe('')
+  })
+})


### PR DESCRIPTION
# Summary
Closes #690

**Proposal:**
- [x] Check the current URL. Re-use whatever path after the base domain, if any
- [x] Create a `LinkWithPrefixNetwork` component to reuse

## To Test
- Mainnet
Go to order detail page -> [Order detail on mainnet](https://pr726--gpui.review.gnosisdev.com/orders/0xd77762f375ad08799710a2e9261142ae641abc8f0009466d9426175f44b3d23404a66cbba0485d7b21af836f52b711401300fddb6086065c)
Press `From` address
- xDai
Go to order detail page -> [Order detail on xDai](https://pr726--gpui.review.gnosisdev.com/orders/0x405bd0278c11399f84f10e19fb9b45123996e7d0a68a60ddebc3b9581576b484ff714b8b0e2700303ec912bd40496c3997ceea2b614b17d9)
Press `From` address
- Rinkeby
Go to order detail page -> [Order detail on rinkeby](https://pr726--gpui.review.gnosisdev.com/rinkeby/orders/0x88537c74a03c324464d6c269d99b29e7289b105766c5368f77c76c241e1d5da8b6bad41ae76a11d10f7b0e664c5007b908bc77c9615b2dac)
Press `From` address