### PR TITLE
[Explorer] Properly show tokens with 0 decimals

### DIFF
--- a/src/components/orders/AmountsDisplay/index.tsx
+++ b/src/components/orders/AmountsDisplay/index.tsx
@@ -31,6 +31,7 @@ function Row(props: RowProps): JSX.Element {
 
   // TODO: calculate real usd amount
   // const usdAmount = '31231.32'
+
   // Decimals are optional on ERC20 spec. In that unlikely case, graceful fallback to raw amount
   const formattedAmount = erc20.decimals >= 0 ? formatSmartMaxPrecision(amount, erc20) : amount.toString(10)
   const tokenDisplay = <TokenDisplay erc20={erc20} network={network} />

--- a/src/components/orders/AmountsDisplay/index.tsx
+++ b/src/components/orders/AmountsDisplay/index.tsx
@@ -31,9 +31,8 @@ function Row(props: RowProps): JSX.Element {
 
   // TODO: calculate real usd amount
   // const usdAmount = '31231.32'
-
   // Decimals are optional on ERC20 spec. In that unlikely case, graceful fallback to raw amount
-  const formattedAmount = erc20.decimals ? formatSmartMaxPrecision(amount, erc20) : amount.toString(10)
+  const formattedAmount = erc20.decimals >= 0 ? formatSmartMaxPrecision(amount, erc20) : amount.toString(10)
   const tokenDisplay = <TokenDisplay erc20={erc20} network={network} />
   return (
     <>

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -45,6 +45,6 @@ export async function getErc20Info({ tokenAddress, networkId, erc20Api, web3 }: 
     address: tokenAddress,
     symbol: parseStringOrBytes32(symbol, 'UNKNOWN'),
     name: parseStringOrBytes32(name, 'Unknown Token'),
-    decimals: decimals !== undefined && decimals >= 0 ? decimals : DEFAULT_PRECISION,
+    decimals: decimals ?? DEFAULT_PRECISION,
   }
 }

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -40,10 +40,11 @@ export async function getErc20Info({ tokenAddress, networkId, erc20Api, web3 }: 
     silentPromise(erc20Api.name({ tokenAddress, networkId }), errorMsg),
     silentPromise(erc20Api.decimals({ tokenAddress, networkId }), errorMsg),
   ])
+
   return {
     address: tokenAddress,
     symbol: parseStringOrBytes32(symbol, 'UNKNOWN'),
     name: parseStringOrBytes32(name, 'Unknown Token'),
-    decimals: decimals || DEFAULT_PRECISION,
+    decimals: decimals !== undefined && decimals >= 0 ? decimals : DEFAULT_PRECISION,
   }
 }


### PR DESCRIPTION
# Summary

Closes #816 

Checked for `0` decimals before default it to `18`

<img width="1188" alt="Screen Shot 2021-11-12 at 09 33 38" src="https://user-images.githubusercontent.com/11525018/141468583-707159f6-7056-4370-bc3a-54e93ad911cc.png">


# To Test

1. Open an order which trade a 0 decimals token
* You'll see the correct value for this token in the `Amount` row

