### PR TITLE
[Explorer] Change 'Unknown Token' to Token like Etherscan

### DIFF
--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -54,7 +54,7 @@ export async function getErc20Info({ tokenAddress, networkId, erc20Api, web3 }: 
   return {
     address: tokenAddress,
     symbol: parseStringOrBytes32(symbol, 'UNKNOWN'),
-    name: parseStringOrBytes32(name, 'Unknown Token'),
+    name: parseStringOrBytes32(name, 'Token'),
     decimals: decimals ?? DEFAULT_PRECISION,
   }
 }

--- a/test/utils/format.spec.ts
+++ b/test/utils/format.spec.ts
@@ -8,6 +8,6 @@ describe('parse string or bytes32', () => {
 
   test('parseStringOrBytes32 parse bytes32', () => {
     const name = '0x4865646765547261646500000000000000000000000000000000000000000000'
-    expect(parseStringOrBytes32(name, 'Unknown Token')).toMatch(/HedgeTrade/)
+    expect(parseStringOrBytes32(name, 'Token')).toMatch(/HedgeTrade/)
   })
 })


### PR DESCRIPTION
# Summary

Closes #912 

Updated default token name to `Token` like it is in Etherscan 

<img width="1229" alt="Screen Shot 2022-01-31 at 17 10 09" src="https://user-images.githubusercontent.com/11525018/151865530-7e070ede-5a75-4aca-9b6b-95f09db57467.png">


# To Test

1. Go to an order page. i.e: `0xa6ac719a3e099a2aa22f36109936c6accaed2a05a826bbb4b6e0c23bb56f0b32ff714b8b0e2700303ec912bd40496c3997ceea2b61a9ee1a`
   * `Token` will we displayed instead of `Unknown Token` in Amount row
 
