### PR TITLE
Adding isOrderCancelled and isOrderCancelling cases

### DIFF
--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -4,6 +4,7 @@ import { AnalyticsDimension, Network } from 'types'
 export const ORDER_QUERY_INTERVAL = 10000 // in ms
 export const ORDERS_QUERY_INTERVAL = 30000 // in ms
 export const ORDERS_HISTORY_MINUTES_AGO = 10 // in minutes
+export const PENDING_ORDERS_BUFFER = 60 * 1000 //60s in ms
 
 export const DISPLAY_TEXT_COPIED_CHECK = 1000 // in ms
 

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -8,6 +8,7 @@ import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
 
 import { formattingAmountPrecision, formatSmartMaxPrecision } from 'utils'
+import { PENDING_ORDERS_BUFFER } from 'apps/explorer/const'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount
@@ -53,7 +54,6 @@ function isOrderPresigning(order: RawOrder): boolean {
  * We assume the order is not fulfilled.
  */
 function isOrderCancelled(order: Pick<RawOrder, 'creationDate' | 'invalidated'>): boolean {
-  const PENDING_ORDERS_BUFFER = 60 * 1000 //60s
   const creationTime = new Date(order.creationDate).getTime()
   return order.invalidated && Date.now() - creationTime > PENDING_ORDERS_BUFFER
 }

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -2,8 +2,8 @@ export * from './data'
 import { DATE } from './data'
 import BN from 'bn.js'
 
-export function mockTimes(): void {
-  jest.spyOn(global.Date, 'now').mockImplementation(() => DATE.valueOf())
+export function mockTimes(dateToUse: Date = DATE): void {
+  jest.spyOn(global.Date, 'now').mockImplementation(() => dateToUse.valueOf())
 }
 
 /**

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -1,4 +1,5 @@
 import { RawOrder, RawOrderStatusFromAPI } from 'api/operator'
+import { PENDING_ORDERS_BUFFER } from 'apps/explorer/const'
 
 import { getOrderStatus } from 'utils'
 
@@ -13,8 +14,13 @@ function _getPastTimestamp(): number {
   return Math.floor(DATE.getTime() / 1000) - 1
 }
 
-// mockTimes set's Date.now() to DATE const in the test context
-beforeEach(() => mockTimes)
+function _creationDatePlusMilliseconds(milliseconds: number): Date {
+  const creationDate = new Date(RAW_ORDER.creationDate)
+  return new Date(creationDate.setMilliseconds(creationDate.getMilliseconds() + milliseconds))
+}
+
+// mockTimes set's Date.now() to creationDate plus twice time PendingBuffer const in the test context
+beforeEach(() => mockTimes(_creationDatePlusMilliseconds(PENDING_ORDERS_BUFFER * 2)))
 
 describe('Filled status', () => {
   describe('Buy order', () => {
@@ -114,10 +120,6 @@ describe('Filled status', () => {
 })
 
 describe('Canceled status', () => {
-  const years = 4 // The const DATE has the year 2017 (less than the creationDate)
-  const currentDate = new Date(DATE.setFullYear(DATE.getFullYear() + years))
-  beforeEach(() => mockTimes(currentDate))
-
   test('Buy order', () => {
     const order: RawOrder = {
       ...RAW_ORDER,
@@ -145,6 +147,49 @@ describe('Canceled status', () => {
       validTo: _getPastTimestamp(),
     }
     expect(getOrderStatus(order)).toEqual('cancelled')
+  })
+})
+
+describe('Cancelling Status', () => {
+  const milliseconds = 30 * 1000 // The creation time should be less than PENDING_ORDERS_BUFFER constant
+  const newCurrentDate = _creationDatePlusMilliseconds(milliseconds)
+  beforeEach(() => mockTimes(newCurrentDate))
+
+  test('Buy order', () => {
+    const order: RawOrder = {
+      ...RAW_ORDER,
+      kind: 'buy',
+      buyAmount: '10000',
+      invalidated: true,
+      validTo: _getCurrentTimestamp(),
+      status: 'cancelled',
+    }
+    expect(getOrderStatus(order)).toEqual('cancelling')
+  })
+  test('Sell order', () => {
+    const order: RawOrder = {
+      ...RAW_ORDER,
+      kind: 'sell',
+      sellAmount: '10000',
+      invalidated: true,
+      validTo: _getCurrentTimestamp(),
+      status: 'cancelled',
+    }
+    expect(getOrderStatus(order)).toEqual('cancelling')
+  })
+  test('When creationDate is already longer than the pendingOrderBuffer', () => {
+    const millisecondsBefore = -PENDING_ORDERS_BUFFER - milliseconds // ms before the newCurrentDate
+    const newCreationDate = _creationDatePlusMilliseconds(millisecondsBefore)
+    const order: RawOrder = {
+      ...RAW_ORDER,
+      kind: 'sell',
+      sellAmount: '10000',
+      invalidated: true,
+      validTo: _getCurrentTimestamp(),
+      creationDate: newCreationDate.toISOString(),
+    }
+
+    expect(getOrderStatus(order)).not.toEqual('cancelling')
   })
 })
 

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -14,7 +14,7 @@ function _getPastTimestamp(): number {
 }
 
 // mockTimes set's Date.now() to DATE const in the test context
-beforeEach(mockTimes)
+beforeEach(() => mockTimes)
 
 describe('Filled status', () => {
   describe('Buy order', () => {
@@ -114,6 +114,9 @@ describe('Filled status', () => {
 })
 
 describe('Canceled status', () => {
+  const currentDate = new Date(DATE.setFullYear(DATE.getFullYear() + 4))
+  beforeEach(() => mockTimes(currentDate))
+
   test('Buy order', () => {
     const order: RawOrder = {
       ...RAW_ORDER,

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -114,7 +114,8 @@ describe('Filled status', () => {
 })
 
 describe('Canceled status', () => {
-  const currentDate = new Date(DATE.setFullYear(DATE.getFullYear() + 4))
+  const years = 4 // The const DATE has the year 2017 (less than the creationDate)
+  const currentDate = new Date(DATE.setFullYear(DATE.getFullYear() + years))
   beforeEach(() => mockTimes(currentDate))
 
   test('Buy order', () => {


### PR DESCRIPTION
# Summary

Closes #612 

**Proposal:**
Add logic to check if the order is cancelled, [cowswap reference](https://github.com/gnosis/cowswap/blob/2165-adding-wallet-supports/src/custom/state/orders/utils.ts#L38)

# To Test

1. Create a new swap on [dev cowswap environment](https://cowswap.dev.gnosisdev.com/#/swap).
2. Go to pending button and clicked, it will open `account modal` try to cancel order.
3. Go to explorer https://pr999--gpui.review.gnosisdev.com/rinkeby/address/<address>    (:bulb:  replace your wallet `address`)