### PR TITLE
Adding resolveENS function and use on UserDetail Page

### DIFF
--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -1,6 +1,4 @@
 import React, { useContext, useState, useEffect } from 'react'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import OrdersTable from 'components/orders/OrdersUserDetailsTable'
 import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
@@ -8,6 +6,7 @@ import { OrdersTableContext } from './context/OrdersTableContext'
 import useFirstRender from 'hooks/useFirstRender'
 import { DEFAULT_TIMEOUT } from 'const'
 import { useSearchInAnotherNetwork, EmptyOrdersMessage } from './useSearchInAnotherNetwork'
+import Spinner from 'components/common/Spinner'
 
 export const OrdersTableWithData: React.FC = () => {
   const {
@@ -39,7 +38,7 @@ export const OrdersTableWithData: React.FC = () => {
 
   return isFirstRender || isFirstLoading ? (
     <EmptyItemWrapper>
-      <FontAwesomeIcon icon={faSpinner} spin size="3x" />
+      <Spinner spin size="3x" />
     </EmptyItemWrapper>
   ) : (
     <OrdersTable

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import ExplorerTabs from 'apps/explorer/components/common/ExplorerTabs/ExplorerTab'
 import { useGetOrders } from './useGetOrders'
@@ -10,6 +8,7 @@ import { useTable } from './useTable'
 import { OrdersTableWithData } from './OrdersTableWithData'
 import { OrdersTableContext, BlockchainNetwork } from './context/OrdersTableContext'
 import PaginationOrdersTable from './PaginationOrdersTable'
+import Spinner from 'components/common/Spinner'
 
 const StyledTabLoader = styled.span`
   padding-left: 4px;
@@ -22,7 +21,7 @@ const tabItems = (isLoadingOrders: boolean): TabItemInterface[] => {
       tab: (
         <>
           Orders
-          <StyledTabLoader>{isLoadingOrders && <FontAwesomeIcon icon={faSpinner} spin size="1x" />}</StyledTabLoader>
+          <StyledTabLoader>{isLoadingOrders && <Spinner spin size="1x" />}</StyledTabLoader>
         </>
       ),
       content: <OrdersTableWithData />,

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 
+import { abbreviateString } from 'utils'
 import { Network } from 'types'
 import { NETWORK_ID_SEARCH_LIST } from 'apps/explorer/const'
 import { BlockchainNetwork } from './context/OrdersTableContext'
@@ -77,7 +78,7 @@ export const EmptyOrdersMessage = ({
       ) : (
         <>
           <p>
-            No orders found on <strong>{Network[networkId]}</strong>.
+            No orders found on <strong>{Network[networkId]}</strong> for {abbreviateString(ownerAddress, 3, 4)}
           </p>
           <section>
             {' '}

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -8,6 +8,7 @@ import { NETWORK_ID_SEARCH_LIST } from 'apps/explorer/const'
 import { BlockchainNetwork } from './context/OrdersTableContext'
 import { Order, getAccountOrders } from 'api/operator'
 import Spinner from 'components/common/Spinner'
+import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
 
 const Wrapper = styled.div`
   display: flex;
@@ -78,7 +79,13 @@ export const EmptyOrdersMessage = ({
       ) : (
         <>
           <p>
-            No orders found on <strong>{Network[networkId]}</strong> for {abbreviateString(ownerAddress, 3, 4)}
+            No orders found on <strong>{Network[networkId]}</strong> for{' '}
+            <BlockExplorerLink
+              identifier={ownerAddress}
+              type="address"
+              label={abbreviateString(ownerAddress, 3, 4)}
+              networkId={networkId}
+            />
           </p>
           <section>
             {' '}

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -9,6 +9,7 @@ import { BlockchainNetwork } from './context/OrdersTableContext'
 import { Order, getAccountOrders } from 'api/operator'
 import Spinner from 'components/common/Spinner'
 import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
+import { MEDIA } from 'const'
 
 const Wrapper = styled.div`
   display: flex;
@@ -16,10 +17,6 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   height: 100%;
-
-  > p {
-    font-weight: 550;
-  }
 
   > section {
     display: flex;
@@ -33,7 +30,7 @@ const Wrapper = styled.div`
   }
 
   ul {
-    padding: 0 0.8rem 0 0;
+    padding: 0;
     margin: 0;
     > li {
       list-style: none;
@@ -42,6 +39,14 @@ const Wrapper = styled.div`
         padding-bottom: 0;
       }
     }
+  }
+`
+const StyledBlockExplorerLink = styled(BlockExplorerLink)`
+  margin-top: 1rem;
+
+  @media ${MEDIA.xSmallDown} {
+    display: flex;
+    justify-content: center;
   }
 `
 interface OrdersInNetwork {
@@ -79,11 +84,11 @@ export const EmptyOrdersMessage = ({
       ) : (
         <>
           <p>
-            No orders found on <strong>{Network[networkId]}</strong> for{' '}
-            <BlockExplorerLink
+            No orders found on <strong>{Network[networkId]}</strong> for:{' '}
+            <StyledBlockExplorerLink
               identifier={ownerAddress}
               type="address"
-              label={abbreviateString(ownerAddress, 3, 4)}
+              label={abbreviateString(ownerAddress, 4, 4)}
               networkId={networkId}
             />
           </p>

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -8,7 +8,7 @@ import { useNetworkId } from 'state/network'
 import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import RedirectToSearch from 'components/RedirectToSearch'
-import { useResolveEns, ResolvedEns } from 'hooks/useResolveEns'
+import { useResolveEns } from 'hooks/useResolveEns'
 import Spinner from 'components/common/Spinner'
 
 const Wrapper = styled.div`
@@ -40,31 +40,31 @@ const TitleAddress = styled(RowWithCopyButton)`
 const UserDetails: React.FC = () => {
   const { address } = useParams<{ address: string }>()
   const networkId = useNetworkId() || undefined
-  const resolvedAddress: ResolvedEns | undefined = useResolveEns(address)
+  const addressAccount = useResolveEns(address)
 
-  if (resolvedAddress?.address === null) {
+  if (addressAccount?.address === null) {
     return <RedirectToSearch from="address" />
   }
 
   return (
     <Wrapper>
-      {resolvedAddress ? (
+      {addressAccount ? (
         <>
           <h1>
             User details
             <TitleAddress
-              textToCopy={resolvedAddress.ens ? resolvedAddress.ens : resolvedAddress.address}
+              textToCopy={addressAccount.address}
               contentsToDisplay={
                 <BlockExplorerLink
                   type="address"
                   networkId={networkId}
                   identifier={address}
-                  label={resolvedAddress.ens}
+                  label={addressAccount.ens}
                 />
               }
             />
           </h1>
-          <OrdersTableWidget ownerAddress={resolvedAddress.address} networkId={networkId} />
+          <OrdersTableWidget ownerAddress={addressAccount.address} networkId={networkId} />
         </>
       ) : (
         <Spinner size="3x" />

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -53,7 +53,7 @@ const UserDetails: React.FC = () => {
           <h1>
             User details
             <TitleAddress
-              textToCopy={resolvedAddress.address}
+              textToCopy={resolvedAddress.ens ? resolvedAddress.ens : resolvedAddress.address}
               contentsToDisplay={
                 <BlockExplorerLink
                   type="address"

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { useParams } from 'react-router'
 import styled from 'styled-components'
-
-import { isAddress } from 'web3-utils'
 
 import { media } from 'theme/styles/media'
 import OrdersTableWidget from '../components/OrdersTableWidget'
@@ -10,8 +8,7 @@ import { useNetworkId } from 'state/network'
 import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import RedirectToSearch from 'components/RedirectToSearch'
-import { isEns } from 'utils'
-import { resolveENS } from 'hooks/useSearchSubmit'
+import { useResolveEns, ResolvedEns } from 'hooks/useResolveEns'
 import Spinner from 'components/common/Spinner'
 
 const Wrapper = styled.div`
@@ -43,24 +40,9 @@ const TitleAddress = styled(RowWithCopyButton)`
 const UserDetails: React.FC = () => {
   const { address } = useParams<{ address: string }>()
   const networkId = useNetworkId() || undefined
-  const [resolvedAddress, setResolvedAddress] = useState<string | undefined | null>()
+  const resolvedAddress: ResolvedEns | undefined = useResolveEns(address)
 
-  useEffect(() => {
-    async function _resolveENS(): Promise<void> {
-      const _address = await resolveENS(address)
-      setResolvedAddress(_address)
-    }
-
-    if (isAddress(address)) {
-      setResolvedAddress(address)
-    } else if (isEns(address)) {
-      _resolveENS()
-    } else {
-      setResolvedAddress(null)
-    }
-  }, [address, networkId])
-
-  if (resolvedAddress === null) {
+  if (resolvedAddress?.address === null) {
     return <RedirectToSearch from="address" />
   }
 
@@ -71,18 +53,18 @@ const UserDetails: React.FC = () => {
           <h1>
             User details
             <TitleAddress
-              textToCopy={resolvedAddress}
+              textToCopy={resolvedAddress.address}
               contentsToDisplay={
                 <BlockExplorerLink
                   type="address"
                   networkId={networkId}
                   identifier={address}
-                  label={isEns(address) ? address : undefined}
+                  label={resolvedAddress.ens}
                 />
               }
             />
           </h1>
-          <OrdersTableWidget ownerAddress={resolvedAddress} networkId={networkId} />
+          <OrdersTableWidget ownerAddress={resolvedAddress.address} networkId={networkId} />
         </>
       ) : (
         <Spinner size="3x" />

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -3,8 +3,6 @@ import { useParams } from 'react-router'
 import styled from 'styled-components'
 
 import { isAddress } from 'web3-utils'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { media } from 'theme/styles/media'
 import OrdersTableWidget from '../components/OrdersTableWidget'
@@ -14,6 +12,7 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import RedirectToSearch from 'components/RedirectToSearch'
 import { isEns } from 'utils'
 import { resolveENS } from 'hooks/useSearchSubmit'
+import Spinner from 'components/common/Spinner'
 
 const Wrapper = styled.div`
   padding: 1.6rem;
@@ -56,6 +55,8 @@ const UserDetails: React.FC = () => {
       setResolvedAddress(address)
     } else if (isEns(address)) {
       _resolveENS()
+    } else {
+      setResolvedAddress(null)
     }
   }, [address, networkId])
 
@@ -84,7 +85,7 @@ const UserDetails: React.FC = () => {
           <OrdersTableWidget ownerAddress={resolvedAddress} networkId={networkId} />
         </>
       ) : (
-        <FontAwesomeIcon icon={faSpinner} spin size="3x" />
+        <Spinner size="3x" />
       )}
     </Wrapper>
   )

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
-import { faExchangeAlt, faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
@@ -21,7 +21,7 @@ import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Spinner from 'components/common/Spinner'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
@@ -155,7 +155,7 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
   }
 
   const renderSpinnerWhenNoValue = (textValue: string): JSX.Element | void => {
-    if (textValue === '-') return <FontAwesomeIcon icon={faSpinner} spin size="1x" />
+    if (textValue === '-') return <Spinner spin size="1x" />
   }
 
   return (

--- a/src/hooks/useResolveEns.ts
+++ b/src/hooks/useResolveEns.ts
@@ -3,29 +3,29 @@ import { useState, useEffect } from 'react'
 import { isEns } from 'utils'
 import { resolveENS } from './useSearchSubmit'
 
-export interface ResolvedEns {
+interface AddressAccount {
   address: string | null
   ens?: string
 }
 
-export function useResolveEns(address: string): ResolvedEns | undefined {
-  const [resolvedEns, setResolvedEns] = useState<ResolvedEns | undefined>()
+export function useResolveEns(address: string): AddressAccount | undefined {
+  const [addressAccount, setAddressAccount] = useState<AddressAccount | undefined>()
 
   useEffect(() => {
     async function _resolveENS(name: string): Promise<void> {
       const _address = await resolveENS(name)
-      setResolvedEns({ address: _address, ens: name })
+      setAddressAccount({ address: _address, ens: name })
     }
 
-    setResolvedEns(undefined)
+    setAddressAccount(undefined)
     if (isEns(address)) {
       _resolveENS(address)
     } else if (isAddress(address)) {
-      setResolvedEns({ address })
+      setAddressAccount({ address })
     } else {
-      setResolvedEns({ address: null })
+      setAddressAccount({ address: null })
     }
   }, [address])
 
-  return resolvedEns
+  return addressAccount
 }

--- a/src/hooks/useResolveEns.ts
+++ b/src/hooks/useResolveEns.ts
@@ -1,0 +1,31 @@
+import { isAddress } from 'web3-utils'
+import { useState, useEffect } from 'react'
+import { isEns } from 'utils'
+import { resolveENS } from './useSearchSubmit'
+
+export interface ResolvedEns {
+  address: string | null
+  ens?: string
+}
+
+export function useResolveEns(address: string): ResolvedEns | undefined {
+  const [resolvedEns, setResolvedEns] = useState<ResolvedEns | undefined>()
+
+  useEffect(() => {
+    async function _resolveENS(name: string): Promise<void> {
+      const _address = await resolveENS(name)
+      setResolvedEns({ address: _address, ens: name })
+    }
+
+    setResolvedEns(undefined)
+    if (isEns(address)) {
+      _resolveENS(address)
+    } else if (isAddress(address)) {
+      setResolvedEns({ address })
+    } else {
+      setResolvedEns({ address: null })
+    }
+  }, [address])
+
+  return resolvedEns
+}

--- a/src/hooks/useSearchSubmit.ts
+++ b/src/hooks/useSearchSubmit.ts
@@ -15,6 +15,18 @@ export function pathAccordingTo(query: string): string {
   return path
 }
 
+export async function resolveENS(name: string): Promise<string | null> {
+  if (!web3) return null
+
+  try {
+    const address = await web3.eth.ens.getAddress(name)
+    return address && address.length > 0 ? address : null
+  } catch (e) {
+    console.error(`[web3:api] Could not resolve ${name} ENS. `, e)
+    return null
+  }
+}
+
 export function useSearchSubmit(): (query: string) => void {
   const history = useHistory()
   const prefixNetwork = usePathPrefix()
@@ -27,18 +39,7 @@ export function useSearchSubmit(): (query: string) => void {
       const pathPrefix = prefixNetwork ? `${prefixNetwork}/${path}` : `${path}`
 
       if (path === 'address' && isEns(query)) {
-        if (web3) {
-          web3.eth.ens
-            .getAddress(query)
-            .then((res) => {
-              if (res && res.length > 0) {
-                history.push(`/${pathPrefix}/${res}`)
-              } else {
-                history.push(`/${pathPrefix}/${query}`)
-              }
-            })
-            .catch(() => history.push(`/${pathPrefix}/${query}`))
-        }
+        history.push(`/${path}/${query}`)
       } else {
         query && query.length > 0 && history.push(`/${pathPrefix}/${query}`)
       }


### PR DESCRIPTION
# Summary
Closes #869 

**Proposal:**
- Allow use `ENS` directly like URL as `/address/<ens_name>`

:warning: This solution prioritizes **Mainnet**, i.e. when searching `.../<network>/search/ensText.eth` it will search in **Mainnet**.

## To Test
- Visit `address` with valid :heavy_check_mark:  **ENS**
[/address/cosmoburn.eth](https://pr888--gpui.review.gnosisdev.com/address/cosmoburn.eth/)
- Visit `address` with Invalid :red_circle:  **ENS**
[/address/asereje.eth](https://pr888--gpui.review.gnosisdev.com/address/asereje.eth/)
