### PR TITLE
Validate if query isATxHash

### DIFF
--- a/src/apps/explorer/components/TransactionsTableWidget/index.tsx
+++ b/src/apps/explorer/components/TransactionsTableWidget/index.tsx
@@ -1,15 +1,39 @@
 import React from 'react'
 
-import { BlockchainNetwork } from '../OrdersTableWidget/context/OrdersTableContext'
+import { TitleAddress } from 'apps/explorer/pages/styled'
 import { useGetTxOrders } from 'hooks/useGetOrders'
+import RedirectToSearch from 'components/RedirectToSearch'
+import Spinner from 'components/common/Spinner'
+import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
+import { useNetworkId } from 'state/network'
 
 interface Props {
   txHash: string
-  networkId: BlockchainNetwork
 }
 
 export const TransactionsTableWidget: React.FC<Props> = ({ txHash }) => {
   const { orders, isLoading: isTxLoading } = useGetTxOrders(txHash)
+  const networkId = useNetworkId() || undefined
 
-  return isTxLoading ? <h2>Loading</h2> : <h2>{orders ? orders.length : '0'} Tx found.</h2>
+  if (!isTxLoading && orders && orders.length < 1) {
+    return <RedirectToSearch from="tx" />
+  }
+
+  if (!orders) {
+    return <Spinner spin size="3x" />
+  }
+
+  // TODO replace with a real table component
+  return (
+    <>
+      <h1>
+        Transaction details
+        <TitleAddress
+          textToCopy={txHash}
+          contentsToDisplay={<BlockExplorerLink type="tx" networkId={networkId} identifier={txHash} />}
+        />
+      </h1>
+      <h2>{orders.length} Tx found.</h2>
+    </>
+  )
 }

--- a/src/apps/explorer/components/common/Search/index.tsx
+++ b/src/apps/explorer/components/common/Search/index.tsx
@@ -15,6 +15,7 @@ export const Search: React.FC<React.HTMLAttributes<HTMLDivElement> & SearchProps
   const [query, setQuery] = useState('')
   const [showPlaceholder, setShowPlaceholder] = useState(true)
   const handleSubmit = useSearchSubmit()
+  const placeHolderText = 'Order ID / ETH Address / ENS Address / Tx Hash'
 
   useEffect(() => {
     if (searchString && submitSearchImmediatly) {
@@ -39,10 +40,10 @@ export const Search: React.FC<React.HTMLAttributes<HTMLDivElement> & SearchProps
         name="query"
         value={query}
         onChange={(e): void => setQuery(e.target.value.trim())}
-        placeholder="Order ID / ETH Address / ENS Address"
+        placeholder={placeHolderText}
         aria-label="Search the GP explorer for orders, batches and transactions"
       />
-      <Placeholder isActive={showPlaceholder}>Order ID / ETH Address / ENS Address</Placeholder>
+      <Placeholder isActive={showPlaceholder}>{placeHolderText}</Placeholder>
     </Wrapper>
   )
 }

--- a/src/apps/explorer/pages/TransactionDetails.tsx
+++ b/src/apps/explorer/pages/TransactionDetails.tsx
@@ -1,26 +1,21 @@
 import React from 'react'
 import { useParams } from 'react-router'
 
-import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
-import { TitleAddress, WrapperPage } from 'apps/explorer/pages/styled'
-import { useNetworkId } from 'state/network'
+import { isATxHash } from 'utils'
+import RedirectToSearch from 'components/RedirectToSearch'
+import { WrapperPage } from 'apps/explorer/pages/styled'
 import { TransactionsTableWidget } from 'apps/explorer/components/TransactionsTableWidget'
 
 const TransactionDetails: React.FC = () => {
   const { txHash } = useParams<{ txHash: string }>()
-  const networkId = useNetworkId() || undefined
 
-  // TODO Validate txHash
+  if (!isATxHash(txHash)) {
+    return <RedirectToSearch from="tx" />
+  }
+
   return (
     <WrapperPage>
-      <h1>
-        Transaction details
-        <TitleAddress
-          textToCopy={txHash}
-          contentsToDisplay={<BlockExplorerLink type="tx" networkId={networkId} identifier={txHash} />}
-        />
-      </h1>
-      <TransactionsTableWidget txHash={txHash} networkId={networkId} />
+      <TransactionsTableWidget txHash={txHash} />
     </WrapperPage>
   )
 }

--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -95,7 +95,7 @@ export const OrderAddressNotFound: React.FC = (): JSX.Element => {
 
   return (
     <>
-      <Title>Order or Address not found</Title>
+      <Title>No results found</Title>
       <Content>
         {searchString ? (
           <>

--- a/src/hooks/useSearchSubmit.ts
+++ b/src/hooks/useSearchSubmit.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useHistory } from 'react-router-dom'
-import { isAnAddressAccount, isAnOrderId, isEns } from 'utils'
+import { isAnAddressAccount, isAnOrderId, isEns, isATxHash } from 'utils'
 import { usePathPrefix } from 'state/network'
 import { web3 } from 'apps/explorer/api'
 
@@ -10,6 +10,8 @@ export function pathAccordingTo(query: string): string {
     path = 'address'
   } else if (isAnOrderId(query)) {
     path = 'orders'
+  } else if (isATxHash(query)) {
+    path = 'tx'
   }
 
   return path

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -281,6 +281,14 @@ export const isAnAddressAccount = (text: string): boolean => {
  */
 export const isEns = (text: string): boolean => text.match(/[a-zA-Z0-9]+\.[a-zA-Z]+$/)?.input !== undefined
 
+/**
+ * Check if a string is a valid Tx Hash against regex
+ *
+ * @param text Possible TxHash string to check
+ * @returns true if valid or false if not
+ */
+export const isATxHash = (text: string): boolean => text.match(/^(0x)?([a-fA-F0-9]{64})$/)?.input !== undefined
+
 /** Convert string to lowercase and remove whitespace */
 export function cleanNetworkName(networkName: string | undefined): string {
   if (!networkName) return ''

--- a/test/utils/miscellaneous.spec.ts
+++ b/test/utils/miscellaneous.spec.ts
@@ -1,5 +1,5 @@
 import { tokenList } from '../data'
-import { cleanNetworkName, getToken, isAnAddressAccount, isAnOrderId, isEns } from 'utils'
+import { cleanNetworkName, getToken, isAnAddressAccount, isAnOrderId, isEns, isATxHash } from 'utils'
 import BN from 'bn.js'
 import { pathAccordingTo } from 'hooks/useSearchSubmit'
 
@@ -154,6 +154,30 @@ describe('isEns', () => {
     const result = isEns(text)
 
     expect(result).toBe(true)
+  })
+})
+
+describe('isATxHash', () => {
+  it('should return true for valid Tx Hash', () => {
+    const text = '0x218ef93e287740cb029f5ca178a9cd21b5fe85a5f9f06795e08ed79b6668a9a0'
+
+    const result = isATxHash(text)
+
+    expect(result).toBe(true)
+  })
+  it('should return true for valid Tx Hash without 0x', () => {
+    const text = '218ef93e287740cb029f5ca178a9cd21b5fe85a5f9f06795e08ed79b6668a9a0'
+
+    const result = isATxHash(text)
+
+    expect(result).toBe(true)
+  })
+  it('should return false for invalid tx Hash', () => {
+    const text = 'invalidTxHash'
+
+    const result = isATxHash(text)
+
+    expect(result).toBe(false)
   })
 })
 


### PR DESCRIPTION
# Summary

Closes #854

**Proposal:**
Add search by Tx Hash:
- [x] search TxHash by full match.
- [x] add Tx Hash to the Main page name/placeholder in the search field.
- [x] add Tx Hash to the 'Not found' page name/placeholder in the search field.
- [x] redirect to the 'Not found' page when no hash found

## To Test:
1. Go to [home (PR-899)](https://pr899--gpui.review.gnosisdev.com/) page, search for **Tx hash** such as `0x98fa49ba5bd6a3ceb4fce7e26d19411b39c2772acafda09d5bf156b4813d73b0`

