### PR TITLE
[Explorer] Networks change menu

### DIFF
--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -257,7 +257,7 @@ export async function getTrades(params: GetTradesParams): Promise<RawTrade[]> {
   }
 
   console.log(`[getTrades] Fetching trades on network ${networkId} with filters: owner=${owner} orderId=${orderId}`)
-  console.log(owner, orderId)
+
   const queryString = `/trades/` + buildSearchString({ owner, orderUid: orderId })
 
   return _fetchQuery(networkId, queryString)

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -257,7 +257,7 @@ export async function getTrades(params: GetTradesParams): Promise<RawTrade[]> {
   }
 
   console.log(`[getTrades] Fetching trades on network ${networkId} with filters: owner=${owner} orderId=${orderId}`)
-
+  console.log(owner, orderId)
   const queryString = `/trades/` + buildSearchString({ owner, orderUid: orderId })
 
   return _fetchQuery(networkId, queryString)

--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -23,6 +23,10 @@ export const OrdersTableWithData: React.FC = () => {
   } = useSearchInAnotherNetwork(networkId, ownerAddress, orders)
 
   useEffect(() => {
+    setIsFirstLoading(true)
+  }, [networkId])
+
+  useEffect(() => {
     let timeOutMs = 0
     if (!orders) {
       timeOutMs = DEFAULT_TIMEOUT

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { Navigation } from 'components/layout/GenericLayout/Navigation'
 import { Header as GenericHeader } from 'components/layout/GenericLayout/Header'
+import { NetworkSelector } from 'components/NetworkSelector'
 import { getNetworkFromId } from '@gnosis.pm/dex-js'
 import { useNetworkId } from 'state/network'
 import styled from 'styled-components'
@@ -29,28 +30,6 @@ const Logo = styled.span`
   }
 `
 
-const NetworkLabel = styled.span`
-  border-radius: 0.6rem;
-  display: flex;
-  margin: 0 0.5rem;
-  font-size: 1.1rem;
-  text-align: center;
-  padding: 0.7rem;
-  text-transform: uppercase;
-  font-weight: ${({ theme }): string => theme.fontBold};
-  letter-spacing: 0.1rem;
-
-  &.rinkeby {
-    background: ${({ theme }): string => theme.borderPrimary};
-    color: ${({ theme }): string => theme.textSecondary1};
-  }
-
-  &.xdai {
-    background: ${({ theme }): string => theme.orangeOpacity};
-    color: ${({ theme }): string => theme.orange};
-  }
-`
-
 export const Header: React.FC = () => {
   const networkId = useNetworkId()
   if (!networkId) {
@@ -62,7 +41,7 @@ export const Header: React.FC = () => {
   return (
     <GenericHeader logoAlt="Gnosis Protocol" linkTo={`/${network || ''}`} label={<Logo>Gnosis Protocol</Logo>}>
       <Navigation>
-        {network && <NetworkLabel className={network}>{network}</NetworkLabel>}
+        <NetworkSelector networkId={networkId} />
         {/*      
         <li>
           <Link to="/">Batches</Link>

--- a/src/apps/explorer/pages/NotFound.tsx
+++ b/src/apps/explorer/pages/NotFound.tsx
@@ -58,7 +58,7 @@ const StyledLink = styled(Link)`
     text-decoration: none;
   }
 `
-const NotFound2: React.FC = () => {
+const NotFoundRequestPage: React.FC = () => {
   const networkId = useNetworkId() || 1
   const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : ''
 
@@ -73,4 +73,4 @@ const NotFound2: React.FC = () => {
   )
 }
 
-export default NotFound2
+export default NotFoundRequestPage

--- a/src/apps/explorer/pages/NotFound.tsx
+++ b/src/apps/explorer/pages/NotFound.tsx
@@ -3,6 +3,9 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
 
+import { getNetworkFromId } from '@gnosis.pm/dex-js'
+import { useNetworkId } from 'state/network'
+
 const Wrapper = styled.div`
   max-width: 118rem;
   margin: 0 auto;
@@ -55,14 +58,19 @@ const StyledLink = styled(Link)`
     text-decoration: none;
   }
 `
-const NotFound2: React.FC = () => (
-  <Wrapper>
-    <Title>Page not found</Title>
-    <Content>
-      <p>We&apos;re sorry, the page you requested could not be found.</p>
-      <StyledLink to="/">Back Home</StyledLink>
-    </Content>
-  </Wrapper>
-)
+const NotFound2: React.FC = () => {
+  const networkId = useNetworkId() || 1
+  const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : ''
+
+  return (
+    <Wrapper>
+      <Title>Page not found</Title>
+      <Content>
+        <p>We&apos;re sorry, the page you requested could not be found.</p>
+        <StyledLink to={`/${network}`}>Back Home</StyledLink>
+      </Content>
+    </Wrapper>
+  )
+}
 
 export default NotFound2

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -65,7 +65,7 @@ export const Option = styled.div`
     border-radius: 100%;
     margin-right: 9px;
     &.rinkeby {
-      background: ${({ theme }): string => theme.borderPrimary};
+      background: ${({ theme }): string => theme.yellow4};
     }
     &.xdai {
       background: ${({ theme }): string => theme.orange1};
@@ -88,8 +88,8 @@ export const NetworkLabel = styled.span`
   letter-spacing: 0.1rem;
 
   &.rinkeby {
-    background: ${({ theme }): string => theme.borderPrimary};
-    color: ${({ theme }): string => theme.textSecondary1};
+    background: ${({ theme }): string => theme.yellow4};
+    color: ${({ theme }): string => theme.black};
   }
 
   &.ethereum {

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -1,0 +1,111 @@
+import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { COLOURS } from 'styles'
+
+const { fadedGreyishWhiteOpacity, white } = COLOURS
+
+export const SelectorContainer = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  .arrow {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: ${({ theme }): string => `5px solid ${theme.grey}`};
+    transform: rotate(0deg);
+    transition: transform 0.1s linear;
+    &.open {
+      transform: rotate(180deg);
+      transition: transform 0.1s linear;
+    }
+  }
+`
+
+export const OptionsContainer = styled.div<{ width: number }>`
+  position: absolute;
+  z-index: 1;
+  margin: 0 auto;
+  width: ${(props: { width: number }): string => `${184 + props.width}px`};
+  height: 128px;
+  left: 15px;
+  top: 50px;
+  background: ${({ theme }): string => theme.bg1};
+  border: ${(): string => `1px solid ${fadedGreyishWhiteOpacity}`};
+  box-sizing: border-box;
+  border-radius: 6px;
+`
+
+export const Option = styled.div`
+  display: flex;
+  flex: 1;
+  font-family: var(--font-avenir);
+  font-weight: 800;
+  font-size: 13px;
+  line-height: 18px;
+  align-items: center;
+  letter-spacing: 0.02em;
+  padding: 12px 16px;
+  &:hover {
+    backdrop-filter: contrast(0.9);
+    .name {
+      color: ${(): string => white};
+    }
+  }
+  .name {
+    color: ${({ theme }): string => theme.grey};
+    &.selected {
+      color: ${(): string => white};
+    }
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 100%;
+    margin-right: 9px;
+    &.rinkeby {
+      background: ${({ theme }): string => theme.borderPrimary};
+    }
+    &.xdai {
+      background: ${({ theme }): string => theme.orange1};
+    }
+    &.mainnet {
+      background: ${({ theme }): string => theme.green};
+    }
+  }
+`
+
+export const NetworkLabel = styled.span`
+  border-radius: 0.6rem;
+  display: flex;
+  margin: 0 0.5rem;
+  font-size: 1.1rem;
+  text-align: center;
+  padding: 0.7rem;
+  text-transform: uppercase;
+  font-weight: ${({ theme }): string => theme.fontBold};
+  letter-spacing: 0.1rem;
+
+  &.rinkeby {
+    background: ${({ theme }): string => theme.borderPrimary};
+    color: ${({ theme }): string => theme.textSecondary1};
+  }
+
+  &.mainnet {
+    background: ${({ theme }): string => theme.green};
+    color: ${({ theme }): string => theme.textSecondary1};
+  }
+
+  &.xdai {
+    background: ${({ theme }): string => theme.orangeOpacity};
+    color: ${({ theme }): string => theme.orange};
+  }
+`
+
+export const StyledFAIcon = styled(FontAwesomeIcon)`
+  color: ${({ theme }): string => theme.orange};
+  position: absolute;
+  right: 10px;
+  font-size: 14px;
+`

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -70,8 +70,8 @@ export const Option = styled.div`
     &.xdai {
       background: ${({ theme }): string => theme.orange1};
     }
-    &.mainnet {
-      background: ${({ theme }): string => theme.green};
+    &.ethereum {
+      background: ${({ theme }): string => theme.blue4};
     }
   }
 `
@@ -92,8 +92,8 @@ export const NetworkLabel = styled.span`
     color: ${({ theme }): string => theme.textSecondary1};
   }
 
-  &.mainnet {
-    background: ${({ theme }): string => theme.green};
+  &.ethereum {
+    background: ${({ theme }): string => theme.blue4};
     color: ${({ theme }): string => theme.textSecondary1};
   }
 

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -1,0 +1,68 @@
+import React, { useRef, useState } from 'react'
+import { useHistory } from 'react-router'
+import { useLocation } from 'react-router-dom'
+import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { SelectorContainer, OptionsContainer, Option, NetworkLabel, StyledFAIcon } from './NetworkSelector.styled'
+import { replaceURL } from 'utils/url'
+import { Network } from 'types'
+
+type networkSelectorProps = {
+  networkId: number
+}
+
+type NetworkOptions = {
+  id: Network
+  name: string
+  url: string
+}
+
+const networkOptions: NetworkOptions[] = [
+  {
+    id: Network.Mainnet,
+    name: 'Ethereum Mainnet',
+    url: 'mainnet',
+  },
+  {
+    id: Network.Rinkeby,
+    name: 'Rinkeby',
+    url: 'rinkeby',
+  },
+  {
+    id: Network.xDAI,
+    name: 'xDAI',
+    url: 'xdai',
+  },
+]
+
+export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) => {
+  const selectContainer = useRef<HTMLInputElement>(null)
+  const history = useHistory()
+  const location = useLocation()
+  const name = networkOptions.find((network) => network.id === networkId)?.name.toLowerCase()
+  const [open, setOpen] = useState(false)
+
+  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void =>
+    history.push(
+      replaceURL(currentNetwork === Network.Mainnet ? `/mainnet${location.pathname}` : location.pathname, newNetwork),
+    )
+
+  return (
+    <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>
+      <NetworkLabel className={name}>{name}</NetworkLabel>
+      <span className={`arrow ${open && 'open'}`} />
+      {open && (
+        <OptionsContainer width={selectContainer.current?.offsetWidth || 0}>
+          {networkOptions.map((network) => (
+            <Option onClick={(): void => redirectToNetwork(network.url, networkId)} key={network.id}>
+              <div className={`dot ${network.name.toLowerCase()} `} />
+              <div className={`name ${network.id === networkId && 'selected'}`}>{network.name}</div>
+              {network.id === networkId && <StyledFAIcon icon={faCheck} />}
+            </Option>
+          ))}
+        </OptionsContainer>
+      )}
+    </SelectorContainer>
+  )
+}
+
+export default NetworkSelector

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -42,22 +42,42 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
   const [open, setOpen] = useState(false)
 
   useEffect(() => {
-    const closeOpenSelector = (e: MouseEvent): void => {
-      if (selectContainer.current && open && !selectContainer.current.contains(e.target as HTMLElement)) {
-        setOpen(false)
+    const closeOpenSelector = (e: MouseEvent | KeyboardEvent): void => {
+      if (!open) return
+      if (e instanceof KeyboardEvent) {
+        if (e.key === 'Escape') {
+          setOpen(false)
+          return
+        }
+      } else {
+        if (selectContainer.current && !selectContainer.current.contains(e.target as HTMLElement)) {
+          setOpen(false)
+        }
       }
     }
 
     window.addEventListener('mousedown', closeOpenSelector)
+    window.addEventListener('keydown', closeOpenSelector)
 
-    return (): void => window.removeEventListener('mousedown', closeOpenSelector)
+    return (): void => {
+      window.removeEventListener('mousedown', closeOpenSelector)
+      window.removeEventListener('keydown', closeOpenSelector)
+    }
   }, [open])
 
-  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void =>
-    history.push(
-      replaceURL(currentNetwork === Network.Mainnet ? `/mainnet${location.pathname}` : location.pathname, newNetwork),
-    )
+  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void => {
+    const NoRedirectHomeRoutes = ['/address']
+    const shouldNotRedirectHome = NoRedirectHomeRoutes.some((r: string) => location.pathname.includes(r))
 
+    history.push(
+      shouldNotRedirectHome
+        ? replaceURL(
+            currentNetwork === Network.Mainnet ? `/mainnet${location.pathname}` : location.pathname,
+            newNetwork,
+          )
+        : `/${newNetwork}`,
+    )
+  }
   return (
     <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>
       <NetworkLabel className={name}>{name}</NetworkLabel>

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { SelectorContainer, OptionsContainer, Option, NetworkLabel, StyledFAIcon } from './NetworkSelector.styled'
 import { replaceURL } from 'utils/url'
+import { NO_REDIRECT_HOME_ROUTES } from 'const'
 import { Network } from 'types'
 
 type networkSelectorProps = {
@@ -20,7 +21,7 @@ const networkOptions: NetworkOptions[] = [
   {
     id: Network.Mainnet,
     name: 'Ethereum',
-    url: 'mainnet',
+    url: '',
   },
   {
     id: Network.xDAI,
@@ -64,17 +65,8 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
   }, [open])
 
   const redirectToNetwork = (newNetwork: string, currentNetwork: number): void => {
-    const NoRedirectHomeRoutes = ['/address']
-    const shouldNotRedirectHome = NoRedirectHomeRoutes.some((r: string) => location.pathname.includes(r))
-
-    history.push(
-      shouldNotRedirectHome
-        ? replaceURL(
-            currentNetwork === Network.Mainnet ? `/mainnet${location.pathname}` : location.pathname,
-            newNetwork,
-          )
-        : `/${newNetwork}`,
-    )
+    const shouldNotRedirectHome = NO_REDIRECT_HOME_ROUTES.some((r: string) => location.pathname.includes(r))
+    history.push(shouldNotRedirectHome ? replaceURL(location.pathname, newNetwork, currentNetwork) : `/${newNetwork}`)
   }
   return (
     <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -41,10 +41,12 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
   const name = networkOptions.find((network) => network.id === networkId)?.name.toLowerCase()
   const [open, setOpen] = useState(false)
 
-  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void =>
+  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void => {
+    console.log('alla')
     history.push(
       replaceURL(currentNetwork === Network.Mainnet ? `/mainnet${location.pathname}` : location.pathname, newNetwork),
     )
+  }
 
   return (
     <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -49,10 +49,8 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
           setOpen(false)
           return
         }
-      } else {
-        if (selectContainer.current && !selectContainer.current.contains(e.target as HTMLElement)) {
-          setOpen(false)
-        }
+      } else if (selectContainer.current && !selectContainer.current.contains(e.target as HTMLElement)) {
+        setOpen(false)
       }
     }
 

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
@@ -19,18 +19,18 @@ type NetworkOptions = {
 const networkOptions: NetworkOptions[] = [
   {
     id: Network.Mainnet,
-    name: 'Ethereum Mainnet',
+    name: 'Ethereum',
     url: 'mainnet',
-  },
-  {
-    id: Network.Rinkeby,
-    name: 'Rinkeby',
-    url: 'rinkeby',
   },
   {
     id: Network.xDAI,
     name: 'xDAI',
     url: 'xdai',
+  },
+  {
+    id: Network.Rinkeby,
+    name: 'Rinkeby',
+    url: 'rinkeby',
   },
 ]
 
@@ -41,12 +41,22 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
   const name = networkOptions.find((network) => network.id === networkId)?.name.toLowerCase()
   const [open, setOpen] = useState(false)
 
-  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void => {
-    console.log('alla')
+  useEffect(() => {
+    const closeOpenSelector = (e: MouseEvent): void => {
+      if (selectContainer.current && open && !selectContainer.current.contains(e.target as HTMLElement)) {
+        setOpen(false)
+      }
+    }
+
+    window.addEventListener('mousedown', closeOpenSelector)
+
+    return (): void => window.removeEventListener('mousedown', closeOpenSelector)
+  }, [open])
+
+  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void =>
     history.push(
       replaceURL(currentNetwork === Network.Mainnet ? `/mainnet${location.pathname}` : location.pathname, newNetwork),
     )
-  }
 
   return (
     <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -10,6 +10,7 @@ import LogoImage from 'assets/img/logo-v2.svg'
 const HeaderStyled = styled.header`
   height: auto;
   margin: 2.2rem auto 0;
+  position: relative;
   display: flex;
   align-items: center;
   box-sizing: border-box;

--- a/src/components/layout/GenericLayout/variablesCss.ts
+++ b/src/components/layout/GenericLayout/variablesCss.ts
@@ -14,6 +14,7 @@ const AllColors = `
   /* FONTS */
   --font-default: "Inter", "Helvetica Neue", Helvetica, sans-serif;
   --font-arial: Arial, Helvetica, sans-serif;
+  --font-avenir: Avenir, Helvetica, sans-serif;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-bold: 700;

--- a/src/const.ts
+++ b/src/const.ts
@@ -245,3 +245,5 @@ export const NATIVE_TOKEN_PER_NETWORK: Record<string, TokenErc20> = {
   '4': ETH,
   '100': XDAI,
 }
+
+export const NO_REDIRECT_HOME_ROUTES: Array<string> = ['/address']

--- a/src/styles/colours.ts
+++ b/src/styles/colours.ts
@@ -20,4 +20,5 @@ export const COLOURS = {
   mainGradient: 'linear-gradient(270deg, #8958FF 0%, #3F77FF 100%)',
   mainGradientDarker: 'linear-gradient(270deg, #6a2cff 0%, #185afb 100%)',
   fadedGreyishWhite: 'rgba(141, 141, 169, 0.08)',
+  fadedGreyishWhiteOpacity: 'rgba(141, 141, 169, 0.3)',
 }

--- a/src/theme/styles/colours.ts
+++ b/src/theme/styles/colours.ts
@@ -48,6 +48,7 @@ export interface Colors {
   blue1: Color
   blue2: Color
   blue3?: Color
+  blue4: Color
   orange: Color
   orangeOpacity: Color
   orange1: Color
@@ -67,6 +68,7 @@ export const BASE_COLOURS = {
   yellow2: '#f1851d',
   blue1: '#2172E5',
   blue2: '#3F77FF',
+  blue4: '#62688F',
   orange1: '#D96D49',
 }
 

--- a/src/theme/styles/colours.ts
+++ b/src/theme/styles/colours.ts
@@ -45,6 +45,7 @@ export interface Colors {
   yellow1: Color
   yellow2: Color
   yellow3?: Color
+  yellow4: Color
   blue1: Color
   blue2: Color
   blue3?: Color
@@ -66,6 +67,7 @@ export const BASE_COLOURS = {
   green3: '#a9ffcd',
   yellow1: '#f1851d',
   yellow2: '#f1851d',
+  yellow4: '#f6c343',
   blue1: '#2172E5',
   blue2: '#3F77FF',
   blue4: '#62688F',

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -11,3 +11,9 @@ export function buildSearchString(params: Record<string, string | undefined>): s
 
   return '?' + searchObj.toString()
 }
+
+export function replaceURL(url: string, strReplace: string): string {
+  const re = /(([\w]+\/){0})([^/]+)(\/.+)/gm
+  const subst = '$1' + strReplace + '$4'
+  return url.replace(re, subst)
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,3 +1,5 @@
+import { Network } from 'types'
+
 export function buildSearchString(params: Record<string, string | undefined>): string {
   const filteredParams = Object.keys(params).reduce((acc, key) => {
     // Pick keys that have values non-falsy
@@ -12,8 +14,9 @@ export function buildSearchString(params: Record<string, string | undefined>): s
   return '?' + searchObj.toString()
 }
 
-export function replaceURL(url: string, strReplace: string): string {
-  const re = /(([\w]+\/){0})([^/]+)(\/.+)*/gm
-  const subst = '$1' + strReplace + '$4'
-  return url.replace(re, subst)
+export function replaceURL(url: string, strReplace: string, currentNetwork: number): string {
+  const re = strReplace ? /(([\w]+\/){0})([^/]+)(\/.+)*/gm : /(?:\/[^/]+){1}/
+  const subst = strReplace ? '$1' + strReplace + '$4' : ''
+  if (currentNetwork === Network.Mainnet) return url.replace(/^/, `/${strReplace}`)
+  else return url.replace(re, subst)
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,8 +15,9 @@ export function buildSearchString(params: Record<string, string | undefined>): s
 }
 
 export function replaceURL(url: string, strReplace: string, currentNetwork: number): string {
+  if (currentNetwork === Network.Mainnet) return url.replace(/^/, `/${strReplace}`)
   const re = strReplace ? /(([\w]+\/){0})([^/]+)(\/.+)*/gm : /(?:\/[^/]+){1}/
   const subst = strReplace ? '$1' + strReplace + '$4' : ''
-  if (currentNetwork === Network.Mainnet) return url.replace(/^/, `/${strReplace}`)
-  else return url.replace(re, subst)
+
+  return url.replace(re, subst)
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,6 +15,5 @@ export function buildSearchString(params: Record<string, string | undefined>): s
 export function replaceURL(url: string, strReplace: string): string {
   const re = /(([\w]+\/){0})([^/]+)(\/.+)*/gm
   const subst = '$1' + strReplace + '$4'
-  console.log('Romiii', url.replace(re, subst))
   return url.replace(re, subst)
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -13,7 +13,8 @@ export function buildSearchString(params: Record<string, string | undefined>): s
 }
 
 export function replaceURL(url: string, strReplace: string): string {
-  const re = /(([\w]+\/){0})([^/]+)(\/.+)/gm
+  const re = /(([\w]+\/){0})([^/]+)(\/.+)*/gm
   const subst = '$1' + strReplace + '$4'
+  console.log('Romiii', url.replace(re, subst))
   return url.replace(re, subst)
 }

--- a/test/utils/url.spec.ts
+++ b/test/utils/url.spec.ts
@@ -1,0 +1,18 @@
+import { replaceURL } from 'utils/url'
+
+describe('replace URL path according to network', () => {
+  test('path is replaced to rinkeby', () => {
+    const currentPath = '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, 'rinkeby')).toBe('/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+  })
+
+  test('path is replaced to xdai', () => {
+    const currentPath = '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, 'xdai')).toBe('/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+  })
+
+  test('url is replaced to mainnet', () => {
+    const currentPath = '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, 'mainnet')).toBe('/mainnet/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+  })
+})

--- a/test/utils/url.spec.ts
+++ b/test/utils/url.spec.ts
@@ -1,19 +1,24 @@
+import { Network } from 'types'
 import { replaceURL, buildSearchString } from 'utils/url'
 
 describe('replace URL path according to network', () => {
   test('path is replaced to rinkeby', () => {
     const currentPath = '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
-    expect(replaceURL(currentPath, 'rinkeby')).toBe('/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+    expect(replaceURL(currentPath, 'rinkeby', Network.xDAI)).toBe(
+      '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9',
+    )
   })
 
   test('path is replaced to xdai', () => {
     const currentPath = '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
-    expect(replaceURL(currentPath, 'xdai')).toBe('/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+    expect(replaceURL(currentPath, 'xdai', Network.Rinkeby)).toBe(
+      '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9',
+    )
   })
 
   test('url is replaced to mainnet', () => {
-    const currentPath = '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
-    expect(replaceURL(currentPath, 'mainnet')).toBe('/mainnet/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+    const currentPath = '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, '', Network.Rinkeby)).toBe('/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
   })
 })
 

--- a/test/utils/url.spec.ts
+++ b/test/utils/url.spec.ts
@@ -1,4 +1,4 @@
-import { replaceURL } from 'utils/url'
+import { replaceURL, buildSearchString } from 'utils/url'
 
 describe('replace URL path according to network', () => {
   test('path is replaced to rinkeby', () => {
@@ -14,5 +14,16 @@ describe('replace URL path according to network', () => {
   test('url is replaced to mainnet', () => {
     const currentPath = '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
     expect(replaceURL(currentPath, 'mainnet')).toBe('/mainnet/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+  })
+})
+
+describe('BuildSearchString', () => {
+  test('params decoded correctly', () => {
+    const owner = '0xbD326ba3D9BaD3A08cf521C41bC69A620a750B3f'
+    const orderId =
+      '0x59920c85de0162e9e55df8d396e75f3b6b7c2dfdb535f03e5c807731c31585eaff714b8b0e2700303ec912bd40496c3997ceea2b616d6710'
+    const queryString = `/trades` + buildSearchString({ owner, orderUid: orderId })
+
+    expect(queryString).toBe(`/trades?owner=${owner}&orderUid=${orderId}`)
   })
 })


### PR DESCRIPTION
# Summary

Closes #160 

Added a networks menu on header in order to change between networks quickly

<img width="1301" alt="Screen Shot 2021-12-09 at 11 13 18" src="https://user-images.githubusercontent.com/11525018/145412932-681faf12-4cb2-4302-9e29-e4f26ce2b33e.png">


# To Test

1.  Open any page in Explorer.
* Click on network name next to header.
* A selector will appear with the different available networks to change.
* Clicking on any of the networks will redirect to the explorer network domain.

