### PR TITLE
Tooltips - increase tap area

### DIFF
--- a/src/components/common/DateDisplay/index.tsx
+++ b/src/components/common/DateDisplay/index.tsx
@@ -14,7 +14,8 @@ const Wrapper = styled.div`
 `
 
 const IconWrapper = styled(FontAwesomeIcon)`
-  padding: 0 0.6rem;
+  padding: 0.6rem;
+  margin: -0.6rem 0 -0.6rem -0.6rem;
   box-sizing: content-box;
 
   :hover {

--- a/src/components/common/DateDisplay/index.tsx
+++ b/src/components/common/DateDisplay/index.tsx
@@ -7,6 +7,12 @@ import styled from 'styled-components'
 import { Tooltip } from 'components/Tooltip'
 import { usePopperDefault } from 'hooks/usePopper'
 
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
 const IconWrapper = styled(FontAwesomeIcon)`
   padding: 0 0.6rem;
   box-sizing: content-box;
@@ -33,14 +39,14 @@ export function DateDisplay({ date, showIcon, tooltipPlacement = 'top' }: DateDi
       <Tooltip {...tooltipProps}>
         {distance} - {fullLocaleBased}
       </Tooltip>
-      <div>
+      <Wrapper>
         {showIcon && (
           <span {...targetProps}>
             <IconWrapper icon={faClock} />
           </span>
         )}{' '}
         {!showIcon ? <span {...targetProps}>{previewDate}</span> : <span>{previewDate}</span>}
-      </div>
+      </Wrapper>
     </span>
   )
 }

--- a/src/components/common/DateDisplay/index.tsx
+++ b/src/components/common/DateDisplay/index.tsx
@@ -8,7 +8,8 @@ import { Tooltip } from 'components/Tooltip'
 import { usePopperDefault } from 'hooks/usePopper'
 
 const IconWrapper = styled(FontAwesomeIcon)`
-  margin-right: 0.4rem;
+  padding: 0 0.6rem;
+  box-sizing: content-box;
 `
 
 interface DateDisplayProps {

--- a/src/components/common/DateDisplay/index.tsx
+++ b/src/components/common/DateDisplay/index.tsx
@@ -5,7 +5,7 @@ import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { Placement } from '@popperjs/core'
 import styled from 'styled-components'
 import { Tooltip } from 'components/Tooltip'
-import { usePopperDefault } from 'hooks/usePopper'
+import { usePopperOnClick } from 'hooks/usePopper'
 
 const Wrapper = styled.div`
   display: flex;
@@ -16,6 +16,10 @@ const Wrapper = styled.div`
 const IconWrapper = styled(FontAwesomeIcon)`
   padding: 0 0.6rem;
   box-sizing: content-box;
+
+  :hover {
+    cursor: pointer;
+  }
 `
 
 interface DateDisplayProps {
@@ -25,7 +29,7 @@ interface DateDisplayProps {
 }
 
 export function DateDisplay({ date, showIcon, tooltipPlacement = 'top' }: DateDisplayProps): JSX.Element {
-  const { tooltipProps, targetProps } = usePopperDefault<HTMLInputElement>(tooltipPlacement)
+  const { tooltipProps, targetProps } = usePopperOnClick<HTMLInputElement>(tooltipPlacement)
   // '5 days ago', '1h from now' date format
   const distance = formatDistanceToNowStrict(date, { addSuffix: true })
   // Long localized date and time '04/29/1453 12:00:00 AM'

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -195,7 +195,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.submission} /> Submission Time
             </td>
             <td>
-              <DateDisplay date={creationDate} />
+              <DateDisplay date={creationDate} showIcon={true} />
             </td>
           </tr>
           <tr>
@@ -203,7 +203,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.expiration} /> Expiration Time
             </td>
             <td>
-              <DateDisplay date={expirationDate} />
+              <DateDisplay date={expirationDate} showIcon={true} />
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
# Summary

Closes #846 
The date tooltip behavior ![image](https://user-images.githubusercontent.com/622217/143488797-0c1e95fa-1bc1-444f-9377-e78bf77c53a4.png) has been changed in order to align it with the question mark tooltip ![image](https://user-images.githubusercontent.com/622217/143488764-122daaf5-d08b-4d97-9775-66a5b4f3f1f4.png) (open/close on click/tap)

# To Test

1. <<Step one>> Open the page[ `User details`](https://pr868--gpui.review.gnosisdev.com/rinkeby/address/0xa67aD1130D126ee892a817103baCBcE6d95431fC) and tap over the clock icon on mobile.


