### PR TITLE
fix ethereum URL on EmptyUserDetailsTable

### DIFF
--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -70,6 +70,12 @@ const _findNetworkName = (networkId: number): string => {
   return networkOptions.find((e) => e.id === networkId)?.name || 'Unknown network'
 }
 
+const _buildInternalNetworkUrl = (networkId: number, ownerAddress: string): string => {
+  const networkPrefix = PREFIX_BY_NETWORK_ID.get(networkId)
+
+  return `${networkPrefix && '/' + networkPrefix}/address/${ownerAddress}`
+}
+
 export const EmptyOrdersMessage = ({
   isLoading,
   networkId,
@@ -106,7 +112,7 @@ export const EmptyOrdersMessage = ({
                 {ordersInNetworks.map((e) => (
                   <li key={e.network}>
                     <Link
-                      to={`/${PREFIX_BY_NETWORK_ID.get(e.network)}/address/${ownerAddress}`}
+                      to={_buildInternalNetworkUrl(e.network, ownerAddress)}
                       onClick={(): void => setLoadingState(true)}
                     >
                       {_findNetworkName(e.network)}


### PR DESCRIPTION
# Summary

Hotfix: 
- To build Internal Network URL by Ethereum.

## Background

*Reported by* @alfetopito on https://github.com/gnosis/gp-ui/pull/921#pullrequestreview-838495359

## To Test
- Go to:
https://pr922--gpui.review.gnosisdev.com/gc/address/0xb638EDa8C10005CB456b1913ad60a8f3d6a92714/ and click **Ethereum**