### PR TITLE
Reuse LinkWithPrefixNetwork in orders/trades table

### DIFF
--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { Order } from 'api/operator'
@@ -16,6 +15,7 @@ import StyledUserDetailsTable, {
 } from '../../common/StyledUserDetailsTable'
 import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
+import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
@@ -62,9 +62,9 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
             className="span-copybtn-wrap"
             textToCopy={uid}
             contentsToDisplay={
-              <Link to={`/orders/${order.uid}`} target="_blank">
+              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
                 {shortId}
-              </Link>
+              </LinkWithPrefixNetwork>
             }
           />
         }

--- a/src/components/trade/TradesTable/index.tsx
+++ b/src/components/trade/TradesTable/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { Trade, RawOrder } from 'api/operator'
@@ -24,6 +23,7 @@ import StyledUserDetailsTable, {
 import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
 import { Surplus } from './Surplus'
+import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
@@ -94,7 +94,11 @@ const RowOrder: React.FC<RowProps> = ({ trade, isPriceInverted }) => {
         <RowWithCopyButton
           className="span-copybtn-wrap"
           textToCopy={orderId}
-          contentsToDisplay={<Link to={`/orders/${trade.orderId}`}>{getShortOrderId(orderId)}</Link>}
+          contentsToDisplay={
+            <LinkWithPrefixNetwork to={`/orders/${trade.orderId}`} rel="noopener noreferrer" target="_blank">
+              {getShortOrderId(orderId)}
+            </LinkWithPrefixNetwork>
+          }
         />
       </td>
       <td>


### PR DESCRIPTION
# Summary

Closes #747 

Direct linking when the network is known in Orders Table.
![Screenshot from 2021-10-13 17-43-50](https://user-images.githubusercontent.com/4270166/137210516-7f28d18e-cd9f-4ac5-9716-6fef126c2512.png)


## To Test

1. Open `Orders table` [page](https://pr766--gpui.review.gnosisdev.com/xdai/address/0xff714b8b0e2700303ec912bd40496c3997ceea2b/).
2. Click an `orderId` **link**


