### PR TITLE
Release/2.5.0

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "🔥 Critical"
+  - "❗️Medium"
+
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. 
+
+  If you think it shouldn't be closed, speak now or forever hold your peace.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/getWebpackConfig.js
+++ b/getWebpackConfig.js
@@ -151,7 +151,7 @@ function _getPlugins({ apps, config, envVars, stats, defineVars, publicPaths, is
 
 function getWebpackConfig({ apps = [], config = {}, envVars = {}, defineVars = {}, baseUrl = '/' } = {}) {
   const { name: appTitle, templatePath, logoPath } = config
-  const isProduction = process.env.NODE_ENV == 'production'
+  const isProduction = process.env.NODE_ENV === 'production'
 
   assert(apps.length > 0, 'At least one app is required')
   assert(appTitle, '"name" missing in config')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -19,7 +19,7 @@ export interface FeeInformation {
 
 export type OrderKind = 'sell' | 'buy'
 
-export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'expired' | 'signing'
+export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'cancelling' | 'expired' | 'signing'
 export type RawOrderStatusFromAPI = 'presignaturePending' | 'open' | 'fullfilled' | 'cancelled' | 'expired'
 
 // Raw API response

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -17,7 +17,19 @@ export function createWeb3Api(provider?: string): Web3 {
     return web3cache[_provider]
   }
   // TODO: Create an `EthereumApi` https://github.com/gnosis/gp-v1-ui/issues/331
-  const web3 = new Web3(_provider)
+  const web3 = new Web3(
+    _provider.startsWith('wss:')
+      ? new Web3.providers.WebsocketProvider(_provider, {
+          reconnect: {
+            auto: true,
+            delay: 5000,
+            maxAttempts: 5,
+            onTimeout: false,
+          },
+        })
+      : _provider,
+  )
+
   // `handleRevert = true` makes `require` failures to throw
   // For more details see https://github.com/gnosis/gp-v1-ui/issues/511
   web3.eth['handleRevert'] = true

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter, HashRouter, Route, Switch, useRouteMatch } from 'react-router-dom'
+import { BrowserRouter, HashRouter, Route, Switch, useRouteMatch, Redirect } from 'react-router-dom'
 import { hot } from 'react-hot-loader/root'
 
 import { withGlobalContext } from 'hooks/useGlobalState'
@@ -57,6 +57,14 @@ const NotFound = React.lazy(
     ),
 )
 
+const SearchNotFound = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "SearchNotFound_chunk"*/
+      './pages/SearchNotFound'
+    ),
+)
+
 const Home = React.lazy(
   () =>
     import(
@@ -108,8 +116,14 @@ const AppContent = (): JSX.Element => {
 
         <Switch>
           <Route path={pathPrefix + '/'} exact component={Home} />
+          <Route
+            path={[pathPrefix + '/address/', pathPrefix + '/orders/']}
+            exact
+            component={(): JSX.Element => <Redirect to={pathPrefix + '/search/'} />}
+          />
           <Route path={pathPrefix + '/orders/:orderId'} exact component={Order} />
           <Route path={pathPrefix + '/address/:address'} exact component={UserDetails} />
+          <Route path={pathPrefix + '/search/:searchString?'} exact component={SearchNotFound} />
           <Route component={NotFound} />
         </Switch>
       </React.Suspense>

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -12,7 +12,7 @@ import { GenericLayout } from 'components/layout'
 import { Header } from './layout/Header'
 import { media } from 'theme/styles/media'
 
-import { NetworkUpdater, RedirectMainnet } from 'state/network'
+import { NetworkUpdater, RedirectMainnet, RedirectXdai } from 'state/network'
 import { initAnalytics } from 'api/analytics'
 import RouteAnalytics from 'components/analytics/RouteAnalytics'
 import NetworkAnalytics from 'components/analytics/NetworkAnalytics'
@@ -158,7 +158,8 @@ export const ExplorerApp: React.FC = () => {
         <StateUpdaters />
         <Switch>
           <Route path="/mainnet" component={RedirectMainnet} />
-          <Route path={['/xdai', '/rinkeby', '/']} component={AppContent} />
+          <Route path="/xdai" component={RedirectXdai} />
+          <Route path={['/gc', '/rinkeby', '/']} component={AppContent} />
         </Switch>
       </Router>
       {process.env.NODE_ENV === 'development' && <Console />}

--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -1,6 +1,4 @@
 import React, { useContext, useState, useEffect } from 'react'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import OrdersTable from 'components/orders/OrdersUserDetailsTable'
 import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
@@ -8,6 +6,7 @@ import { OrdersTableContext } from './context/OrdersTableContext'
 import useFirstRender from 'hooks/useFirstRender'
 import { DEFAULT_TIMEOUT } from 'const'
 import { useSearchInAnotherNetwork, EmptyOrdersMessage } from './useSearchInAnotherNetwork'
+import Spinner from 'components/common/Spinner'
 
 export const OrdersTableWithData: React.FC = () => {
   const {
@@ -43,7 +42,7 @@ export const OrdersTableWithData: React.FC = () => {
 
   return isFirstRender || isFirstLoading ? (
     <EmptyItemWrapper>
-      <FontAwesomeIcon icon={faSpinner} spin size="3x" />
+      <Spinner spin size="3x" />
     </EmptyItemWrapper>
   ) : (
     <OrdersTable

--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -23,6 +23,10 @@ export const OrdersTableWithData: React.FC = () => {
   } = useSearchInAnotherNetwork(networkId, ownerAddress, orders)
 
   useEffect(() => {
+    setIsFirstLoading(true)
+  }, [networkId])
+
+  useEffect(() => {
     let timeOutMs = 0
     if (!orders) {
       timeOutMs = DEFAULT_TIMEOUT

--- a/src/apps/explorer/components/OrdersTableWidget/index.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import ExplorerTabs from 'apps/explorer/components/common/ExplorerTabs/ExplorerTab'
 import { useGetOrders } from './useGetOrders'
@@ -10,6 +8,7 @@ import { useTable } from './useTable'
 import { OrdersTableWithData } from './OrdersTableWithData'
 import { OrdersTableContext, BlockchainNetwork } from './context/OrdersTableContext'
 import PaginationOrdersTable from './PaginationOrdersTable'
+import Spinner from 'components/common/Spinner'
 
 const StyledTabLoader = styled.span`
   padding-left: 4px;
@@ -22,7 +21,7 @@ const tabItems = (isLoadingOrders: boolean): TabItemInterface[] => {
       tab: (
         <>
           Orders
-          <StyledTabLoader>{isLoadingOrders && <FontAwesomeIcon icon={faSpinner} spin size="1x" />}</StyledTabLoader>
+          <StyledTabLoader>{isLoadingOrders && <Spinner spin size="1x" />}</StyledTabLoader>
         </>
       ),
       content: <OrdersTableWithData />,

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -70,6 +70,12 @@ const _findNetworkName = (networkId: number): string => {
   return networkOptions.find((e) => e.id === networkId)?.name || 'Unknown network'
 }
 
+const _buildInternalNetworkUrl = (networkId: number, ownerAddress: string): string => {
+  const networkPrefix = PREFIX_BY_NETWORK_ID.get(networkId)
+
+  return `${networkPrefix && '/' + networkPrefix}/address/${ownerAddress}`
+}
+
 export const EmptyOrdersMessage = ({
   isLoading,
   networkId,
@@ -106,7 +112,7 @@ export const EmptyOrdersMessage = ({
                 {ordersInNetworks.map((e) => (
                   <li key={e.network}>
                     <Link
-                      to={`/${PREFIX_BY_NETWORK_ID.get(e.network)}/address/${ownerAddress}`}
+                      to={_buildInternalNetworkUrl(e.network, ownerAddress)}
                       onClick={(): void => setLoadingState(true)}
                     >
                       {_findNetworkName(e.network)}

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -2,11 +2,14 @@ import React, { useCallback, useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 
+import { abbreviateString } from 'utils'
 import { Network } from 'types'
 import { NETWORK_ID_SEARCH_LIST } from 'apps/explorer/const'
 import { BlockchainNetwork } from './context/OrdersTableContext'
 import { Order, getAccountOrders } from 'api/operator'
 import Spinner from 'components/common/Spinner'
+import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
+import { MEDIA } from 'const'
 
 const Wrapper = styled.div`
   display: flex;
@@ -14,10 +17,6 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   height: 100%;
-
-  > p {
-    font-weight: 550;
-  }
 
   > section {
     display: flex;
@@ -31,7 +30,7 @@ const Wrapper = styled.div`
   }
 
   ul {
-    padding: 0 0.8rem 0 0;
+    padding: 0;
     margin: 0;
     > li {
       list-style: none;
@@ -40,6 +39,14 @@ const Wrapper = styled.div`
         padding-bottom: 0;
       }
     }
+  }
+`
+const StyledBlockExplorerLink = styled(BlockExplorerLink)`
+  margin-top: 1rem;
+
+  @media ${MEDIA.xSmallDown} {
+    display: flex;
+    justify-content: center;
   }
 `
 interface OrdersInNetwork {
@@ -77,7 +84,13 @@ export const EmptyOrdersMessage = ({
       ) : (
         <>
           <p>
-            No orders found on <strong>{Network[networkId]}</strong>.
+            No orders found on <strong>{Network[networkId]}</strong> for:{' '}
+            <StyledBlockExplorerLink
+              identifier={ownerAddress}
+              type="address"
+              label={abbreviateString(ownerAddress, 4, 4)}
+              networkId={networkId}
+            />
           </p>
           <section>
             {' '}

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -10,6 +10,8 @@ import { Order, getAccountOrders } from 'api/operator'
 import Spinner from 'components/common/Spinner'
 import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
 import { MEDIA } from 'const'
+import { PREFIX_BY_NETWORK_ID } from 'state/network'
+import { networkOptions } from 'components/NetworkSelector'
 
 const Wrapper = styled.div`
   display: flex;
@@ -50,7 +52,7 @@ const StyledBlockExplorerLink = styled(BlockExplorerLink)`
   }
 `
 interface OrdersInNetwork {
-  network: string
+  network: number
 }
 
 interface ResultSeachInAnotherNetwork {
@@ -62,6 +64,10 @@ interface ResultSeachInAnotherNetwork {
 type EmptyMessageProps = ResultSeachInAnotherNetwork & {
   networkId: BlockchainNetwork
   ownerAddress: string
+}
+
+const _findNetworkName = (networkId: number): string => {
+  return networkOptions.find((e) => e.id === networkId)?.name || 'Unknown network'
 }
 
 export const EmptyOrdersMessage = ({
@@ -84,7 +90,7 @@ export const EmptyOrdersMessage = ({
       ) : (
         <>
           <p>
-            No orders found on <strong>{Network[networkId]}</strong> for:{' '}
+            No orders found on <strong>{_findNetworkName(networkId)}</strong> for:{' '}
             <StyledBlockExplorerLink
               identifier={ownerAddress}
               type="address"
@@ -100,10 +106,10 @@ export const EmptyOrdersMessage = ({
                 {ordersInNetworks.map((e) => (
                   <li key={e.network}>
                     <Link
-                      to={`/${e.network.toLowerCase()}/address/${ownerAddress}`}
+                      to={`/${PREFIX_BY_NETWORK_ID.get(e.network)}/address/${ownerAddress}`}
                       onClick={(): void => setLoadingState(true)}
                     >
-                      {e.network}
+                      {_findNetworkName(e.network)}
                     </Link>
                   </li>
                 ))}
@@ -137,7 +143,7 @@ export const useSearchInAnotherNetwork = (
           .then((response) => {
             if (!response.length) return
 
-            return { network: Network[network] }
+            return { network }
           })
           .catch((e) => {
             console.error(`Failed to fetch order in ${Network[network]}`, e)

--- a/src/apps/explorer/components/common/Search/Search.styled.ts
+++ b/src/apps/explorer/components/common/Search/Search.styled.ts
@@ -1,5 +1,7 @@
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import SVG from 'react-inlinesvg'
+import { media } from 'theme/styles/media'
+import * as CSS from 'csstype'
 
 export const Wrapper = styled.form`
   display: flex;
@@ -9,6 +11,7 @@ export const Wrapper = styled.form`
           width: 100%;
           max-width: 50rem;
           margin: 0 auto;
+          flex-direction: column-reverse;
         `
       : css`
           width: 60rem;
@@ -41,10 +44,18 @@ export const Input = styled.input`
   &::placeholder {
     color: inherit;
     transition: color 0.2s ease-in-out;
+    ${media.mobile} {
+      color: transparent;
+    }
   }
 
   &:focus::placeholder {
     color: transparent;
+  }
+  &:focus ~ span {
+    z-index: -1;
+    opacity: 0;
+    transition: all 0.2s ease-in-out;
   }
 `
 
@@ -78,4 +89,28 @@ export const SearchIcon = styled(SVG)`
   &:hover {
     opacity: 1;
   }
+`
+
+export const Placeholder = styled.span<Partial<CSS.Properties & { isActive: boolean }>>`
+  ${media.mobile} {
+    display: flex;
+    font-size: 1.4rem;
+  }
+  display: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: ${({ theme }): string => theme.greyShade};
+  transition: all 0.2s ease-in-out;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 1.6rem 1.6rem 1.6rem 5rem;
+  max-height: 5rem;
+  pointer-events: none;
+  align-items: center;
+  justify-content: center;
+  ${({ isActive }): string =>
+    isActive
+      ? 'z-index: -1; opacity: 0; transition: all 0.2s ease-in-out;'
+      : 'z-index: 1; opacity: 1; transition: all 0.2s ease-in-out;'};
 `

--- a/src/apps/explorer/components/common/Search/index.tsx
+++ b/src/apps/explorer/components/common/Search/index.tsx
@@ -1,14 +1,25 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Wrapper, Button, Input, SearchIcon } from './Search.styled'
 import { useSearchSubmit } from 'hooks/useSearchSubmit'
 
 // assets
 import searchImg from 'assets/img/search2.svg'
 
-export const Search: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props) => {
+interface SearchProps {
+  searchString?: string
+  submitSearchImmediatly?: boolean
+}
+
+export const Search: React.FC<React.HTMLAttributes<HTMLDivElement> & SearchProps> = (props) => {
+  const { className, searchString = '', submitSearchImmediatly = false } = props
   const [query, setQuery] = useState('')
   const handleSubmit = useSearchSubmit()
-  const { className } = props
+
+  useEffect(() => {
+    if (searchString && submitSearchImmediatly) {
+      handleSubmit(searchString)
+    }
+  }, [handleSubmit, searchString, submitSearchImmediatly])
 
   return (
     <Wrapper

--- a/src/apps/explorer/components/common/Search/index.tsx
+++ b/src/apps/explorer/components/common/Search/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Wrapper, Button, Input, SearchIcon } from './Search.styled'
+import { Wrapper, Button, Input, SearchIcon, Placeholder } from './Search.styled'
 import { useSearchSubmit } from 'hooks/useSearchSubmit'
 
 // assets
@@ -13,14 +13,15 @@ interface SearchProps {
 export const Search: React.FC<React.HTMLAttributes<HTMLDivElement> & SearchProps> = (props) => {
   const { className, searchString = '', submitSearchImmediatly = false } = props
   const [query, setQuery] = useState('')
+  const [showPlaceholder, setShowPlaceholder] = useState(true)
   const handleSubmit = useSearchSubmit()
 
   useEffect(() => {
     if (searchString && submitSearchImmediatly) {
       handleSubmit(searchString)
     }
-  }, [handleSubmit, searchString, submitSearchImmediatly])
-
+    setShowPlaceholder(query.length > 0)
+  }, [handleSubmit, searchString, submitSearchImmediatly, query])
   return (
     <Wrapper
       onSubmit={(e): void => {
@@ -38,9 +39,10 @@ export const Search: React.FC<React.HTMLAttributes<HTMLDivElement> & SearchProps
         name="query"
         value={query}
         onChange={(e): void => setQuery(e.target.value.trim())}
-        placeholder="Search by Order ID / ETH Address / ENS Address"
+        placeholder="Order ID / ETH Address / ENS Address"
         aria-label="Search the GP explorer for orders, batches and transactions"
       />
+      <Placeholder isActive={showPlaceholder}>Order ID / ETH Address / ENS Address</Placeholder>
     </Wrapper>
   )
 }

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { Navigation } from 'components/layout/GenericLayout/Navigation'
 import { Header as GenericHeader } from 'components/layout/GenericLayout/Header'
+import { NetworkSelector } from 'components/NetworkSelector'
 import { getNetworkFromId } from '@gnosis.pm/dex-js'
 import { useNetworkId } from 'state/network'
 import styled from 'styled-components'
@@ -29,28 +30,6 @@ const Logo = styled.span`
   }
 `
 
-const NetworkLabel = styled.span`
-  border-radius: 0.6rem;
-  display: flex;
-  margin: 0 0.5rem;
-  font-size: 1.1rem;
-  text-align: center;
-  padding: 0.7rem;
-  text-transform: uppercase;
-  font-weight: ${({ theme }): string => theme.fontBold};
-  letter-spacing: 0.1rem;
-
-  &.rinkeby {
-    background: ${({ theme }): string => theme.borderPrimary};
-    color: ${({ theme }): string => theme.textSecondary1};
-  }
-
-  &.xdai {
-    background: ${({ theme }): string => theme.orangeOpacity};
-    color: ${({ theme }): string => theme.orange};
-  }
-`
-
 export const Header: React.FC = () => {
   const networkId = useNetworkId()
   if (!networkId) {
@@ -62,7 +41,7 @@ export const Header: React.FC = () => {
   return (
     <GenericHeader logoAlt="Gnosis Protocol" linkTo={`/${network || ''}`} label={<Logo>Gnosis Protocol</Logo>}>
       <Navigation>
-        {network && <NetworkLabel className={network}>{network}</NetworkLabel>}
+        <NetworkSelector networkId={networkId} />
         {/*      
         <li>
           <Link to="/">Batches</Link>

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -3,8 +3,7 @@ import React from 'react'
 import { Navigation } from 'components/layout/GenericLayout/Navigation'
 import { Header as GenericHeader } from 'components/layout/GenericLayout/Header'
 import { NetworkSelector } from 'components/NetworkSelector'
-import { getNetworkFromId } from '@gnosis.pm/dex-js'
-import { useNetworkId } from 'state/network'
+import { PREFIX_BY_NETWORK_ID, useNetworkId } from 'state/network'
 import styled from 'styled-components'
 
 const Logo = styled.span`
@@ -36,10 +35,10 @@ export const Header: React.FC = () => {
     return null
   }
 
-  const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : null
+  const prefixNetwork = PREFIX_BY_NETWORK_ID.get(networkId)
 
   return (
-    <GenericHeader logoAlt="Gnosis Protocol" linkTo={`/${network || ''}`} label={<Logo>Gnosis Protocol</Logo>}>
+    <GenericHeader logoAlt="Gnosis Protocol" linkTo={`/${prefixNetwork || ''}`} label={<Logo>Gnosis Protocol</Logo>}>
       <Navigation>
         <NetworkSelector networkId={networkId} />
         {/*      

--- a/src/apps/explorer/pages/Home/index.tsx
+++ b/src/apps/explorer/pages/Home/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Search } from 'apps/explorer/components/common/Search'
+import { media } from 'theme/styles/media'
 
 const Wrapper = styled.div`
   display: flex;
@@ -12,22 +13,28 @@ const Wrapper = styled.div`
   width: 100%;
 
   > h1 {
-    display: flex;
+    text-align: center;
     padding: 2.4rem 0 0.75rem;
-    align-items: center;
-    justify-content: center;
     font-weight: ${({ theme }): string => theme.fontBold};
     width: 100%;
     margin: 0 0 2.4rem;
-    font-size: 2.4rem;
+    font-size: 2rem;
     line-height: 1;
+  }
+
+  ${media.mobile} {
+    > h1 {
+      line-height: 1.2;
+      margin-bottom: 1rem;
+      font-size: 1.7rem;
+    }
   }
 `
 
 export const Home: React.FC = () => {
   return (
     <Wrapper>
-      <h1>Search Order ID / ETH Address / ENS Address</h1>
+      <h1>Search on Gnosis Protocol Explorer</h1>
       <Search className="home" />
     </Wrapper>
   )

--- a/src/apps/explorer/pages/NotFound.tsx
+++ b/src/apps/explorer/pages/NotFound.tsx
@@ -3,6 +3,9 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
 
+import { getNetworkFromId } from '@gnosis.pm/dex-js'
+import { useNetworkId } from 'state/network'
+
 const Wrapper = styled.div`
   max-width: 118rem;
   margin: 0 auto;
@@ -55,14 +58,19 @@ const StyledLink = styled(Link)`
     text-decoration: none;
   }
 `
-const NotFound2: React.FC = () => (
-  <Wrapper>
-    <Title>Page not found</Title>
-    <Content>
-      <p>We&apos;re sorry, the page you requested could not be found.</p>
-      <StyledLink to="/">Back Home</StyledLink>
-    </Content>
-  </Wrapper>
-)
+const NotFoundRequestPage: React.FC = () => {
+  const networkId = useNetworkId() || 1
+  const network = networkId !== 1 ? getNetworkFromId(networkId).toLowerCase() : ''
 
-export default NotFound2
+  return (
+    <Wrapper>
+      <Title>Page not found</Title>
+      <Content>
+        <p>We&apos;re sorry, the page you requested could not be found.</p>
+        <StyledLink to={`/${network}`}>Back Home</StyledLink>
+      </Content>
+    </Wrapper>
+  )
+}
+
+export default NotFoundRequestPage

--- a/src/apps/explorer/pages/Order.tsx
+++ b/src/apps/explorer/pages/Order.tsx
@@ -1,6 +1,24 @@
 import React from 'react'
-import { OrderWidget } from '../components/OrderWidget'
 
-const Order: React.FC = () => <OrderWidget />
+import { useOrderIdParam } from 'hooks/useSanitizeOrderIdAndUpdateUrl'
+import { isAnOrderId } from 'utils'
+
+import RedirectToSearch from 'components/RedirectToSearch'
+import { OrderWidget } from 'apps/explorer/components/OrderWidget'
+import { WrapperPage } from './styled'
+
+const Order: React.FC = () => {
+  const orderId = useOrderIdParam()
+
+  if (!isAnOrderId(orderId)) {
+    return <RedirectToSearch from="orders" />
+  }
+
+  return (
+    <WrapperPage>
+      <OrderWidget />
+    </WrapperPage>
+  )
+}
 
 export default Order

--- a/src/apps/explorer/pages/SearchNotFound.tsx
+++ b/src/apps/explorer/pages/SearchNotFound.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { OrderAddressNotFound } from 'components/orders/OrderNotFound'
+import { WrapperPage } from './styled'
+
+const SearchNotFound: React.FC = () => {
+  return (
+    <WrapperPage>
+      <OrderAddressNotFound />
+    </WrapperPage>
+  )
+}
+
+export default SearchNotFound

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -5,11 +5,11 @@ import styled from 'styled-components'
 import { isAddress } from 'web3-utils'
 
 import { media } from 'theme/styles/media'
-import NotFound from './NotFound'
 import OrdersTableWidget from '../components/OrdersTableWidget'
 import { useNetworkId } from 'state/network'
 import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
+import RedirectToSearch from 'components/RedirectToSearch'
 
 const Wrapper = styled.div`
   padding: 1.6rem;
@@ -42,21 +42,21 @@ const UserDetails: React.FC = () => {
   const networkId = useNetworkId() || undefined
 
   if (!isAddress(address)) {
-    return <NotFound />
-  } else {
-    return (
-      <Wrapper>
-        <h1>
-          User details
-          <TitleAddress
-            textToCopy={address}
-            contentsToDisplay={<BlockExplorerLink type="address" networkId={networkId} identifier={address} />}
-          />
-        </h1>
-        <OrdersTableWidget ownerAddress={address} networkId={networkId} />
-      </Wrapper>
-    )
+    return <RedirectToSearch from="address" />
   }
+
+  return (
+    <Wrapper>
+      <h1>
+        User details
+        <TitleAddress
+          textToCopy={address}
+          contentsToDisplay={<BlockExplorerLink type="address" networkId={networkId} identifier={address} />}
+        />
+      </h1>
+      <OrdersTableWidget ownerAddress={address} networkId={networkId} />
+    </Wrapper>
+  )
 }
 
 export default UserDetails

--- a/src/apps/explorer/pages/UserDetails.tsx
+++ b/src/apps/explorer/pages/UserDetails.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import { useParams } from 'react-router'
 import styled from 'styled-components'
 
-import { isAddress } from 'web3-utils'
-
 import { media } from 'theme/styles/media'
 import OrdersTableWidget from '../components/OrdersTableWidget'
 import { useNetworkId } from 'state/network'
 import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import RedirectToSearch from 'components/RedirectToSearch'
+import { useResolveEns } from 'hooks/useResolveEns'
+import Spinner from 'components/common/Spinner'
 
 const Wrapper = styled.div`
   padding: 1.6rem;
@@ -40,21 +40,35 @@ const TitleAddress = styled(RowWithCopyButton)`
 const UserDetails: React.FC = () => {
   const { address } = useParams<{ address: string }>()
   const networkId = useNetworkId() || undefined
+  const addressAccount = useResolveEns(address)
 
-  if (!isAddress(address)) {
+  if (addressAccount?.address === null) {
     return <RedirectToSearch from="address" />
   }
 
   return (
     <Wrapper>
-      <h1>
-        User details
-        <TitleAddress
-          textToCopy={address}
-          contentsToDisplay={<BlockExplorerLink type="address" networkId={networkId} identifier={address} />}
-        />
-      </h1>
-      <OrdersTableWidget ownerAddress={address} networkId={networkId} />
+      {addressAccount ? (
+        <>
+          <h1>
+            User details
+            <TitleAddress
+              textToCopy={addressAccount.address}
+              contentsToDisplay={
+                <BlockExplorerLink
+                  type="address"
+                  networkId={networkId}
+                  identifier={address}
+                  label={addressAccount.ens}
+                />
+              }
+            />
+          </h1>
+          <OrdersTableWidget ownerAddress={addressAccount.address} networkId={networkId} />
+        </>
+      ) : (
+        <Spinner size="3x" />
+      )}
     </Wrapper>
   )
 }

--- a/src/apps/explorer/pages/styled.tsx
+++ b/src/apps/explorer/pages/styled.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+import { media } from 'theme/styles/media'
+
+export const WrapperPage = styled.div`
+  padding: 1.6rem;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 140rem;
+
+  ${media.mediumDown} {
+    max-width: 94rem;
+  }
+
+  ${media.mobile} {
+    max-width: 100%;
+  }
+
+  > h1 {
+    display: flex;
+    padding: 2.4rem 0 0.75rem;
+    align-items: center;
+    font-weight: ${({ theme }): string => theme.fontBold};
+  }
+`

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -1,0 +1,111 @@
+import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { COLOURS } from 'styles'
+
+const { fadedGreyishWhiteOpacity, white } = COLOURS
+
+export const SelectorContainer = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  .arrow {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: ${({ theme }): string => `5px solid ${theme.grey}`};
+    transform: rotate(0deg);
+    transition: transform 0.1s linear;
+    &.open {
+      transform: rotate(180deg);
+      transition: transform 0.1s linear;
+    }
+  }
+`
+
+export const OptionsContainer = styled.div<{ width: number }>`
+  position: absolute;
+  z-index: 1;
+  margin: 0 auto;
+  width: ${(props: { width: number }): string => `${184 + props.width}px`};
+  height: 128px;
+  left: 15px;
+  top: 50px;
+  background: ${({ theme }): string => theme.bg1};
+  border: ${(): string => `1px solid ${fadedGreyishWhiteOpacity}`};
+  box-sizing: border-box;
+  border-radius: 6px;
+`
+
+export const Option = styled.div`
+  display: flex;
+  flex: 1;
+  font-family: var(--font-avenir);
+  font-weight: 800;
+  font-size: 13px;
+  line-height: 18px;
+  align-items: center;
+  letter-spacing: 0.02em;
+  padding: 12px 16px;
+  &:hover {
+    backdrop-filter: contrast(0.9);
+    .name {
+      color: ${(): string => white};
+    }
+  }
+  .name {
+    color: ${({ theme }): string => theme.grey};
+    &.selected {
+      color: ${(): string => white};
+    }
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 100%;
+    margin-right: 9px;
+    &.rinkeby {
+      background: ${({ theme }): string => theme.yellow4};
+    }
+    &.xdai {
+      background: ${({ theme }): string => theme.orange1};
+    }
+    &.ethereum {
+      background: ${({ theme }): string => theme.blue4};
+    }
+  }
+`
+
+export const NetworkLabel = styled.span`
+  border-radius: 0.6rem;
+  display: flex;
+  margin: 0 0.5rem;
+  font-size: 1.1rem;
+  text-align: center;
+  padding: 0.7rem;
+  text-transform: uppercase;
+  font-weight: ${({ theme }): string => theme.fontBold};
+  letter-spacing: 0.1rem;
+
+  &.rinkeby {
+    background: ${({ theme }): string => theme.yellow4};
+    color: ${({ theme }): string => theme.black};
+  }
+
+  &.ethereum {
+    background: ${({ theme }): string => theme.blue4};
+    color: ${({ theme }): string => theme.textSecondary1};
+  }
+
+  &.xdai {
+    background: ${({ theme }): string => theme.orangeOpacity};
+    color: ${({ theme }): string => theme.orange};
+  }
+`
+
+export const StyledFAIcon = styled(FontAwesomeIcon)`
+  color: ${({ theme }): string => theme.orange};
+  position: absolute;
+  right: 10px;
+  font-size: 14px;
+`

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { COLOURS } from 'styles'
 
-const { fadedGreyishWhiteOpacity, white } = COLOURS
+const { fadedGreyishWhiteOpacity, white, hippieBlue } = COLOURS
 
 export const SelectorContainer = styled.div`
   display: flex;
@@ -67,8 +67,8 @@ export const Option = styled.div`
     &.rinkeby {
       background: ${({ theme }): string => theme.yellow4};
     }
-    &.xdai {
-      background: ${({ theme }): string => theme.orange1};
+    &.gnosischain {
+      background: ${(): string => hippieBlue};
     }
     &.ethereum {
       background: ${({ theme }): string => theme.blue4};
@@ -97,9 +97,9 @@ export const NetworkLabel = styled.span`
     color: ${({ theme }): string => theme.textSecondary1};
   }
 
-  &.xdai {
-    background: ${({ theme }): string => theme.orangeOpacity};
-    color: ${({ theme }): string => theme.orange};
+  &.gnosischain {
+    background: ${(): string => `rgb(72 169 166 / 25%);`};
+    color: ${(): string => hippieBlue};
   }
 `
 

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useHistory } from 'react-router'
+import { useLocation } from 'react-router-dom'
+import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { SelectorContainer, OptionsContainer, Option, NetworkLabel, StyledFAIcon } from './NetworkSelector.styled'
+import { replaceURL } from 'utils/url'
+import { NO_REDIRECT_HOME_ROUTES } from 'const'
+import { Network } from 'types'
+
+type networkSelectorProps = {
+  networkId: number
+}
+
+type NetworkOptions = {
+  id: Network
+  name: string
+  url: string
+}
+
+const networkOptions: NetworkOptions[] = [
+  {
+    id: Network.Mainnet,
+    name: 'Ethereum',
+    url: '',
+  },
+  {
+    id: Network.xDAI,
+    name: 'xDAI',
+    url: 'xdai',
+  },
+  {
+    id: Network.Rinkeby,
+    name: 'Rinkeby',
+    url: 'rinkeby',
+  },
+]
+
+export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) => {
+  const selectContainer = useRef<HTMLInputElement>(null)
+  const history = useHistory()
+  const location = useLocation()
+  const name = networkOptions.find((network) => network.id === networkId)?.name.toLowerCase()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const closeOpenSelector = (e: MouseEvent | KeyboardEvent): void => {
+      if (!open) return
+      if (e instanceof KeyboardEvent) {
+        if (e.key === 'Escape') {
+          setOpen(false)
+          return
+        }
+      } else if (selectContainer.current && !selectContainer.current.contains(e.target as HTMLElement)) {
+        setOpen(false)
+      }
+    }
+
+    window.addEventListener('mousedown', closeOpenSelector)
+    window.addEventListener('keydown', closeOpenSelector)
+
+    return (): void => {
+      window.removeEventListener('mousedown', closeOpenSelector)
+      window.removeEventListener('keydown', closeOpenSelector)
+    }
+  }, [open])
+
+  const redirectToNetwork = (newNetwork: string, currentNetwork: number): void => {
+    const shouldNotRedirectHome = NO_REDIRECT_HOME_ROUTES.some((r: string) => location.pathname.includes(r))
+    history.push(shouldNotRedirectHome ? replaceURL(location.pathname, newNetwork, currentNetwork) : `/${newNetwork}`)
+  }
+  return (
+    <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>
+      <NetworkLabel className={name}>{name}</NetworkLabel>
+      <span className={`arrow ${open && 'open'}`} />
+      {open && (
+        <OptionsContainer width={selectContainer.current?.offsetWidth || 0}>
+          {networkOptions.map((network) => (
+            <Option onClick={(): void => redirectToNetwork(network.url, networkId)} key={network.id}>
+              <div className={`dot ${network.name.toLowerCase()} `} />
+              <div className={`name ${network.id === networkId && 'selected'}`}>{network.name}</div>
+              {network.id === networkId && <StyledFAIcon icon={faCheck} />}
+            </Option>
+          ))}
+        </OptionsContainer>
+      )}
+    </SelectorContainer>
+  )
+}
+
+export default NetworkSelector

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -6,6 +6,7 @@ import { SelectorContainer, OptionsContainer, Option, NetworkLabel, StyledFAIcon
 import { replaceURL } from 'utils/url'
 import { NO_REDIRECT_HOME_ROUTES } from 'const'
 import { Network } from 'types'
+import { cleanNetworkName } from 'utils'
 
 type networkSelectorProps = {
   networkId: number
@@ -17,7 +18,7 @@ type NetworkOptions = {
   url: string
 }
 
-const networkOptions: NetworkOptions[] = [
+export const networkOptions: NetworkOptions[] = [
   {
     id: Network.Mainnet,
     name: 'Ethereum',
@@ -25,8 +26,8 @@ const networkOptions: NetworkOptions[] = [
   },
   {
     id: Network.xDAI,
-    name: 'xDAI',
-    url: 'xdai',
+    name: 'Gnosis Chain',
+    url: 'gc',
   },
   {
     id: Network.Rinkeby,
@@ -70,13 +71,13 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
   }
   return (
     <SelectorContainer ref={selectContainer} onClick={(): void => setOpen(!open)}>
-      <NetworkLabel className={name}>{name}</NetworkLabel>
+      <NetworkLabel className={cleanNetworkName(name)}>{name}</NetworkLabel>
       <span className={`arrow ${open && 'open'}`} />
       {open && (
         <OptionsContainer width={selectContainer.current?.offsetWidth || 0}>
           {networkOptions.map((network) => (
             <Option onClick={(): void => redirectToNetwork(network.url, networkId)} key={network.id}>
-              <div className={`dot ${network.name.toLowerCase()} `} />
+              <div className={`dot ${cleanNetworkName(network.name)} `} />
               <div className={`name ${network.id === networkId && 'selected'}`}>{network.name}</div>
               {network.id === networkId && <StyledFAIcon icon={faCheck} />}
             </Option>

--- a/src/components/RedirectToSearch.tsx
+++ b/src/components/RedirectToSearch.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { usePathPrefix, usePathSuffix } from 'state/network'
+import { Redirect } from 'react-router-dom'
+
+interface RedirectToSearchParams {
+  from: string
+}
+
+const RedirectToSearch: React.FC<RedirectToSearchParams> = ({ from }) => {
+  const prefix = usePathPrefix() || ''
+  const prefixPath = prefix ? `/${prefix}` : ''
+  const suffix = usePathSuffix() || ''
+  const pathMatchArray = suffix.match(`${from}(.*)`)
+
+  const newPath =
+    pathMatchArray && pathMatchArray.length > 0 ? `${prefixPath}/search${pathMatchArray[1]}` : `${prefixPath}${suffix}`
+
+  return <Redirect push={false} to={{ pathname: newPath, state: { referrer: from } }} />
+}
+
+export default RedirectToSearch

--- a/src/components/common/DateDisplay/index.tsx
+++ b/src/components/common/DateDisplay/index.tsx
@@ -5,10 +5,22 @@ import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { Placement } from '@popperjs/core'
 import styled from 'styled-components'
 import { Tooltip } from 'components/Tooltip'
-import { usePopperDefault } from 'hooks/usePopper'
+import { usePopperOnClick } from 'hooks/usePopper'
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
 
 const IconWrapper = styled(FontAwesomeIcon)`
-  margin-right: 0.4rem;
+  padding: 0.6rem;
+  margin: -0.6rem 0 -0.6rem -0.6rem;
+  box-sizing: content-box;
+
+  :hover {
+    cursor: pointer;
+  }
 `
 
 interface DateDisplayProps {
@@ -18,7 +30,7 @@ interface DateDisplayProps {
 }
 
 export function DateDisplay({ date, showIcon, tooltipPlacement = 'top' }: DateDisplayProps): JSX.Element {
-  const { tooltipProps, targetProps } = usePopperDefault<HTMLInputElement>(tooltipPlacement)
+  const { tooltipProps, targetProps } = usePopperOnClick<HTMLInputElement>(tooltipPlacement)
   // '5 days ago', '1h from now' date format
   const distance = formatDistanceToNowStrict(date, { addSuffix: true })
   // Long localized date and time '04/29/1453 12:00:00 AM'
@@ -32,14 +44,14 @@ export function DateDisplay({ date, showIcon, tooltipPlacement = 'top' }: DateDi
       <Tooltip {...tooltipProps}>
         {distance} - {fullLocaleBased}
       </Tooltip>
-      <div>
+      <Wrapper>
         {showIcon && (
           <span {...targetProps}>
             <IconWrapper icon={faClock} />
           </span>
         )}{' '}
         {!showIcon ? <span {...targetProps}>{previewDate}</span> : <span>{previewDate}</span>}
-      </div>
+      </Wrapper>
     </span>
   )
 }

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -10,6 +10,7 @@ import LogoImage from 'assets/img/logo-v2.svg'
 const HeaderStyled = styled.header`
   height: auto;
   margin: 2.2rem auto 0;
+  position: relative;
   display: flex;
   align-items: center;
   box-sizing: border-box;

--- a/src/components/layout/GenericLayout/variablesCss.ts
+++ b/src/components/layout/GenericLayout/variablesCss.ts
@@ -14,6 +14,7 @@ const AllColors = `
   /* FONTS */
   --font-default: "Inter", "Helvetica Neue", Helvetica, sans-serif;
   --font-arial: Arial, Helvetica, sans-serif;
+  --font-avenir: Avenir, Helvetica, sans-serif;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-bold: 700;

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -195,7 +195,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.submission} /> Submission Time
             </td>
             <td>
-              <DateDisplay date={creationDate} />
+              <DateDisplay date={creationDate} showIcon={true} />
             </td>
           </tr>
           <tr>
@@ -203,7 +203,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.expiration} /> Expiration Time
             </td>
             <td>
-              <DateDisplay date={expirationDate} />
+              <DateDisplay date={expirationDate} showIcon={true} />
             </td>
           </tr>
           <tr>

--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useParams } from 'react-router'
+import { useLocation, useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { Search } from 'apps/explorer/components/common/Search'
 import SupportIcon from 'assets/img/support.png'
@@ -69,21 +70,46 @@ const Support = styled.a`
     text-decoration: none;
   }
 `
+interface LocationState {
+  referrer: string
+}
+export const OrderAddressNotFound: React.FC = (): JSX.Element => {
+  const { searchString } = useParams<{ searchString: string }>()
+  const location = useLocation<LocationState>()
+  const history = useHistory()
+  const { referrer } = location.state || { referrer: null }
+  const wasRedirected = referrer ? true : false
 
-export const OrderNotFound: React.FC = () => {
-  const { orderId } = useParams<{ orderId: string }>()
+  // used after refresh by remove referrer state if was redirected
+  useEffect(() => {
+    window.addEventListener('beforeunload', () => {
+      history.replace(location.pathname, null)
+    })
+
+    return (): void => {
+      window.removeEventListener('beforeunload', () => {
+        history.replace(location.pathname, null)
+      })
+    }
+  }, [history, location.pathname])
 
   return (
     <>
-      <Title>Order not found</Title>
+      <Title>Order or Address not found</Title>
       <Content>
-        <p>Sorry, no matches found for:</p>
-        <p>
-          <strong>&quot;{orderId}&quot;</strong>
-        </p>
+        {searchString ? (
+          <>
+            <p>Sorry, no matches found for:</p>
+            <p>
+              <strong>&quot;{searchString}&quot;</strong>
+            </p>
+          </>
+        ) : (
+          <p>The search cannot be empty</p>
+        )}
         <SearchSection>
           <SearchContent>
-            <Search />
+            <Search searchString={wasRedirected ? '' : searchString} submitSearchImmediatly={!wasRedirected} />
             <p>or</p>
             <Support href="https://chat.cowswap.exchange/" target="_blank" rel="noopener noreferrer">
               Get Support

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { media } from 'theme/styles/media'
-import { faExchangeAlt, faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 
 import { Order } from 'api/operator'
@@ -21,7 +21,7 @@ import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Spinner from 'components/common/Spinner'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
@@ -155,7 +155,7 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
   }
 
   const renderSpinnerWhenNoValue = (textValue: string): JSX.Element | void => {
-    if (textValue === '-') return <FontAwesomeIcon icon={faSpinner} spin size="1x" />
+    if (textValue === '-') return <Spinner spin size="1x" />
   }
 
   return (

--- a/src/components/orders/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/orders/StatusLabel/StatusLabel.stories.tsx
@@ -23,6 +23,9 @@ Expired.args = { status: 'expired' }
 export const Cancelled = Template.bind({})
 Cancelled.args = { status: 'cancelled' }
 
+export const Cancelling = Template.bind({})
+Cancelling.args = { status: 'cancelling' }
+
 export const Open = Template.bind({})
 Open.args = { status: 'open' }
 
@@ -35,3 +38,5 @@ export const ExpiredPartiallyFilled = Template.bind({})
 ExpiredPartiallyFilled.args = { status: 'expired', partiallyFilled: true }
 export const CancelledPartiallyFilled = Template.bind({})
 CancelledPartiallyFilled.args = { status: 'cancelled', partiallyFilled: true }
+export const CancellingPartiallyFilled = Template.bind({})
+CancellingPartiallyFilled.args = { status: 'cancelling', partiallyFilled: true }

--- a/src/components/orders/StatusLabel/index.tsx
+++ b/src/components/orders/StatusLabel/index.tsx
@@ -20,6 +20,7 @@ function setStatusColors({ theme, status }: { theme: DefaultTheme; status: Order
   switch (status) {
     case 'expired':
     case 'cancelled':
+    case 'cancelling':
       text = theme.orange
       background = theme.orangeOpacity
       break
@@ -66,7 +67,6 @@ const Label = styled.div<DisplayProps & ShimmingProps>`
   ${({ shimming }): FlattenSimpleInterpolation | null =>
     shimming
       ? css`
-          display: inline-block;
           -webkit-mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
           mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%;
           background-repeat: no-repeat;
@@ -94,6 +94,8 @@ function getStatusIcon(status: OrderStatus): IconDefinition {
       return faCheckCircle
     case 'cancelled':
       return faTimesCircle
+    case 'cancelling':
+      return faTimesCircle
     case 'signing':
       return faKey
     case 'open':
@@ -112,7 +114,7 @@ export type Props = DisplayProps & { partiallyFilled: boolean }
 
 export function StatusLabel(props: Props): JSX.Element {
   const { status, partiallyFilled } = props
-  const shimming = status === 'signing'
+  const shimming = status === 'signing' || status === 'cancelling'
 
   return (
     <Wrapper>

--- a/src/const.ts
+++ b/src/const.ts
@@ -245,3 +245,5 @@ export const NATIVE_TOKEN_PER_NETWORK: Record<string, TokenErc20> = {
   '4': ETH,
   '100': XDAI,
 }
+
+export const NO_REDIRECT_HOME_ROUTES: Array<string> = ['/address']

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -16,7 +16,7 @@ import { getErc20Info } from 'services/helpers'
 import { web3, erc20Api } from 'apps/explorer/api'
 
 import { NATIVE_TOKEN_PER_NETWORK } from 'const'
-import { isNativeToken } from 'utils'
+import { isNativeToken, retry } from 'utils'
 
 async function _fetchErc20FromNetwork(params: {
   address: string
@@ -34,7 +34,7 @@ async function _fetchErc20FromNetwork(params: {
   }
 
   try {
-    return getErc20Info({ tokenAddress: address, networkId, web3, erc20Api })
+    return await retry(() => getErc20Info({ tokenAddress: address, networkId, web3, erc20Api }))
   } catch (e) {
     const msg = `Failed to fetch erc20 details for ${address} on network ${networkId}`
     console.error(msg, e)

--- a/src/hooks/useResolveEns.ts
+++ b/src/hooks/useResolveEns.ts
@@ -1,0 +1,31 @@
+import { isAddress } from 'web3-utils'
+import { useState, useEffect } from 'react'
+import { isEns } from 'utils'
+import { resolveENS } from './useSearchSubmit'
+
+interface AddressAccount {
+  address: string | null
+  ens?: string
+}
+
+export function useResolveEns(address: string): AddressAccount | undefined {
+  const [addressAccount, setAddressAccount] = useState<AddressAccount | undefined>()
+
+  useEffect(() => {
+    async function _resolveENS(name: string): Promise<void> {
+      const _address = await resolveENS(name)
+      setAddressAccount({ address: _address, ens: name })
+    }
+
+    setAddressAccount(undefined)
+    if (isEns(address)) {
+      _resolveENS(address)
+    } else if (isAddress(address)) {
+      setAddressAccount({ address })
+    } else {
+      setAddressAccount({ address: null })
+    }
+  }, [address])
+
+  return addressAccount
+}

--- a/src/hooks/useSanitizeOrderIdAndUpdateUrl.ts
+++ b/src/hooks/useSanitizeOrderIdAndUpdateUrl.ts
@@ -1,6 +1,6 @@
 import { useHistory, useParams, useRouteMatch } from 'react-router'
 
-function useOrderIdParam(): string {
+export function useOrderIdParam(): string {
   const { orderId } = useParams<{ orderId: string }>()
 
   return orderId

--- a/src/hooks/useSearchSubmit.ts
+++ b/src/hooks/useSearchSubmit.ts
@@ -1,13 +1,15 @@
 import { useCallback } from 'react'
 import { useHistory } from 'react-router-dom'
-import { isAnAddressAccount, isEns } from 'utils'
+import { isAnAddressAccount, isAnOrderId, isEns } from 'utils'
 import { usePathPrefix } from 'state/network'
 import { web3 } from 'apps/explorer/api'
 
 export function pathAccordingTo(query: string): string {
-  let path = 'orders'
+  let path = 'search'
   if (isAnAddressAccount(query)) {
     path = 'address'
+  } else if (isAnOrderId(query)) {
+    path = 'orders'
   }
 
   return path
@@ -23,6 +25,7 @@ export function useSearchSubmit(): (query: string) => void {
       // Orders, transactions, tokens, batches
       const path = pathAccordingTo(query)
       const pathPrefix = prefixNetwork ? `${prefixNetwork}/${path}` : `${path}`
+
       if (path === 'address' && isEns(query)) {
         if (web3) {
           web3.eth.ens

--- a/src/hooks/useSearchSubmit.ts
+++ b/src/hooks/useSearchSubmit.ts
@@ -15,6 +15,18 @@ export function pathAccordingTo(query: string): string {
   return path
 }
 
+export async function resolveENS(name: string): Promise<string | null> {
+  if (!web3) return null
+
+  try {
+    const address = await web3.eth.ens.getAddress(name)
+    return address && address.length > 0 ? address : null
+  } catch (e) {
+    console.error(`[web3:api] Could not resolve ${name} ENS. `, e)
+    return null
+  }
+}
+
 export function useSearchSubmit(): (query: string) => void {
   const history = useHistory()
   const prefixNetwork = usePathPrefix()
@@ -27,18 +39,7 @@ export function useSearchSubmit(): (query: string) => void {
       const pathPrefix = prefixNetwork ? `${prefixNetwork}/${path}` : `${path}`
 
       if (path === 'address' && isEns(query)) {
-        if (web3) {
-          web3.eth.ens
-            .getAddress(query)
-            .then((res) => {
-              if (res && res.length > 0) {
-                history.push(`/${pathPrefix}/${res}`)
-              } else {
-                history.push(`/${pathPrefix}/${query}`)
-              }
-            })
-            .catch(() => history.push(`/${pathPrefix}/${query}`))
-        }
+        history.push(`/${path}/${query}`)
       } else {
         query && query.length > 0 && history.push(`/${pathPrefix}/${query}`)
       }

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -12,10 +12,10 @@ import { web3 } from 'apps/explorer/api'
 const MAINNET_PREFIX = ''
 const NETWORK_PREFIXES_RAW: [Network, string][] = [
   [Network.Mainnet, ''],
-  [Network.xDAI, 'xdai'],
+  [Network.xDAI, 'gc'],
   [Network.Rinkeby, 'rinkeby'],
 ]
-const PREFIX_BY_NETWORK_ID: Map<Network, string> = new Map(NETWORK_PREFIXES_RAW)
+export const PREFIX_BY_NETWORK_ID: Map<Network, string> = new Map(NETWORK_PREFIXES_RAW)
 const NETWORK_ID_BY_PREFIX: Map<string, Network> = new Map(NETWORK_PREFIXES_RAW.map(([key, value]) => [value, key]))
 
 function getNetworkId(network = MAINNET_PREFIX): Network {
@@ -29,13 +29,13 @@ function getNetworkPrefix(network: Network): string {
 }
 
 /**
- * Decompose URL pathname like /xdai/orders/123
+ * Decompose URL pathname like /gc/orders/123
  *
- * @returns ['xdai', 'orders/123']
+ * @returns ['gc', 'orders/123']
  */
 export const useDecomposedPath = (): [string, string] | [] => {
   const { pathname } = useLocation()
-  const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet)?/?(.*)')
+  const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet|gc)?/?(.*)')
 
   return pathMatchArray == null ? [] : [pathMatchArray[1], pathMatchArray[2]]
 }
@@ -59,12 +59,24 @@ export const RedirectToNetwork = (props: { networkId: Network }): JSX.Element | 
   return <Redirect push={false} to={newPath} />
 }
 
-/** Redirects to the canonnical URL for mainnet */
-export const RedirectMainnet = (): JSX.Element => {
+/** Replace Network name in URL from X to Y */
+export const SubstituteNetworkName = (from: string, toNetworkName = ''): string => {
   const { pathname } = useLocation()
 
-  const pathMatchArray = pathname.match('/mainnet(.*)')
-  const newPath = pathMatchArray && pathMatchArray.length > 0 ? pathMatchArray[1] : '/'
+  const pathMatchArray = pathname.match(`/${from}(.*)`)
+  return pathMatchArray && pathMatchArray.length > 0 ? `${toNetworkName}${pathMatchArray[1]}` : '/'
+}
+
+/** Redirects to the canonnical URL for mainnet */
+export const RedirectMainnet = (): JSX.Element => {
+  const newPath = SubstituteNetworkName('mainnet')
+
+  return <Redirect push={false} to={newPath} />
+}
+
+/** Redirects to the xDai to the GnosisChain new name */
+export const RedirectXdai = (): JSX.Element => {
+  const newPath = SubstituteNetworkName('xdai', '/gc')
 
   return <Redirect push={false} to={newPath} />
 }
@@ -77,7 +89,7 @@ export const NetworkUpdater: React.FC = () => {
   const location = useLocation()
 
   useEffect(() => {
-    const networkMatchArray = location.pathname.match('^/(rinkeby|xdai)')
+    const networkMatchArray = location.pathname.match('^/(rinkeby|gc)')
     const network = networkMatchArray && networkMatchArray.length > 0 ? networkMatchArray[1] : undefined
     const networkId = getNetworkId(network)
 

--- a/src/styles/colours.ts
+++ b/src/styles/colours.ts
@@ -3,6 +3,7 @@ export const COLOURS = {
   whiteDark: '#e9e9f0',
   blue: '#3F77FF',
   blueDark: '#185afb',
+  hippieBlue: '#48A9A6',
   purple: '#8958FF',
   bgLight: '#edf2f7',
   bgDark: 'linear-gradient(0deg, #21222E 0.05%, #2C2D3F 100%)',

--- a/src/styles/colours.ts
+++ b/src/styles/colours.ts
@@ -20,4 +20,5 @@ export const COLOURS = {
   mainGradient: 'linear-gradient(270deg, #8958FF 0%, #3F77FF 100%)',
   mainGradientDarker: 'linear-gradient(270deg, #6a2cff 0%, #185afb 100%)',
   fadedGreyishWhite: 'rgba(141, 141, 169, 0.08)',
+  fadedGreyishWhiteOpacity: 'rgba(141, 141, 169, 0.3)',
 }

--- a/src/theme/styles/colours.ts
+++ b/src/theme/styles/colours.ts
@@ -45,9 +45,11 @@ export interface Colors {
   yellow1: Color
   yellow2: Color
   yellow3?: Color
+  yellow4: Color
   blue1: Color
   blue2: Color
   blue3?: Color
+  blue4: Color
   orange: Color
   orangeOpacity: Color
   orange1: Color
@@ -65,8 +67,10 @@ export const BASE_COLOURS = {
   green3: '#a9ffcd',
   yellow1: '#f1851d',
   yellow2: '#f1851d',
+  yellow4: '#f6c343',
   blue1: '#2172E5',
   blue2: '#3F77FF',
+  blue4: '#62688F',
   orange1: '#D96D49',
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,6 +2,7 @@ type Envs = {
   isDev: boolean
   isStaging: boolean
   isProd: boolean
+  isBarn: boolean
 }
 
 const getRegex = (regex: string | undefined): RegExp | undefined => (regex ? new RegExp(regex) : undefined)
@@ -10,19 +11,23 @@ function checkEnvironment(host: string): Envs {
   const domainDevRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_DEV)
   const domainStagingRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_STAGING)
   const domainProdRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_PROD)
+  const domainBarnRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_BARN)
 
   return {
     isDev: domainDevRegex?.test(host) || false,
     isStaging: domainStagingRegex?.test(host) || false,
     isProd: domainProdRegex?.test(host) || false,
+    isBarn: domainBarnRegex?.test(host) || false,
   }
 }
 
-const { isDev, isStaging, isProd } = checkEnvironment(window.location.host)
+const { isDev, isStaging, isProd, isBarn } = checkEnvironment(window.location.host)
 
-export const environmentName = (function (): 'production' | 'staging' | 'development' | undefined {
+export const environmentName = (function (): 'production' | 'barn' | 'staging' | 'development' | undefined {
   if (isProd) {
     return 'production'
+  } else if (isBarn) {
+    return 'barn'
   } else if (isStaging) {
     return 'staging'
   } else if (isDev) {
@@ -32,4 +37,4 @@ export const environmentName = (function (): 'production' | 'staging' | 'develop
   }
 })()
 
-export { isDev, isStaging, isProd }
+export { isDev, isStaging, isProd, isBarn }

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { TEN, ZERO } from '@gnosis.pm/dex-js'
 
 const toChecksumAddress = Web3.utils.toChecksumAddress
 
@@ -9,7 +10,6 @@ import { AssertionError } from 'assert'
 import { AuctionElement, Trade, Order } from 'api/exchange/ExchangeApi'
 import { batchIdToDate } from './time'
 import { ORDER_FILLED_FACTOR, MINIMUM_ALLOWANCE_DECIMALS, DEFAULT_TIMEOUT, NATIVE_TOKEN_ADDRESS } from 'const'
-import { TEN, ZERO } from '@gnosis.pm/dex-js'
 
 export function assertNonNull<T>(val: T, message: string): asserts val is NonNullable<T> {
   if (val === undefined || val === null) {
@@ -280,3 +280,10 @@ export const isAnAddressAccount = (text: string): boolean => {
  * @returns true if valid or false if not
  */
 export const isEns = (text: string): boolean => text.match(/[a-zA-Z0-9]+\.[a-zA-Z]+$/)?.input !== undefined
+
+/** Convert string to lowercase and remove whitespace */
+export function cleanNetworkName(networkName: string | undefined): string {
+  if (!networkName) return ''
+
+  return networkName.replace(/\s+/g, '').toLowerCase()
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,3 +1,5 @@
+import { Network } from 'types'
+
 export function buildSearchString(params: Record<string, string | undefined>): string {
   const filteredParams = Object.keys(params).reduce((acc, key) => {
     // Pick keys that have values non-falsy
@@ -10,4 +12,12 @@ export function buildSearchString(params: Record<string, string | undefined>): s
   const searchObj = new URLSearchParams(filteredParams)
 
   return '?' + searchObj.toString()
+}
+
+export function replaceURL(url: string, strReplace: string, currentNetwork: number): string {
+  if (currentNetwork === Network.Mainnet) return url.replace(/^/, `/${strReplace}`)
+  const re = strReplace ? /(([\w]+\/){0})([^/]+)(\/.+)*/gm : /(?:\/[^/]+){1}/
+  const subst = strReplace ? '$1' + strReplace + '$4' : ''
+
+  return url.replace(re, subst)
 }

--- a/test/hooks/useSearchSubmit.test.tsx
+++ b/test/hooks/useSearchSubmit.test.tsx
@@ -19,7 +19,7 @@ function wrapperMemoryRouter(props: Props): JSX.Element {
 }
 
 describe('useSearchSubmit', () => {
-  it('should be /orders/... with invalid search', () => {
+  it('should be /search/... with invalid search', () => {
     const query = 'invalid_search'
     const history = createMemoryHistory()
 
@@ -31,7 +31,7 @@ describe('useSearchSubmit', () => {
       result.current(query)
     })
 
-    expect(history.location.pathname).toBe(`/orders/${query}`)
+    expect(history.location.pathname).toBe(`/search/${query}`)
   })
 
   it('should be /address/0x... when address string is valid', () => {
@@ -47,5 +47,21 @@ describe('useSearchSubmit', () => {
     })
 
     expect(history.location.pathname).toBe(`/address/${query}`)
+  })
+
+  it('should be /orders/0x... when orders string is valid', () => {
+    const query =
+      '0xeaeb698c973f691c702fdd6aacd09ea97acb7275ae26adbfdd884abda1d6697db6bad41ae76a11d10f7b0e664c5007b908bc77c9618b4c31'
+    const history = createMemoryHistory()
+
+    const { result } = renderHook(() => useSearchSubmit(), {
+      wrapper: ({ children }) => wrapperMemoryRouter({ children, history }),
+    })
+
+    act(() => {
+      result.current(query)
+    })
+
+    expect(history.location.pathname).toBe(`/orders/${query}`)
   })
 })

--- a/test/services/getErc20Info.test.ts
+++ b/test/services/getErc20Info.test.ts
@@ -1,0 +1,25 @@
+import BN from 'bn.js'
+
+import { getErc20Info } from 'services/helpers'
+import { web3, erc20Api } from 'apps/explorer/api'
+
+describe('getErc20Info', () => {
+  test('Get null when the address is not a contract', async () => {
+    const tokenAddress = '0xe4A09175F943783525b8161243205fc62467C367'
+    const networkId = 4
+    web3.eth.getCode = async (): Promise<string> => '0x'
+
+    const result = await getErc20Info({ tokenAddress, networkId, web3, erc20Api })
+
+    expect(result).toEqual(null)
+  })
+  test('Get null when the ERC20 specification is not met', async () => {
+    const tokenAddress = '0xe4A09175F943783525b8161243205fc62467C367'
+    const networkId = 4
+    web3.eth.getCode = async (address: string): Promise<string> => address
+    erc20Api.totalSupply = (): Promise<BN> => Promise.reject('fail')
+    const result = await getErc20Info({ tokenAddress, networkId, web3, erc20Api })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/test/utils/miscellaneous.spec.ts
+++ b/test/utils/miscellaneous.spec.ts
@@ -130,12 +130,12 @@ describe('isAnAddressAccount', () => {
 })
 
 describe('pathAccordingTo', () => {
-  it('should return the orders word when it does not match', () => {
+  it('should return the search word when it does not match', () => {
     const text = 'Invalid Search'
 
     const result = pathAccordingTo(text)
 
-    expect(result).toBe('orders')
+    expect(result).toBe('search')
   })
 
   it('should return the address word when it match', () => {

--- a/test/utils/miscellaneous.spec.ts
+++ b/test/utils/miscellaneous.spec.ts
@@ -1,5 +1,5 @@
 import { tokenList } from '../data'
-import { getToken, isAnAddressAccount, isAnOrderId, isEns } from 'utils'
+import { cleanNetworkName, getToken, isAnAddressAccount, isAnOrderId, isEns } from 'utils'
 import BN from 'bn.js'
 import { pathAccordingTo } from 'hooks/useSearchSubmit'
 
@@ -154,5 +154,22 @@ describe('isEns', () => {
     const result = isEns(text)
 
     expect(result).toBe(true)
+  })
+})
+
+describe('cleanNetworkName', () => {
+  it('should return empty string for undefined input', () => {
+    const text = undefined
+
+    const result = cleanNetworkName(text)
+
+    expect(result).toBe('')
+  })
+  it('should return lowercase withouth white space', () => {
+    const text = 'Gnosis Chain'
+
+    const result = cleanNetworkName(text)
+
+    expect(result).toBe('gnosischain')
   })
 })

--- a/test/utils/url.spec.ts
+++ b/test/utils/url.spec.ts
@@ -1,0 +1,34 @@
+import { Network } from 'types'
+import { replaceURL, buildSearchString } from 'utils/url'
+
+describe('replace URL path according to network', () => {
+  test('path is replaced to rinkeby', () => {
+    const currentPath = '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, 'rinkeby', Network.xDAI)).toBe(
+      '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9',
+    )
+  })
+
+  test('path is replaced to xdai', () => {
+    const currentPath = '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, 'xdai', Network.Rinkeby)).toBe(
+      '/xdai/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9',
+    )
+  })
+
+  test('url is replaced to mainnet', () => {
+    const currentPath = '/rinkeby/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9'
+    expect(replaceURL(currentPath, '', Network.Rinkeby)).toBe('/address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9')
+  })
+})
+
+describe('BuildSearchString', () => {
+  test('params decoded correctly', () => {
+    const owner = '0xbD326ba3D9BaD3A08cf521C41bC69A620a750B3f'
+    const orderId =
+      '0x59920c85de0162e9e55df8d396e75f3b6b7c2dfdb535f03e5c807731c31585eaff714b8b0e2700303ec912bd40496c3997ceea2b616d6710'
+    const queryString = `/trades` + buildSearchString({ owner, orderUid: orderId })
+
+    expect(queryString).toBe(`/trades?owner=${owner}&orderUid=${orderId}`)
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const getWebpackConfig = require('./getWebpackConfig')
 const loadConfig = require('./src/loadConfig')
 const overrideEnvConfig = require('./src/overrideEnvConfig')
 
-const isProduction = process.env.NODE_ENV == 'production'
+const isProduction = process.env.NODE_ENV === 'production'
 const baseUrl = isProduction ? '' : '/'
 
 // FIXME: The apps right now depend on config they don't, se below attempt to check what was required. One example of something that is required but we don't need is --> for some reason "createTheGraphApi" it's being executed
@@ -23,6 +23,7 @@ const EXPLORER_APP = {
     EXPLORER_APP_DOMAIN_REGEX_DEV: '^protocol-explorer\\.dev|^localhost:\\d{2,5}|^pr\\d+--gpui\\.review',
     EXPLORER_APP_DOMAIN_REGEX_STAGING: '^protocol-explorer\\.staging',
     EXPLORER_APP_DOMAIN_REGEX_PROD: '^gnosis-protocol\\.io',
+    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.gnosis-protocol\\.io',
 
     OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
     OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,9 +23,9 @@
     xlsx "^0.17.0"
 
 "@apollo/client@^3.1.5":
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.4.tgz#a2c1c1c377c5ffb5822dd6269a741749b3ad5df3"
-  integrity sha512-6kybsXEdtRYGUDap4kOded6OFw501H+wL3/WGeRtO+NBcLfhuvRwkfCNpm0oTJWDDSxhQnWKCbxJgrLgoxCeFg==
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.5.tgz#ce331403ee5f099e595430890f9b510c8435c932"
+  integrity sha512-EiQstc8VjeqosS2h21bwY9fhL3MCRRmACtRrRh2KYpp9vkDyx5pUfMnN3swgiBVYw1twdXg9jHmyZa1gZlvlog==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7573,9 +7573,9 @@ data-urls@^2.0.0:
     whatwg-url "^8.0.0"
 
 date-fns@^2.9.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.26.0.tgz#fa45305543c392c4f914e50775fd2a4461e60fbd"
-  integrity sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg==
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
+  integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,9 +23,9 @@
     xlsx "^0.17.0"
 
 "@apollo/client@^3.1.5":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.2.tgz#f0a4d8cb42f045e0527f081da9bb21c4fb53aeaf"
-  integrity sha512-STC7ZQthcOGU+MXRIzcb3s1ULW9QQFEhXFEIUaK3Jdwy0RxncxYkg2LpwxXV0FqlYUjKEW92f+NUIZ2FhpKGug==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.3.tgz#938181be042cdd31152948fd6ac915bae0dc1f70"
+  integrity sha512-Zo6OzaKIoLADsq0afpnuq0x/SI+gr9TXukDN5AvaIfU5Jwm37TNpzayDUx3Xgu1G4lmt5UBDTg7MUoaBa53yoQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,10 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
-"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.0.tgz#ea269d7f78deb3a7826c39a4048eecda541ebdaa"
-  integrity sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
+  integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -140,14 +140,14 @@
     "@babel/helper-explode-assignable-expression" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz#01d615762e796c17952c29e3ede9d6de07d235a8"
-  integrity sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.16.0", "@babel/helper-compilation-targets@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz#5b480cd13f68363df6ec4dc8ac8e2da11363cbf0"
+  integrity sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==
   dependencies:
     "@babel/compat-data" "^7.16.0"
     "@babel/helper-validator-option" "^7.14.5"
-    browserslist "^4.16.6"
+    browserslist "^4.17.5"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.15.0":
@@ -186,20 +186,6 @@
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz#3c2f91b7971b9fc11fe779c945c014065dea340e"
   integrity sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==
-  dependencies:
-    "@babel/helper-compilation-targets" "^7.13.0"
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.13.0"
-    "@babel/traverse" "^7.13.0"
-    debug "^4.1.1"
-    lodash.debounce "^4.0.8"
-    resolve "^1.14.2"
-    semver "^6.1.2"
-
-"@babel/helper-define-polyfill-provider@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.4.tgz#8867aed79d3ea6cade40f801efb7ac5c66916b10"
-  integrity sha512-OrpPZ97s+aPi6h2n1OXzdhVis1SGSsMU2aMHgLcOKfsp4/v1NWpx3CWT3lBj5eeBq9cDkPkh+YCfdF7O12uNDQ==
   dependencies:
     "@babel/helper-compilation-targets" "^7.13.0"
     "@babel/helper-module-imports" "^7.12.13"
@@ -338,6 +324,15 @@
     "@babel/helper-wrap-function" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-remap-async-to-generator@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.4.tgz#5d7902f61349ff6b963e07f06a389ce139fbfe6e"
+  integrity sha512-vGERmmhR+s7eH5Y/cp8PCVzj4XEjerq8jooMfxFdA5xVtAk9Sh4AQsrWgiErUEBjtGrBtOFKDUcWQFW4/dFwMA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-wrap-function" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-replace-supers@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz#ace07708f5bf746bf2e6ba99572cce79b5d4e7f4"
@@ -443,10 +438,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.0.tgz#cf147d7ada0a3655e79bf4b08ee846f00a00a295"
   integrity sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A==
 
-"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.0.tgz#efb7f147042aca34ce8156a055906a7abaadeaf0"
-  integrity sha512-djyecbGMEh4rOb/Tc1M5bUW2Ih1IZRa9PoubnPOCzM+DRE89uGUHR1Y+3aDdTMW4drjGRZ2ol8dt1JUFg6hJLQ==
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.2":
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.2.tgz#2977fca9b212db153c195674e57cfab807733183"
+  integrity sha512-h37CvpLSf8gb2lIJ2CgC3t+EjFbi0t8qS7LCS1xcJIlEXE4czlofwaW7W1HA8zpgOCzI9C1nmoqNR1zWkk0pQg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
@@ -459,13 +454,13 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
     "@babel/plugin-proposal-optional-chaining" "^7.16.0"
 
-"@babel/plugin-proposal-async-generator-functions@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.0.tgz#11425d47a60364352f668ad5fbc1d6596b2c5caf"
-  integrity sha512-nyYmIo7ZqKsY6P4lnVmBlxp9B3a96CscbLotlsNuktMHahkDwoPYEjXrZHU0Tj844Z9f1IthVxQln57mhkcExw==
+"@babel/plugin-proposal-async-generator-functions@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.4.tgz#e606eb6015fec6fa5978c940f315eae4e300b081"
+  integrity sha512-/CUekqaAaZCQHleSK/9HajvcD/zdnJiKRiuUFq8ITE+0HsPzquf53cpFiqAwl/UfmJbR6n5uGPQSPdrmKOvHHg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/helper-remap-async-to-generator" "^7.16.0"
+    "@babel/helper-remap-async-to-generator" "^7.16.4"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
 "@babel/plugin-proposal-class-properties@^7.12.1", "@babel/plugin-proposal-class-properties@^7.16.0", "@babel/plugin-proposal-class-properties@^7.8.3":
@@ -944,10 +939,10 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-replace-supers" "^7.16.0"
 
-"@babel/plugin-transform-parameters@^7.12.1", "@babel/plugin-transform-parameters@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.0.tgz#1b50765fc421c229819dc4c7cdb8911660b3c2d7"
-  integrity sha512-XgnQEm1CevKROPx+udOi/8f8TiGhrUWiHiaUCIp47tE0tpFDjzXNTZc9E5CmCwxNjXTWEVqvRfWZYOTFvMa/ZQ==
+"@babel/plugin-transform-parameters@^7.12.1", "@babel/plugin-transform-parameters@^7.16.0", "@babel/plugin-transform-parameters@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.3.tgz#fa9e4c874ee5223f891ee6fa8d737f4766d31d15"
+  integrity sha512-3MaDpJrOXT1MZ/WCmkOFo7EtmVVC8H4EUZVrHvFOsmwkk4lOjQj8rzv8JKUZV4YoQKeoIgk07GO+acPU9IMu/w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
@@ -1078,17 +1073,17 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/preset-env@^7.12.11", "@babel/preset-env@^7.9.4":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.0.tgz#97228393d217560d6a1c6c56f0adb9d12bca67f5"
-  integrity sha512-cdTu/W0IrviamtnZiTfixPfIncr2M1VqRrkjzZWlr1B4TVYimCFK5jkyOdP4qw2MrlKHi+b3ORj6x8GoCew8Dg==
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.4.tgz#4f6ec33b2a3fe72d6bfdcdf3859500232563a2e3"
+  integrity sha512-v0QtNd81v/xKj4gNKeuAerQ/azeNn/G1B1qMLeXOcV8+4TWlD2j3NV1u8q29SDFBXx/NBq5kyEAO+0mpRgacjA==
   dependencies:
-    "@babel/compat-data" "^7.16.0"
-    "@babel/helper-compilation-targets" "^7.16.0"
+    "@babel/compat-data" "^7.16.4"
+    "@babel/helper-compilation-targets" "^7.16.3"
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-validator-option" "^7.14.5"
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.16.0"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.16.2"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.16.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.16.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.16.4"
     "@babel/plugin-proposal-class-properties" "^7.16.0"
     "@babel/plugin-proposal-class-static-block" "^7.16.0"
     "@babel/plugin-proposal-dynamic-import" "^7.16.0"
@@ -1138,7 +1133,7 @@
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.16.0"
     "@babel/plugin-transform-new-target" "^7.16.0"
     "@babel/plugin-transform-object-super" "^7.16.0"
-    "@babel/plugin-transform-parameters" "^7.16.0"
+    "@babel/plugin-transform-parameters" "^7.16.3"
     "@babel/plugin-transform-property-literals" "^7.16.0"
     "@babel/plugin-transform-regenerator" "^7.16.0"
     "@babel/plugin-transform-reserved-words" "^7.16.0"
@@ -1151,10 +1146,10 @@
     "@babel/plugin-transform-unicode-regex" "^7.16.0"
     "@babel/preset-modules" "^0.1.5"
     "@babel/types" "^7.16.0"
-    babel-plugin-polyfill-corejs2 "^0.2.3"
-    babel-plugin-polyfill-corejs3 "^0.3.0"
-    babel-plugin-polyfill-regenerator "^0.2.3"
-    core-js-compat "^3.19.0"
+    babel-plugin-polyfill-corejs2 "^0.3.0"
+    babel-plugin-polyfill-corejs3 "^0.4.0"
+    babel-plugin-polyfill-regenerator "^0.3.0"
+    core-js-compat "^3.19.1"
     semver "^6.3.0"
 
 "@babel/preset-flow@^7.12.1":
@@ -5468,15 +5463,6 @@ babel-plugin-named-asset-import@^0.3.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz#156cd55d3f1228a5765774340937afc8398067dd"
   integrity sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==
 
-babel-plugin-polyfill-corejs2@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.3.tgz#6ed8e30981b062f8fe6aca8873a37ebcc8cc1c0f"
-  integrity sha512-NDZ0auNRzmAfE1oDDPW2JhzIMXUk+FFe2ICejmt5T4ocKgiQx3e0VCRx9NCAidcMtL2RUZaWtXnmjTCkx0tcbA==
-  dependencies:
-    "@babel/compat-data" "^7.13.11"
-    "@babel/helper-define-polyfill-provider" "^0.2.4"
-    semver "^6.1.1"
-
 babel-plugin-polyfill-corejs2@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz#407082d0d355ba565af24126fb6cb8e9115251fd"
@@ -5494,14 +5480,6 @@ babel-plugin-polyfill-corejs3@^0.1.0:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
     core-js-compat "^3.8.1"
 
-babel-plugin-polyfill-corejs3@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz#fa7ca3d1ee9ddc6193600ffb632c9785d54918af"
-  integrity sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.2.4"
-    core-js-compat "^3.18.0"
-
 babel-plugin-polyfill-corejs3@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz#0b571f4cf3d67f911512f5c04842a7b8e8263087"
@@ -5509,13 +5487,6 @@ babel-plugin-polyfill-corejs3@^0.4.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.0"
     core-js-compat "^3.18.0"
-
-babel-plugin-polyfill-regenerator@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz#2e9808f5027c4336c994992b48a4262580cb8d6d"
-  integrity sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.2.4"
 
 babel-plugin-polyfill-regenerator@^0.3.0:
   version "0.3.0"
@@ -6033,7 +6004,7 @@ browserslist@4.14.2:
     escalade "^3.0.2"
     node-releases "^1.1.61"
 
-browserslist@^4.12.0, browserslist@^4.16.6:
+browserslist@^4.12.0:
   version "4.16.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.7.tgz#108b0d1ef33c4af1b587c54f390e7041178e4335"
   integrity sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==
@@ -6051,6 +6022,17 @@ browserslist@^4.17.5:
   dependencies:
     caniuse-lite "^1.0.30001271"
     electron-to-chromium "^1.3.878"
+    escalade "^3.1.1"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
+
+browserslist@^4.17.6:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
+  integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
+  dependencies:
+    caniuse-lite "^1.0.30001280"
+    electron-to-chromium "^1.3.896"
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
@@ -6384,6 +6366,11 @@ caniuse-lite@^1.0.30001271:
   version "1.0.30001274"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz#26ca36204d15b17601ba6fc35dbdad950a647cc7"
   integrity sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==
+
+caniuse-lite@^1.0.30001280:
+  version "1.0.30001282"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
+  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7125,12 +7112,12 @@ copy-webpack-plugin@^6.4.1:
     serialize-javascript "^5.0.1"
     webpack-sources "^1.4.3"
 
-core-js-compat@^3.18.0, core-js-compat@^3.19.0, core-js-compat@^3.8.1:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.19.0.tgz#b3b93f93c8721b3ed52b91f12f964cc410967f8b"
-  integrity sha512-R09rKZ56ccGBebjTLZHvzDxhz93YPT37gBm6qUhnwj3Kt7aCjjZWD1injyNbyeFHxNKfeZBSyds6O9n3MKq1sw==
+core-js-compat@^3.18.0, core-js-compat@^3.19.1, core-js-compat@^3.8.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.19.1.tgz#fe598f1a9bf37310d77c3813968e9f7c7bb99476"
+  integrity sha512-Q/VJ7jAF/y68+aUsQJ/afPOewdsGkDtcMb40J8MbuWKlK3Y+wtHq8bTHKPj2WKWLIqmS5JhHs4CzHtz6pT2W6g==
   dependencies:
-    browserslist "^4.17.5"
+    browserslist "^4.17.6"
     semver "7.0.0"
 
 core-js-pure@^3.8.2:
@@ -8256,6 +8243,11 @@ electron-to-chromium@^1.3.878:
   version "1.3.885"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.885.tgz#c8cec32fbc61364127849ae00f2395a1bae7c454"
   integrity sha512-JXKFJcVWrdHa09n4CNZYfYaK6EW5aAew7/wr3L1OnsD1L+JHL+RCtd7QgIsxUbFPeTwPlvnpqNNTOLkoefmtXg==
+
+electron-to-chromium@^1.3.896:
+  version "1.3.901"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.901.tgz#ce2c3157d61bce9f42f1e83225c17358ae9f4918"
+  integrity sha512-ToJdV2vzwT2jeAsw8zIggTFllJ4Kxvwghk39AhJEHHlIxor10wsFI3wo69p8nFc0s/ATWBqugPv/k3nW4Y9Mww==
 
 element-resize-detector@^1.2.2:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10723,9 +10723,9 @@ graphql-tag@^2.12.3:
     tslib "^2.1.0"
 
 graphql@^15.3.0:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.6.1.tgz#9125bdf057553525da251e19e96dab3d3855ddfc"
-  integrity sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
+  integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
 
 growly@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3981,9 +3981,9 @@
   integrity sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==
 
 "@types/node@^14.0.10", "@types/node@^14.0.14":
-  version "14.17.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.33.tgz#011ee28e38dc7aee1be032ceadf6332a0ab15b12"
-  integrity sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==
+  version "14.17.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.34.tgz#fe4b38b3f07617c0fa31ae923fca9249641038f0"
+  integrity sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,9 +23,9 @@
     xlsx "^0.17.0"
 
 "@apollo/client@^3.1.5":
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.3.tgz#938181be042cdd31152948fd6ac915bae0dc1f70"
-  integrity sha512-Zo6OzaKIoLADsq0afpnuq0x/SI+gr9TXukDN5AvaIfU5Jwm37TNpzayDUx3Xgu1G4lmt5UBDTg7MUoaBa53yoQ==
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.4.tgz#a2c1c1c377c5ffb5822dd6269a741749b3ad5df3"
+  integrity sha512-6kybsXEdtRYGUDap4kOded6OFw501H+wL3/WGeRtO+NBcLfhuvRwkfCNpm0oTJWDDSxhQnWKCbxJgrLgoxCeFg==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4163,9 +4163,9 @@
     csstype "^3.0.2"
 
 "@types/react@^16", "@types/react@^16.9.19":
-  version "16.14.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.20.tgz#ff6e932ad71d92c27590e4a8667c7a53a7d0baad"
-  integrity sha512-SV7TaVc8e9E/5Xuv6TIyJ5VhQpZoVFJqX6IZgj5HZoFCtIDCArE3qXkcHlc6O/Ud4UwcMoX+tlvDA95YrKdLgA==
+  version "16.14.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
+  integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15870,9 +15870,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.1.2:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
+  integrity sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==
 
 prettier@~2.2.1:
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8740,9 +8740,9 @@ eslint-plugin-prettier@^3.1.4:
     prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-react-hooks@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
-  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
+  integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
 
 eslint-plugin-react@^7.21.2:
   version "7.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,9 +2696,9 @@
     source-map "^0.7.3"
 
 "@popperjs/core@^2.0.6", "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
-  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.0.tgz#6734f8ebc106a0860dff7f92bf90df193f0935d7"
+  integrity sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==
 
 "@reach/router@^1.3.4":
   version "1.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,6 +210,20 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-define-polyfill-provider@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz#c5b10cf4b324ff840140bb07e05b8564af2ae971"
+  integrity sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
+
 "@babel/helper-explode-assignable-expression@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz#753017337a15f46f9c09f674cff10cee9b9d7778"
@@ -992,15 +1006,15 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-runtime@^7.5.5", "@babel/plugin-transform-runtime@^7.8.3":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz#3fe0da36c2f0834bef7c4d3e7f2b2db0ee0c8909"
-  integrity sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz#f9ba3c7034d429c581e1bd41b4952f3db3c2c7e8"
+  integrity sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==
   dependencies:
     "@babel/helper-module-imports" "^7.16.0"
     "@babel/helper-plugin-utils" "^7.14.5"
-    babel-plugin-polyfill-corejs2 "^0.2.3"
-    babel-plugin-polyfill-corejs3 "^0.3.0"
-    babel-plugin-polyfill-regenerator "^0.2.3"
+    babel-plugin-polyfill-corejs2 "^0.3.0"
+    babel-plugin-polyfill-corejs3 "^0.4.0"
+    babel-plugin-polyfill-regenerator "^0.3.0"
     semver "^6.3.0"
 
 "@babel/plugin-transform-shorthand-properties@^7.12.1", "@babel/plugin-transform-shorthand-properties@^7.16.0":
@@ -5494,6 +5508,15 @@ babel-plugin-polyfill-corejs2@^0.2.3:
     "@babel/helper-define-polyfill-provider" "^0.2.4"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs2@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz#407082d0d355ba565af24126fb6cb8e9115251fd"
+  integrity sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==
+  dependencies:
+    "@babel/compat-data" "^7.13.11"
+    "@babel/helper-define-polyfill-provider" "^0.3.0"
+    semver "^6.1.1"
+
 babel-plugin-polyfill-corejs3@^0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0"
@@ -5510,12 +5533,27 @@ babel-plugin-polyfill-corejs3@^0.3.0:
     "@babel/helper-define-polyfill-provider" "^0.2.4"
     core-js-compat "^3.18.0"
 
+babel-plugin-polyfill-corejs3@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz#0b571f4cf3d67f911512f5c04842a7b8e8263087"
+  integrity sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.0"
+    core-js-compat "^3.18.0"
+
 babel-plugin-polyfill-regenerator@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz#2e9808f5027c4336c994992b48a4262580cb8d6d"
   integrity sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.4"
+
+babel-plugin-polyfill-regenerator@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz#9ebbcd7186e1a33e21c5e20cae4e7983949533be"
+  integrity sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.0"
 
 babel-plugin-react-docgen@^4.2.1:
   version "4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7608,9 +7608,9 @@ data-urls@^2.0.0:
     whatwg-url "^8.0.0"
 
 date-fns@^2.9.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"
-  integrity sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.26.0.tgz#fa45305543c392c4f914e50775fd2a4461e60fbd"
+  integrity sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8744,9 +8744,9 @@ eslint-plugin-react-hooks@^4.1.2:
   integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
 
 eslint-plugin-react@^7.21.2:
-  version "7.27.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz#f952c76517a3915b81c7788b220b2b4c96703124"
-  integrity sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.1.tgz#469202442506616f77a854d91babaae1ec174b45"
+  integrity sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flatmap "^1.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,10 +1595,10 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
-"@ethersproject/networks@5.5.0", "@ethersproject/networks@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.0.tgz#babec47cab892c51f8dd652ce7f2e3e14283981a"
-  integrity sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==
+"@ethersproject/networks@5.5.1", "@ethersproject/networks@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.1.tgz#b7f7b9fb88dec1ea48f739b7fb9621311aa8ce6c"
+  integrity sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
@@ -1617,10 +1617,10 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
-"@ethersproject/providers@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.0.tgz#bc2876a8fe5e0053ed9828b1f3767ae46e43758b"
-  integrity sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==
+"@ethersproject/providers@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.1.tgz#ba87e3c93219bbd2e2edf8b369873aee774abf04"
+  integrity sha512-2zdD5sltACDWhjUE12Kucg2PcgM6V2q9JMyVvObtVGnzJu+QSmibbP+BHQyLWZUBfLApx2942+7DC5D+n4wBQQ==
   dependencies:
     "@ethersproject/abstract-provider" "^5.5.0"
     "@ethersproject/abstract-signer" "^5.5.0"
@@ -1745,10 +1745,10 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/wordlists" "^5.5.0"
 
-"@ethersproject/web@5.5.0", "@ethersproject/web@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.0.tgz#0e5bb21a2b58fb4960a705bfc6522a6acf461e28"
-  integrity sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==
+"@ethersproject/web@5.5.1", "@ethersproject/web@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.1.tgz#cfcc4a074a6936c657878ac58917a61341681316"
+  integrity sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==
   dependencies:
     "@ethersproject/base64" "^5.5.0"
     "@ethersproject/bytes" "^5.5.0"
@@ -9204,9 +9204,9 @@ ethereumjs-wallet@^1.0.1:
     uuid "^3.3.2"
 
 ethers@^5.0.26:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.1.tgz#d3259a95a42557844aa543906c537106c0406fbf"
-  integrity sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.2.tgz#cd2e508c7342c44fa70392f722e8de8f2416489f"
+  integrity sha512-EF5W+6Wwcu6BqVwpgmyR5U2+L4c1FQzlM/02dkZOugN3KF0cG9bzHZP+TDJglmPm2/IzCEJDT7KBxzayk7SAHw==
   dependencies:
     "@ethersproject/abi" "5.5.0"
     "@ethersproject/abstract-provider" "5.5.1"
@@ -9223,10 +9223,10 @@ ethers@^5.0.26:
     "@ethersproject/json-wallets" "5.5.0"
     "@ethersproject/keccak256" "5.5.0"
     "@ethersproject/logger" "5.5.0"
-    "@ethersproject/networks" "5.5.0"
+    "@ethersproject/networks" "5.5.1"
     "@ethersproject/pbkdf2" "5.5.0"
     "@ethersproject/properties" "5.5.0"
-    "@ethersproject/providers" "5.5.0"
+    "@ethersproject/providers" "5.5.1"
     "@ethersproject/random" "5.5.0"
     "@ethersproject/rlp" "5.5.0"
     "@ethersproject/sha2" "5.5.0"
@@ -9236,7 +9236,7 @@ ethers@^5.0.26:
     "@ethersproject/transactions" "5.5.0"
     "@ethersproject/units" "5.5.0"
     "@ethersproject/wallet" "5.5.0"
-    "@ethersproject/web" "5.5.0"
+    "@ethersproject/web" "5.5.1"
     "@ethersproject/wordlists" "5.5.0"
 
 ethjs-unit@0.1.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,15 +2748,6 @@
     "@sentry/utils" "6.15.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.14.3":
-  version "6.14.3"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.14.3.tgz#f6e84e561a4aff1a4447927356fea541465364c1"
-  integrity sha512-ZRWLHcAcv4oZAbpSwvCkXlaa1rVFDxcb9lxo5/5v5n6qJq2IG5Z+bXuT2DZlIHQmuCuqRnFSwuBjmBXY7OTHaw==
-  dependencies:
-    "@sentry/types" "6.14.3"
-    "@sentry/utils" "6.14.3"
-    tslib "^1.9.3"
-
 "@sentry/hub@6.15.0":
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.15.0.tgz#fb8a91d12fdd2726a884374ea7242f6bbd081d69"
@@ -2764,15 +2755,6 @@
   dependencies:
     "@sentry/types" "6.15.0"
     "@sentry/utils" "6.15.0"
-    tslib "^1.9.3"
-
-"@sentry/minimal@6.14.3":
-  version "6.14.3"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.14.3.tgz#f3a5b062bdc578000689fd0b31abbb994e6b81f3"
-  integrity sha512-2KNOJuhBpMICoOgdxX56UcO9vGdxCw5mNGYdWvJdKrMwRQr7mC+Fc9lTuTbrYTj6zkfklj2lbdDc3j44Rg787A==
-  dependencies:
-    "@sentry/hub" "6.14.3"
-    "@sentry/types" "6.14.3"
     tslib "^1.9.3"
 
 "@sentry/minimal@6.15.0":
@@ -2797,33 +2779,20 @@
     tslib "^1.9.3"
 
 "@sentry/tracing@^6.11.0":
-  version "6.14.3"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.14.3.tgz#0223d365ea0c7d3f7c90cb17ea84c4874bc9ef52"
-  integrity sha512-laFayAxpO/dQL3K3ZcSjtaqJkSf70DH1hHJ8Oiiic0c/xBxh38WSx8yu3TMrbfka5MVIuMNlkq1Gi+SC+moe4w==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.15.0.tgz#5a5f08ee6b9cc1189227536fca053cd23488600d"
+  integrity sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==
   dependencies:
-    "@sentry/hub" "6.14.3"
-    "@sentry/minimal" "6.14.3"
-    "@sentry/types" "6.14.3"
-    "@sentry/utils" "6.14.3"
+    "@sentry/hub" "6.15.0"
+    "@sentry/minimal" "6.15.0"
+    "@sentry/types" "6.15.0"
+    "@sentry/utils" "6.15.0"
     tslib "^1.9.3"
-
-"@sentry/types@6.14.3":
-  version "6.14.3"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.14.3.tgz#4af799df7ddfa2702a46bffabc3f1b6eb195de23"
-  integrity sha512-GuyqvjQ/N0hIgAjGD1Rn0aQ8kpLBBsImk+Aoh7YFhnvXRhCNkp9N8BuXTfC/uMdMshcWa1OFik/udyjdQM3EJA==
 
 "@sentry/types@6.15.0":
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.15.0.tgz#a2917f8aed91471bdfd6651384ffcd47b95c43ad"
   integrity sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA==
-
-"@sentry/utils@6.14.3":
-  version "6.14.3"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.14.3.tgz#4ae907054152882fbd376906695ac326934669d1"
-  integrity sha512-jsCnclEsR2sV9aHMuaLA5gvxSa0xV4Sc6IJCJ81NTTdb/A5fFbteFBbhuISGF9YoFW1pwbpjuTA6+efXwvLwNQ==
-  dependencies:
-    "@sentry/types" "6.14.3"
-    tslib "^1.9.3"
 
 "@sentry/utils@6.15.0":
   version "6.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7840,9 +7840,9 @@ detect-browser@5.2.0:
   integrity sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA==
 
 detect-browser@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.2.1.tgz#b884f8d84e8f33bb874ffed10b4beea26133fcd1"
-  integrity sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.3.0.tgz#9705ef2bddf46072d0f7265a1fe300e36fe7ceca"
+  integrity sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==
 
 detect-file@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,15 +3,17 @@
 
 
 "@amcharts/amcharts4@^4.9.12":
-  version "4.10.22"
-  resolved "https://registry.yarnpkg.com/@amcharts/amcharts4/-/amcharts4-4.10.22.tgz#5f2000b20c8db0a2ed4cc74c525c807b11c23ace"
-  integrity sha512-Z/vPGKtNf1m4sdKK1P4San8SAG1AuYJ0tLhptUqntb4u+kRfRbU2QydIGsVmpHPENLg17ukIWySwo6mv3by/tw==
+  version "4.10.23"
+  resolved "https://registry.yarnpkg.com/@amcharts/amcharts4/-/amcharts4-4.10.23.tgz#103ee61d7516c0a627e8ffc64348cf5023fa56fc"
+  integrity sha512-cMxChIV7+Glngw0WU2VvM7qv5MQUuUNenh7wSeQ04iJGLLc3spLv2964V74nAVZvWS6/5b4153D3HZcSqObZXQ==
   dependencies:
     "@babel/runtime" "^7.6.3"
     core-js "^3.0.0"
     d3-force "^2.0.1"
     d3-geo "^2.0.1"
     d3-geo-projection "^3.0.0"
+    d3-selection "^1.0.2"
+    d3-transition "^1.0.1"
     pdfmake "^0.2.2"
     polylabel "^1.0.2"
     raf "^3.4.1"
@@ -19,7 +21,6 @@
     rgbcolor "^1.0.1"
     stackblur-canvas "^2.0.0"
     tslib "^2.0.1"
-    venn.js "^0.2.20"
     xlsx "^0.17.0"
 
 "@apollo/client@^3.1.5":
@@ -4890,15 +4891,6 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
-  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
-  dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
-
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -6279,7 +6271,7 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@~1.0.2:
+call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -6326,11 +6318,6 @@ camelcase-keys@^6.2.2:
     camelcase "^5.3.1"
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
-
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 camelcase@^2.0.0:
   version "2.1.1"
@@ -6404,14 +6391,6 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
-
 cfb@^1.1.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.0.tgz#6a4d0872b525ed60349e1ef51fb4b0bf73eca9a8"
@@ -6439,7 +6418,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.0.0, chalk@^1.1.1:
+chalk@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -6678,15 +6657,6 @@ clipboardy@1.2.3:
   dependencies:
     arch "^2.1.0"
     execa "^0.8.0"
-
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
-  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
-  dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -7043,11 +7013,6 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-contour_plot@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/contour_plot/-/contour_plot-0.0.1.tgz#475870f032b8e338412aa5fc507880f0bf495c77"
-  integrity sha1-R1hw8DK44zhBKqX8UHiA8L9JXHc=
 
 convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
@@ -7641,7 +7606,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -7735,7 +7700,7 @@ deep-equal-ident@^1.1.1:
   dependencies:
     lodash.isequal "^3.0"
 
-deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@~1.1.1:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -7815,11 +7780,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-defined@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
 del@^4.1.1:
   version "4.1.1"
@@ -8135,13 +8095,6 @@ dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
-dotignore@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"
-  integrity sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==
-  dependencies:
-    minimatch "^3.0.4"
 
 download@^6.2.2:
   version "6.2.5"
@@ -10036,17 +9989,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-fmin@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fmin/-/fmin-0.0.2.tgz#59bbb40d43ffdc1c94cd00a568c41f95f1973017"
-  integrity sha1-Wbu0DUP/3ByUzQClaMQflfGXMBc=
-  dependencies:
-    contour_plot "^0.0.1"
-    json2module "^0.0.3"
-    rollup "^0.25.8"
-    tape "^4.5.1"
-    uglify-js "^2.6.2"
-
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
@@ -10069,7 +10011,7 @@ fontkit@^1.8.1:
     unicode-properties "^1.2.2"
     unicode-trie "^0.3.0"
 
-for-each@^0.3.3, for-each@~0.3.3:
+for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
@@ -10493,7 +10435,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.7:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -10857,7 +10799,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@^1.0.3, has@~1.0.3:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -11496,7 +11438,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -11969,7 +11911,7 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.2, is-regex@^1.1.3, is-regex@^1.1.4, is-regex@~1.1.3:
+is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.2, is-regex@^1.1.3, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -12947,13 +12889,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2module@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/json2module/-/json2module-0.0.3.tgz#00fb5f4a9b7adfc3f0647c29cb17bcd1979be9b2"
-  integrity sha1-APtfSpt638PwZHwpyxe80Zeb6bI=
-  dependencies:
-    rw "^1.3.2"
-
 json3@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
@@ -13181,11 +13116,6 @@ lazy-ass@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
-
-lazy-cache@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-  integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
 
 lazy-universal-dotenv@^3.0.1:
   version "3.0.1"
@@ -13547,7 +13477,7 @@ longest-streak@^2.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
-longest@^1.0.0, longest@^1.0.1:
+longest@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
@@ -14119,7 +14049,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -14710,7 +14640,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.11.0, object-inspect@^1.6.0, object-inspect@^1.7.0, object-inspect@^1.9.0, object-inspect@~1.11.0:
+object-inspect@^1.11.0, object-inspect@^1.6.0, object-inspect@^1.7.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
@@ -17037,7 +16967,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
   integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
-repeat-string@^1.0.0, repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -17180,7 +17110,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.10, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@~1.20.0:
+resolve@^1.1.10, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -17210,13 +17140,6 @@ restructure@^0.5.3:
   dependencies:
     browserify-optional "^1.0.0"
 
-resumer@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
-  integrity sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=
-  dependencies:
-    through "~2.3.4"
-
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -17241,13 +17164,6 @@ rifm@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.12.0.tgz#8d3a9dc0de9c190e0de9bdc8861a91a221dc1341"
   integrity sha512-PqOl+Mo2lyqrKiD34FPlnQ+ksD3F+a62TQlphiZshgriyHdfjn6jGyqUZhd+s3nsMYXwXYDdjrrv8wX7QsOG3g==
-
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
-  dependencies:
-    align-text "^0.1.1"
 
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
@@ -17277,15 +17193,6 @@ rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4:
   integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==
   dependencies:
     bn.js "^4.11.1"
-
-rollup@^0.25.8:
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.25.8.tgz#bf6ce83b87510d163446eeaa577ed6a6fc5835e0"
-  integrity sha1-v2zoO4dRDRY0Ru6qV37WpvxYNeA=
-  dependencies:
-    chalk "^1.1.1"
-    minimist "^1.2.0"
-    source-map-support "^0.3.2"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -17318,11 +17225,6 @@ rustbn.js@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
-
-rw@^1.3.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@^7.1.0:
   version "7.3.0"
@@ -17942,13 +17844,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.3.3.tgz#34900977d5ba3f07c7757ee72e73bb1a9b53754f"
-  integrity sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=
-  dependencies:
-    source-map "0.1.32"
-
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -17962,14 +17857,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
-source-map@0.1.32:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
-  integrity sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=
-  dependencies:
-    amdefine ">=0.0.4"
-
-source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -18368,7 +18256,7 @@ string.prototype.padstart@^3.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
 
-string.prototype.trim@^1.2.1, string.prototype.trim@~1.2.4:
+string.prototype.trim@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz#6014689baf5efaf106ad031a5fa45157666ed1bd"
   integrity sha512-hWCk/iqf7lp0/AgTF7/ddO1IWtSNPASjlzCicV5irAVdE1grjsneK26YG6xACMBEdCvO8fUST0UzDMh/2Qy+9Q==
@@ -18755,27 +18643,6 @@ tapable@^2.0.0, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
-tape@^4.5.1:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.14.0.tgz#e4d46097e129817175b90925f2385f6b1bcfa826"
-  integrity sha512-z0+WrUUJuG6wIdWrl4W3rTte2CR26G6qcPOj3w1hfRdcmhF3kHBhOBW9VHsPVAkz08ZmGzp7phVpDupbLzrYKQ==
-  dependencies:
-    call-bind "~1.0.2"
-    deep-equal "~1.1.1"
-    defined "~1.0.0"
-    dotignore "~0.1.2"
-    for-each "~0.3.3"
-    glob "~7.1.7"
-    has "~1.0.3"
-    inherits "~2.0.4"
-    is-regex "~1.1.3"
-    minimist "~1.2.5"
-    object-inspect "~1.11.0"
-    resolve "~1.20.0"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.2.4"
-    through "~2.3.8"
-
 tar-fs@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
@@ -18992,7 +18859,7 @@ through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-through@2, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4, through@~2.3.8:
+through@2, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -19398,21 +19265,6 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
-
-uglify-js@^2.6.2:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
-  dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
 
 ultron@~1.1.0:
   version "1.1.1"
@@ -19898,15 +19750,6 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
-venn.js@^0.2.20:
-  version "0.2.20"
-  resolved "https://registry.yarnpkg.com/venn.js/-/venn.js-0.2.20.tgz#3f0e50cc75cba1f58692a8a32f67bd7aaf1aa6fa"
-  integrity sha512-bb5SYq/wamY9fvcuErb9a0FJkgIFHJjkLZWonQ+DoKKuDX3WPH2B4ouI1ce4K2iejBklQy6r1ly8nOGIyOCO6w==
-  dependencies:
-    d3-selection "^1.0.2"
-    d3-transition "^1.0.1"
-    fmin "0.0.2"
 
 verror@1.10.0:
   version "1.10.0"
@@ -20599,11 +20442,6 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
-
 wmf@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wmf/-/wmf-1.0.2.tgz#7d19d621071a08c2bdc6b7e688a9c435298cc2da"
@@ -20618,11 +20456,6 @@ word@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 worker-farm@^1.7.0:
   version "1.7.0"
@@ -20928,16 +20761,6 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
 
 yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
# Release 2.5.0

:warning: DO NOT SQUASH :warning: 

**Main features**:
* Allow network switching through a menu in the header
* Improve user search experience
* Misc bug fixes and improvements

## Changelog

### Features
440788cc 917 rename xdai to gc (#918)
6f015160 Adding resolveENS function and use on UserDetail Page (#888)
ed26bc58 [Explorer] Networks change menu (#898)
c0c44a6f Retry endpoint when it does not return (#723)
bd1d8647 replaced placeholder with el (#880)
6620910e Explorer barn (#850)
d46940b5 Tooltips - increase tap area (#868)
e72bce00 Add SearchNotFound page (#828)
80ea6d8e Enable stale bot
e23e93d0 Signing status styles (#866)
e5b17876 Merge remote-tracking branch 'origin/release/2.4.0_update_develop' into develop
41b6c8cf Merge pull request #858 from gnosis/release/2.4.0

### Dependency updates
cf1e8c3e Bump date-fns from 2.26.0 to 2.27.0 (#907)
33f78817 Bump detect-browser from 5.2.1 to 5.3.0 (#893)
50bcf6ae Bump ethers from 5.5.1 to 5.5.2 (#892)
f77ac436 Bump @amcharts/amcharts4 from 4.10.22 to 4.10.23 (#879)
7002eeca Bump @popperjs/core from 2.10.2 to 2.11.0 (#877)
72593550 Bump @apollo/client from 3.5.4 to 3.5.5 (#878)
fb6e0fe3 Bump prettier from 2.4.1 to 2.5.0 (#872)
26a9144c Bump graphql from 15.6.1 to 15.7.2 (#805)
8f2053a5 Bump @apollo/client from 3.5.3 to 3.5.4 (#865)
6d2ba153 Bump date-fns from 2.25.0 to 2.26.0 (#864)
a0644e4b Bump eslint-plugin-react from 7.27.0 to 7.27.1 (#863)
011615ec Bump @types/node from 14.17.33 to 14.17.34 (#860)
459a4e04 Bump @apollo/client from 3.5.2 to 3.5.3 (#842)
a64fccde Bump @babel/preset-env from 7.16.0 to 7.16.4 (#841)
62083f28 Bump @sentry/tracing from 6.14.3 to 6.15.0 (#839)
b36e4c61 Bump @babel/plugin-transform-runtime from 7.16.0 to 7.16.4 (#840)
b4332944 Bump eslint-plugin-react-hooks from 4.2.0 to 4.3.0 (#837)
cc4f8117 Bump @types/react from 16.14.20 to 16.14.21 (#836)
