### PR TITLE
Adding signature pending orderStatus

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -20,13 +20,7 @@ export interface FeeInformation {
 export type OrderKind = 'sell' | 'buy'
 
 export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signature pending'
-export enum RawOrderStatusFromAPI {
-  presignaturePending = 'presignaturePending',
-  open = 'open',
-  fulfilled = 'fullfilled',
-  cancelled = 'cancelled',
-  expired = 'expired',
-}
+export type RawOrderStatusFromAPI = 'presignaturePending' | 'open' | 'fullfilled' | 'cancelled' | 'expired'
 
 // Raw API response
 export type RawOrder = {

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -21,11 +21,11 @@ export type OrderKind = 'sell' | 'buy'
 
 export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signature pending'
 export enum RawOrderStatusFromAPI {
-  signaturePending,
-  open,
-  fulfilled,
-  cancelled,
-  expired,
+  presignaturePending = 'presignaturePending',
+  open = 'open',
+  fulfilled = 'fullfilled',
+  cancelled = 'cancelled',
+  expired = 'expired',
 }
 
 // Raw API response

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -42,7 +42,7 @@ export type RawOrder = {
   kind: OrderKind
   partiallyFillable: boolean
   signature: string
-  status?: RawOrderStatusFromAPI
+  status: RawOrderStatusFromAPI
 }
 
 /**

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -19,7 +19,7 @@ export interface FeeInformation {
 
 export type OrderKind = 'sell' | 'buy'
 
-export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signature pending'
+export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signing'
 export type RawOrderStatusFromAPI = 'presignaturePending' | 'open' | 'fullfilled' | 'cancelled' | 'expired'
 
 // Raw API response

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -19,7 +19,14 @@ export interface FeeInformation {
 
 export type OrderKind = 'sell' | 'buy'
 
-export type OrderStatus = 'open' | 'filled' | 'canceled' | 'expired'
+export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signature pending'
+export enum RawOrderStatusFromAPI {
+  signaturePending,
+  open,
+  fulfilled,
+  cancelled,
+  expired,
+}
 
 // Raw API response
 export type RawOrder = {

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -42,6 +42,7 @@ export type RawOrder = {
   kind: OrderKind
   partiallyFillable: boolean
   signature: string
+  status?: RawOrderStatusFromAPI
 }
 
 /**

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -2,7 +2,7 @@ import { AnalyticsDimension, Network } from 'types'
 
 /** Explorer app constants */
 export const ORDER_QUERY_INTERVAL = 10000 // in ms
-export const ORDERS_QUERY_INTERVAL = 30000 // in ms
+export const ORDERS_QUERY_INTERVAL = 25000 // in ms
 export const ORDERS_HISTORY_MINUTES_AGO = 10 // in minutes
 
 export const DISPLAY_TEXT_COPIED_CHECK = 1000 // in ms

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -2,7 +2,7 @@ import { AnalyticsDimension, Network } from 'types'
 
 /** Explorer app constants */
 export const ORDER_QUERY_INTERVAL = 10000 // in ms
-export const ORDERS_QUERY_INTERVAL = 25000 // in ms
+export const ORDERS_QUERY_INTERVAL = 30000 // in ms
 export const ORDERS_HISTORY_MINUTES_AGO = 10 // in minutes
 
 export const DISPLAY_TEXT_COPIED_CHECK = 1000 // in ms

--- a/src/components/orders/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/orders/StatusLabel/StatusLabel.stories.tsx
@@ -20,15 +20,18 @@ Filled.args = { status: 'filled' }
 export const Expired = Template.bind({})
 Expired.args = { status: 'expired' }
 
-export const Canceled = Template.bind({})
-Canceled.args = { status: 'cancelled' }
+export const Cancelled = Template.bind({})
+Cancelled.args = { status: 'cancelled' }
 
 export const Open = Template.bind({})
 Open.args = { status: 'open' }
+
+export const Signing = Template.bind({})
+Signing.args = { status: 'signing' }
 
 export const OpenPartiallyFilled = Template.bind({})
 OpenPartiallyFilled.args = { status: 'open', partiallyFilled: true }
 export const ExpiredPartiallyFilled = Template.bind({})
 ExpiredPartiallyFilled.args = { status: 'expired', partiallyFilled: true }
-export const CanceledPartiallyFilled = Template.bind({})
-CanceledPartiallyFilled.args = { status: 'cancelled', partiallyFilled: true }
+export const CancelledPartiallyFilled = Template.bind({})
+CancelledPartiallyFilled.args = { status: 'cancelled', partiallyFilled: true }

--- a/src/components/orders/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/orders/StatusLabel/StatusLabel.stories.tsx
@@ -21,7 +21,7 @@ export const Expired = Template.bind({})
 Expired.args = { status: 'expired' }
 
 export const Canceled = Template.bind({})
-Canceled.args = { status: 'canceled' }
+Canceled.args = { status: 'cancelled' }
 
 export const Open = Template.bind({})
 Open.args = { status: 'open' }
@@ -31,4 +31,4 @@ OpenPartiallyFilled.args = { status: 'open', partiallyFilled: true }
 export const ExpiredPartiallyFilled = Template.bind({})
 ExpiredPartiallyFilled.args = { status: 'expired', partiallyFilled: true }
 export const CanceledPartiallyFilled = Template.bind({})
-CanceledPartiallyFilled.args = { status: 'canceled', partiallyFilled: true }
+CanceledPartiallyFilled.args = { status: 'cancelled', partiallyFilled: true }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -28,7 +28,7 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
       background = theme.greenOpacity
       break
     case 'open':
-    case 'signature pending':
+    case 'signing':
       text = theme.labelTextOpen
       background = theme.labelBgOpen
       break
@@ -95,7 +95,7 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
       return faCheckCircle
     case 'cancelled':
       return faTimesCircle
-    case 'signature pending':
+    case 'signing':
       return faKey
     case 'open':
       return faCircleNotch
@@ -105,7 +105,7 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
 function StatusIcon({ status }: DisplayProps): JSX.Element {
   const icon = getStatusIcon(status)
   const isOpen = status === 'open'
-  const shimming = status === 'signature pending'
+  const shimming = status === 'signing'
 
   return <StyledFAIcon icon={icon} spin={isOpen} $shimming={shimming} />
 }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -12,7 +12,7 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
 
   switch (status) {
     case 'expired':
-    case 'canceled':
+    case 'cancelled':
       text = theme.orange
       background = theme.orangeOpacity
       break
@@ -21,6 +21,7 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
       background = theme.greenOpacity
       break
     case 'open':
+    case 'signature pending':
       text = theme.labelTextOpen
       background = theme.labelBgOpen
       break
@@ -65,9 +66,10 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
       return faClock
     case 'filled':
       return faCheckCircle
-    case 'canceled':
+    case 'cancelled':
       return faTimesCircle
     case 'open':
+    case 'signature pending':
       return faCircleNotch
   }
 }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
-import styled, { DefaultTheme } from 'styled-components'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCheckCircle, faCircleNotch, faClock, faTimesCircle, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import styled, { DefaultTheme, css, keyframes, FlattenSimpleInterpolation } from 'styled-components'
+import { FontAwesomeIcon, FontAwesomeIconProps } from '@fortawesome/react-fontawesome'
+import {
+  faCheckCircle,
+  faCircleNotch,
+  faClock,
+  faTimesCircle,
+  IconDefinition,
+  faKey,
+} from '@fortawesome/free-solid-svg-icons'
 
 import { OrderStatus } from 'api/operator'
 
@@ -50,8 +57,28 @@ const Label = styled.div<DisplayProps>`
   ${({ theme, status }): string => setStatusColors({ theme, status })}
 `
 
-const StyledFAIcon = styled(FontAwesomeIcon)`
+const frameAnimation = keyframes`
+    100% {
+      -webkit-mask-position: left;
+    }
+`
+type StyledFAIconProps = FontAwesomeIconProps & {
+  $shimming?: boolean
+}
+
+const StyledFAIcon = styled(FontAwesomeIcon)<StyledFAIconProps>`
   margin: 0 0.75rem 0 0;
+  ${(props): FlattenSimpleInterpolation | null =>
+    props.$shimming
+      ? css`
+          display: inline-block;
+          -webkit-mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
+          mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
+          background-repeat: no-repeat;
+          animation: shimmer 1.5s infinite;
+          animation-name: ${frameAnimation};
+        `
+      : null}
 `
 
 const PartialFill = styled.div`
@@ -68,17 +95,19 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
       return faCheckCircle
     case 'cancelled':
       return faTimesCircle
-    case 'open':
     case 'signature pending':
+      return faKey
+    case 'open':
       return faCircleNotch
   }
 }
 
 function StatusIcon({ status }: DisplayProps): JSX.Element {
   const icon = getStatusIcon(status)
-  const isOpen = ['open', 'signature pending'].includes(status)
+  const isOpen = status === 'open'
+  const shimming = status === 'signature pending'
 
-  return <StyledFAIcon icon={icon} spin={isOpen} />
+  return <StyledFAIcon icon={icon} spin={isOpen} $shimming={shimming} />
 }
 
 export type Props = DisplayProps & { partiallyFilled: boolean }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled, { DefaultTheme, css, keyframes, FlattenSimpleInterpolation } from 'styled-components'
-import { FontAwesomeIcon, FontAwesomeIconProps } from '@fortawesome/react-fontawesome'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faCheckCircle,
   faCircleNotch,
@@ -45,8 +45,16 @@ const Wrapper = styled.div`
   align-items: center;
   font-size: ${({ theme }): string => theme.fontSizeDefault};
 `
+const frameAnimation = keyframes`
+    100% {
+      -webkit-mask-position: left;
+    }
+`
+type ShimmingProps = {
+  shimming?: boolean
+}
 
-const Label = styled.div<DisplayProps>`
+const Label = styled.div<DisplayProps & ShimmingProps>`
   font-weight: ${({ theme }): string => theme.fontBold};
   text-transform: capitalize;
   border-radius: 0.4rem;
@@ -55,21 +63,8 @@ const Label = styled.div<DisplayProps>`
   display: flex;
   align-items: center;
   ${({ theme, status }): string => setStatusColors({ theme, status })}
-`
-
-const frameAnimation = keyframes`
-    100% {
-      -webkit-mask-position: left;
-    }
-`
-type StyledFAIconProps = FontAwesomeIconProps & {
-  $shimming?: boolean
-}
-
-const StyledFAIcon = styled(FontAwesomeIcon)<StyledFAIconProps>`
-  margin: 0 0.75rem 0 0;
-  ${(props): FlattenSimpleInterpolation | null =>
-    props.$shimming
+  ${({ shimming }): FlattenSimpleInterpolation | null =>
+    shimming
       ? css`
           display: inline-block;
           -webkit-mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
@@ -79,6 +74,10 @@ const StyledFAIcon = styled(FontAwesomeIcon)<StyledFAIconProps>`
           animation-name: ${frameAnimation};
         `
       : null}
+`
+
+const StyledFAIcon = styled(FontAwesomeIcon)`
+  margin: 0 0.75rem 0 0;
 `
 
 const PartialFill = styled.div`
@@ -105,19 +104,19 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
 function StatusIcon({ status }: DisplayProps): JSX.Element {
   const icon = getStatusIcon(status)
   const isOpen = status === 'open'
-  const shimming = status === 'signing'
 
-  return <StyledFAIcon icon={icon} spin={isOpen} $shimming={shimming} />
+  return <StyledFAIcon icon={icon} spin={isOpen} />
 }
 
 export type Props = DisplayProps & { partiallyFilled: boolean }
 
 export function StatusLabel(props: Props): JSX.Element {
   const { status, partiallyFilled } = props
+  const shimming = status === 'signing'
 
   return (
     <Wrapper>
-      <Label status={status}>
+      <Label status={status} shimming={shimming}>
         <StatusIcon status={status} />
         {status}
       </Label>

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -76,7 +76,7 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
 
 function StatusIcon({ status }: DisplayProps): JSX.Element {
   const icon = getStatusIcon(status)
-  const isOpen = status === 'open'
+  const isOpen = ['open', 'signature pending'].includes(status)
 
   return <StyledFAIcon icon={icon} spin={isOpen} />
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -49,8 +49,6 @@ function isOrderPresigning(order: RawOrder): boolean {
 }
 
 export function getOrderStatus(order: RawOrder): OrderStatus {
-  const date = new Date(order.creationDate)
-  if (date > new Date('2021-11-10T03:44:29.471646Z')) console.log(order)
   if (isOrderFilled(order)) {
     return 'filled'
   } else if (order.invalidated) {
@@ -58,7 +56,7 @@ export function getOrderStatus(order: RawOrder): OrderStatus {
   } else if (isOrderExpired(order)) {
     return 'expired'
   } else if (isOrderPresigning(order)) {
-    return 'signature pending'
+    return 'signing'
   } else {
     return 'open'
   }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -5,7 +5,7 @@ import { calculatePrice, invertPrice, TokenErc20 } from '@gnosis.pm/dex-js'
 
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
-import { Order, OrderStatus, RawOrderStatusFromAPI, RawOrder, RawTrade, Trade } from 'api/operator/types'
+import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
 
 import { formattingAmountPrecision, formatSmartMaxPrecision } from 'utils'
 
@@ -40,12 +40,8 @@ function isOrderPartiallyFilled(order: RawOrder): boolean {
   }
 }
 
-export interface RawOrderWithStatus extends RawOrder {
-  status: RawOrderStatusFromAPI
-}
-
 function isOrderPresigning(order: RawOrder): boolean {
-  return (order as RawOrderWithStatus).status === 'presignaturePending'
+  return order.status === 'presignaturePending'
 }
 
 export function getOrderStatus(order: RawOrder): OrderStatus {

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -40,22 +40,24 @@ function isOrderPartiallyFilled(order: RawOrder): boolean {
   }
 }
 
-interface RawOrderWithStatus extends RawOrder {
+export interface RawOrderWithStatus extends RawOrder {
   status: RawOrderStatusFromAPI
 }
 
-function hasRawOrderStatus(order: RawOrder): order is RawOrderWithStatus {
-  return (order as RawOrderWithStatus).status !== undefined
+function isOrderPresigning(order: RawOrder): boolean {
+  return (order as RawOrderWithStatus).status === 'presignaturePending'
 }
 
 export function getOrderStatus(order: RawOrder): OrderStatus {
+  const date = new Date(order.creationDate)
+  if (date > new Date('2021-11-10T03:44:29.471646Z')) console.log(order)
   if (isOrderFilled(order)) {
     return 'filled'
   } else if (order.invalidated) {
     return 'cancelled'
   } else if (isOrderExpired(order)) {
     return 'expired'
-  } else if (hasRawOrderStatus(order) && order.status === RawOrderStatusFromAPI.presignaturePending) {
+  } else if (isOrderPresigning(order)) {
     return 'signature pending'
   } else {
     return 'open'

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -5,7 +5,7 @@ import { calculatePrice, invertPrice, TokenErc20 } from '@gnosis.pm/dex-js'
 
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
-import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
+import { Order, OrderStatus, RawOrderStatusFromAPI, RawOrder, RawTrade, Trade } from 'api/operator/types'
 
 import { formattingAmountPrecision, formatSmartMaxPrecision } from 'utils'
 
@@ -40,13 +40,23 @@ function isOrderPartiallyFilled(order: RawOrder): boolean {
   }
 }
 
+interface RawOrderWithStatus extends RawOrder {
+  status: RawOrderStatusFromAPI
+}
+
+function isRawOrderStatus(order: RawOrder): order is RawOrderWithStatus {
+  return (order as RawOrderWithStatus).status !== undefined
+}
+
 export function getOrderStatus(order: RawOrder): OrderStatus {
   if (isOrderFilled(order)) {
     return 'filled'
   } else if (order.invalidated) {
-    return 'canceled'
+    return 'cancelled'
   } else if (isOrderExpired(order)) {
     return 'expired'
+  } else if (isRawOrderStatus(order) && order.status === RawOrderStatusFromAPI.signaturePending) {
+    return 'signature pending'
   } else {
     return 'open'
   }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -44,7 +44,7 @@ interface RawOrderWithStatus extends RawOrder {
   status: RawOrderStatusFromAPI
 }
 
-function isRawOrderStatus(order: RawOrder): order is RawOrderWithStatus {
+function hasRawOrderStatus(order: RawOrder): order is RawOrderWithStatus {
   return (order as RawOrderWithStatus).status !== undefined
 }
 
@@ -55,7 +55,7 @@ export function getOrderStatus(order: RawOrder): OrderStatus {
     return 'cancelled'
   } else if (isOrderExpired(order)) {
     return 'expired'
-  } else if (isRawOrderStatus(order) && order.status === RawOrderStatusFromAPI.signaturePending) {
+  } else if (hasRawOrderStatus(order) && order.status === RawOrderStatusFromAPI.presignaturePending) {
     return 'signature pending'
   } else {
     return 'open'

--- a/test/data/operator.ts
+++ b/test/data/operator.ts
@@ -26,6 +26,7 @@ export const RAW_ORDER: RawOrder = {
   partiallyFillable: false,
   signature:
     '0x04dca25f59e9ac744c4093530a38f1719c4e0b1ce8e4b68c8018b6b05fd4a6944e1dcf2a009df2d5932f7c034b4a24da0999f9309dd5108d51d54236b605ed991c',
+  status: 'open',
 }
 
 export const RICH_ORDER: Order = {

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -121,7 +121,7 @@ describe('Canceled status', () => {
       buyAmount: '10000',
       invalidated: true,
     }
-    expect(getOrderStatus(order)).toEqual('canceled')
+    expect(getOrderStatus(order)).toEqual('cancelled')
   })
   test('Sell order', () => {
     const order: RawOrder = {
@@ -130,7 +130,7 @@ describe('Canceled status', () => {
       sellAmount: '10000',
       invalidated: true,
     }
-    expect(getOrderStatus(order)).toEqual('canceled')
+    expect(getOrderStatus(order)).toEqual('cancelled')
   })
   test('Expired and invalidated', () => {
     const order: RawOrder = {
@@ -140,7 +140,7 @@ describe('Canceled status', () => {
       invalidated: true,
       validTo: _getPastTimestamp(),
     }
-    expect(getOrderStatus(order)).toEqual('canceled')
+    expect(getOrderStatus(order)).toEqual('cancelled')
   })
 })
 

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -255,7 +255,7 @@ describe('Presignature pending status', () => {
         executedBuyAmount: '0',
         validTo: _getCurrentTimestamp(),
       }
-      expect(getOrderStatus(order)).toEqual('signature pending')
+      expect(getOrderStatus(order)).toEqual('signing')
     })
     test('signature is not pending', () => {
       const statusFetched: RawOrderStatusFromAPI = 'open'
@@ -268,7 +268,7 @@ describe('Presignature pending status', () => {
         executedBuyAmount: '0',
         validTo: _getCurrentTimestamp(),
       }
-      expect(getOrderStatus(order)).not.toEqual('signature pending')
+      expect(getOrderStatus(order)).not.toEqual('signing')
     })
   })
   describe('Sell order', () => {
@@ -283,7 +283,7 @@ describe('Presignature pending status', () => {
         executedSellAmount: '0',
         validTo: _getCurrentTimestamp(),
       }
-      expect(getOrderStatus(order)).toEqual('signature pending')
+      expect(getOrderStatus(order)).toEqual('signing')
     })
   })
 })

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -1,6 +1,6 @@
 import { RawOrder, RawOrderStatusFromAPI } from 'api/operator'
 
-import { getOrderStatus, RawOrderWithStatus } from 'utils'
+import { getOrderStatus } from 'utils'
 
 import { RAW_ORDER } from '../../data'
 import { mockTimes, DATE } from '../../testHelpers'
@@ -247,7 +247,7 @@ describe('Presignature pending status', () => {
     test('signature is pending', () => {
       const statusFetched: RawOrderStatusFromAPI = 'presignaturePending'
 
-      const order: RawOrderWithStatus = {
+      const order: RawOrder = {
         ...RAW_ORDER,
         kind: 'buy',
         status: statusFetched,
@@ -260,7 +260,7 @@ describe('Presignature pending status', () => {
     test('signature is not pending', () => {
       const statusFetched: RawOrderStatusFromAPI = 'open'
 
-      const order: RawOrderWithStatus = {
+      const order: RawOrder = {
         ...RAW_ORDER,
         kind: 'buy',
         status: statusFetched,
@@ -275,7 +275,7 @@ describe('Presignature pending status', () => {
     test('signature is pending', () => {
       const statusFetched: RawOrderStatusFromAPI = 'presignaturePending'
 
-      const order: RawOrderWithStatus = {
+      const order: RawOrder = {
         ...RAW_ORDER,
         kind: 'sell',
         status: statusFetched,

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -1,6 +1,6 @@
-import { RawOrder } from 'api/operator'
+import { RawOrder, RawOrderStatusFromAPI } from 'api/operator'
 
-import { getOrderStatus } from 'utils'
+import { getOrderStatus, RawOrderWithStatus } from 'utils'
 
 import { RAW_ORDER } from '../../data'
 import { mockTimes, DATE } from '../../testHelpers'
@@ -238,6 +238,52 @@ describe('Open status', () => {
         validTo: _getCurrentTimestamp(),
       }
       expect(getOrderStatus(order)).toEqual('open')
+    })
+  })
+})
+
+describe('Presignature pending status', () => {
+  describe('Buy order', () => {
+    test('signature is pending', () => {
+      const statusFetched: RawOrderStatusFromAPI = 'presignaturePending'
+
+      const order: RawOrderWithStatus = {
+        ...RAW_ORDER,
+        kind: 'buy',
+        status: statusFetched,
+        buyAmount: '10000',
+        executedBuyAmount: '0',
+        validTo: _getCurrentTimestamp(),
+      }
+      expect(getOrderStatus(order)).toEqual('signature pending')
+    })
+    test('signature is not pending', () => {
+      const statusFetched: RawOrderStatusFromAPI = 'open'
+
+      const order: RawOrderWithStatus = {
+        ...RAW_ORDER,
+        kind: 'buy',
+        status: statusFetched,
+        buyAmount: '10000',
+        executedBuyAmount: '0',
+        validTo: _getCurrentTimestamp(),
+      }
+      expect(getOrderStatus(order)).not.toEqual('signature pending')
+    })
+  })
+  describe('Sell order', () => {
+    test('signature is pending', () => {
+      const statusFetched: RawOrderStatusFromAPI = 'presignaturePending'
+
+      const order: RawOrderWithStatus = {
+        ...RAW_ORDER,
+        kind: 'sell',
+        status: statusFetched,
+        sellAmount: '10000',
+        executedSellAmount: '0',
+        validTo: _getCurrentTimestamp(),
+      }
+      expect(getOrderStatus(order)).toEqual('signature pending')
     })
   })
 })


### PR DESCRIPTION
# Summary

Closes #628 

- Adding `signing` in order status  
![Selection_351](https://user-images.githubusercontent.com/4270166/141126109-422dc1c6-b1fa-4487-b663-56b946b9ce30.png)
- Maintain consistency with status 'Cancelled' instead of 'Canceled' from `cowswap`
![Selection_352](https://user-images.githubusercontent.com/4270166/141126355-1ad5525a-7f24-483f-bb4d-94701f5a7d6b.png)


## To test
Signing status.
- Go to https://cowswap.dev.gnosisdev.com/#/swap
- Connect with **gnosis-safe** through **wallet connect**
- Once connected with gnosis-safe, create a swap.
- Paste wallet address in https://pr826--gpui.review.gnosisdev.com/
- View new order with `signing` **status** in table.

View the OrderStatus `signing` label
- Go to [`Storybook/Orders/StatusLabel/Signing`](https://pr826--gpui.review.gnosisdev.com/storybook/?path=/story/orders-statuslabel--signing)
