### PR TITLE
[Explorer] Make contracts URLs on footer network aware

### DIFF
--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -564,7 +564,7 @@ export class WalletApiImpl implements WalletApi {
     return {
       isConnected,
       userAddress: accounts[0],
-      networkId: isConnected ? +chainId : undefined,
+      networkId: +chainId,
     }
   }
 

--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -7,10 +7,11 @@ import { getGpV2ContractAddress } from 'utils/contract'
 import { BlockExplorerLink } from 'apps/gp-v1/components/common/BlockExplorerLink'
 
 // Hooks
-import { useWalletConnection } from 'hooks/useWalletConnection'
+import { useNetworkId } from 'state/network'
 
 // Config
 import { footerConfig } from '../Footer/config'
+import { Network } from 'types'
 
 const FooterStyled = styled.footer`
   display: flex;
@@ -99,10 +100,9 @@ export interface FooterType {
 
 export const Footer: React.FC<FooterType> = (props) => {
   const { isBeta = footerConfig.isBeta, url = footerConfig.url } = props
-  const { networkIdOrDefault: networkId } = useWalletConnection()
+  const networkId = useNetworkId() || Network.Mainnet
   const settlementContractAddress = getGpV2ContractAddress(networkId, 'GPv2Settlement')
   const vaultRelayerContractAddress = getGpV2ContractAddress(networkId, 'GPv2VaultRelayer')
-
   return (
     <FooterStyled>
       <BetaWrapper>{isBeta && 'This project is in beta. Use at your own risk.'}</BetaWrapper>


### PR DESCRIPTION
# Summary

Closes #408 

Make contracts urls on footer network aware by receiving network changes.

<img width="1530" alt="Screen Shot 2022-01-03 at 16 51 52" src="https://user-images.githubusercontent.com/11525018/147974021-5c046618-c3a9-48e5-be58-312b23c9fd47.png">

# To Test

1.  Open any page. i.e: `root page`
    * Navigate to the footer and click on any of those contract links.
2. Change networks using the selector.
   * Click on contract links again and you will se they are being updated to match network and explorer.

