### PR TITLE
Update Explorer URLs due to rebranding

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,8 @@ const EXPLORER_APP = {
   envVars: {
     EXPLORER_APP_DOMAIN_REGEX_DEV: '^protocol-explorer\\.dev|^localhost:\\d{2,5}|^pr\\d+--gpui\\.review',
     EXPLORER_APP_DOMAIN_REGEX_STAGING: '^protocol-explorer\\.staging',
-    EXPLORER_APP_DOMAIN_REGEX_PROD: '^gnosis-protocol\\.io',
-    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.gnosis-protocol\\.io',
+    EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi',
+    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi',
 
     OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
     OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,12 +22,12 @@ const EXPLORER_APP = {
   envVars: {
     EXPLORER_APP_DOMAIN_REGEX_DEV: '^protocol-explorer\\.dev|^localhost:\\d{2,5}|^pr\\d+--gpui\\.review',
     EXPLORER_APP_DOMAIN_REGEX_STAGING: '^protocol-explorer\\.staging',
-    EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi',
-    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi',
+    EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi|^gnosis-protocol\\.io',
+    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi|^barn\\.gnosis-protocol\\.io',
 
-    OPERATOR_URL_STAGING_MAINNET: 'https://barn.api.cow.fi/mainnet',
-    OPERATOR_URL_STAGING_RINKEBY: 'https://barn.api.cow.fi/rinkeby',
-    OPERATOR_URL_STAGING_XDAI: 'https://barn.api.cow.fi/xdai',
+    OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
+    OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
+    OPERATOR_URL_STAGING_XDAI: 'https://protocol-xdai.dev.gnosisdev.com/api',
     OPERATOR_URL_PROD_MAINNET: 'https://api.cow.fi/mainnet',
     OPERATOR_URL_PROD_RINKEBY: 'https://api.cow.fi/rinkeby',
     OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,9 +28,9 @@ const EXPLORER_APP = {
     OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
     OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
     OPERATOR_URL_STAGING_XDAI: 'https://protocol-xdai.dev.gnosisdev.com/api',
-    OPERATOR_URL_PROD_MAINNET: 'https://api.cow.fi/mainnet',
-    OPERATOR_URL_PROD_RINKEBY: 'https://api.cow.fi/rinkeby',
-    OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai',
+    OPERATOR_URL_PROD_MAINNET: 'https://api.cow.fi/mainnet/api',
+    OPERATOR_URL_PROD_RINKEBY: 'https://api.cow.fi/rinkeby/api',
+    OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai/api',
 
     GOOGLE_ANALYTICS_ID: undefined,
     REACT_APP_SENTRY_DSN: undefined,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,9 +25,9 @@ const EXPLORER_APP = {
     EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi',
     EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi',
 
-    OPERATOR_URL_STAGING_MAINNET: 'https://bar.api.cow.fi/mainnet',
-    OPERATOR_URL_STAGING_RINKEBY: 'https://bar.api.cow.fi/rinkeby',
-    OPERATOR_URL_STAGING_XDAI: 'https://bar.api.cow.fi/xdai',
+    OPERATOR_URL_STAGING_MAINNET: 'https://barn.api.cow.fi/mainnet',
+    OPERATOR_URL_STAGING_RINKEBY: 'https://barn.api.cow.fi/rinkeby',
+    OPERATOR_URL_STAGING_XDAI: 'https://barn.api.cow.fi/xdai',
     OPERATOR_URL_PROD_MAINNET: 'https://api.cow.fi/mainnet',
     OPERATOR_URL_PROD_RINKEBY: 'https://api.cow.fi/rinkeby',
     OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,12 +25,12 @@ const EXPLORER_APP = {
     EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi',
     EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi',
 
-    OPERATOR_URL_STAGING_MAINNET: 'https://protocol-mainnet.dev.gnosisdev.com/api',
-    OPERATOR_URL_STAGING_RINKEBY: 'https://protocol-rinkeby.dev.gnosisdev.com/api',
-    OPERATOR_URL_STAGING_XDAI: 'https://protocol-xdai.dev.gnosisdev.com/api',
-    OPERATOR_URL_PROD_MAINNET: 'https://protocol-mainnet.gnosis.io/api',
-    OPERATOR_URL_PROD_RINKEBY: 'https://protocol-rinkeby.gnosis.io/api',
-    OPERATOR_URL_PROD_XDAI: 'https://protocol-xdai.gnosis.io/api',
+    OPERATOR_URL_STAGING_MAINNET: 'https://bar.api.cow.fi/mainnet',
+    OPERATOR_URL_STAGING_RINKEBY: 'https://bar.api.cow.fi/rinkeby',
+    OPERATOR_URL_STAGING_XDAI: 'https://bar.api.cow.fi/xdai',
+    OPERATOR_URL_PROD_MAINNET: 'https://api.cow.fi/mainnet',
+    OPERATOR_URL_PROD_RINKEBY: 'https://api.cow.fi/rinkeby',
+    OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai',
 
     GOOGLE_ANALYTICS_ID: undefined,
     REACT_APP_SENTRY_DSN: undefined,


### PR DESCRIPTION
Closes #914, #915

- Update URLs to identify PROD, BARN stages with base `explorer.cow.fi`

- Update URLs to talk to backend API with base `api.cow.fi`
