### PR TITLE
Signing status styles

### DIFF
--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -20,13 +20,7 @@ export interface FeeInformation {
 export type OrderKind = 'sell' | 'buy'
 
 export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'cancelling' | 'expired' | 'signing'
-export type RawOrderStatusFromAPI =
-  | 'presignaturePending'
-  | 'open'
-  | 'fullfilled'
-  | 'cancelled'
-  | 'cancelling'
-  | 'expired'
+export type RawOrderStatusFromAPI = 'presignaturePending' | 'open' | 'fullfilled' | 'cancelled' | 'expired'
 
 // Raw API response
 export type RawOrder = {

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -19,8 +19,14 @@ export interface FeeInformation {
 
 export type OrderKind = 'sell' | 'buy'
 
-export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signing'
-export type RawOrderStatusFromAPI = 'presignaturePending' | 'open' | 'fullfilled' | 'cancelled' | 'expired'
+export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'cancelling' | 'expired' | 'signing'
+export type RawOrderStatusFromAPI =
+  | 'presignaturePending'
+  | 'open'
+  | 'fullfilled'
+  | 'cancelled'
+  | 'cancelling'
+  | 'expired'
 
 // Raw API response
 export type RawOrder = {

--- a/src/components/orders/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/orders/StatusLabel/StatusLabel.stories.tsx
@@ -23,6 +23,9 @@ Expired.args = { status: 'expired' }
 export const Cancelled = Template.bind({})
 Cancelled.args = { status: 'cancelled' }
 
+export const Cancelling = Template.bind({})
+Cancelling.args = { status: 'cancelling' }
+
 export const Open = Template.bind({})
 Open.args = { status: 'open' }
 
@@ -35,3 +38,5 @@ export const ExpiredPartiallyFilled = Template.bind({})
 ExpiredPartiallyFilled.args = { status: 'expired', partiallyFilled: true }
 export const CancelledPartiallyFilled = Template.bind({})
 CancelledPartiallyFilled.args = { status: 'cancelled', partiallyFilled: true }
+export const CancellingPartiallyFilled = Template.bind({})
+CancellingPartiallyFilled.args = { status: 'cancelling', partiallyFilled: true }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -66,7 +66,6 @@ const Label = styled.div<DisplayProps & ShimmingProps>`
   ${({ shimming }): FlattenSimpleInterpolation | null =>
     shimming
       ? css`
-          display: inline-block;
           -webkit-mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
           mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
           background-repeat: no-repeat;

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -20,6 +20,7 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
   switch (status) {
     case 'expired':
     case 'cancelled':
+    case 'cancelling':
       text = theme.orange
       background = theme.orangeOpacity
       break
@@ -93,6 +94,8 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
       return faCheckCircle
     case 'cancelled':
       return faTimesCircle
+    case 'cancelling':
+      return faTimesCircle
     case 'signing':
       return faKey
     case 'open':
@@ -111,7 +114,7 @@ export type Props = DisplayProps & { partiallyFilled: boolean }
 
 export function StatusLabel(props: Props): JSX.Element {
   const { status, partiallyFilled } = props
-  const shimming = status === 'signing'
+  const shimming = status === 'signing' || status === 'cancelling'
 
   return (
     <Wrapper>


### PR DESCRIPTION
# Summary

Closes #843 
Also I've added the "Cancelling" status following the suggestion from Elena (#612)
![image](https://user-images.githubusercontent.com/622217/143253779-891b394b-c579-4d77-a19f-48185d068c8e.png)

# To Test

1.  Open the [Signing StatusLabel](https://pr866--gpui.review.gnosisdev.com/storybook/?path=/story/orders-statuslabel--filled&args=status:signing) component
1. Open the [Cancelling StatusLabel](https://pr866--gpui.review.gnosisdev.com/storybook/?path=/story/orders-statuslabel--filled&args=status:cancelling) component
