### PR TITLE
[Explorer] Update Gnosis Chain color and contrast

### DIFF
--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -98,8 +98,8 @@ export const NetworkLabel = styled.span`
   }
 
   &.gnosischain {
-    background: ${(): string => `rgb(4 121 91 / 15%);`};
-    color: ${(): string => gnosisChainColor};
+    background: ${(): string => `rgba(7,121,91,1.00);`};
+    color: ${(): string => white};
   }
 `
 

--- a/src/styles/colours.ts
+++ b/src/styles/colours.ts
@@ -3,7 +3,7 @@ export const COLOURS = {
   whiteDark: '#e9e9f0',
   blue: '#3F77FF',
   blueDark: '#185afb',
-  gnosisChainColor: '#04795b',
+  gnosisChainColor: '#07795b',
   purple: '#8958FF',
   bgLight: '#edf2f7',
   bgDark: 'linear-gradient(0deg, #21222E 0.05%, #2C2D3F 100%)',


### PR DESCRIPTION
# Summary

Closes #1015 

Updated background and font color of Gnosis Chain in order to increase contrast.

<img width="1308" alt="Screen Shot 2022-02-01 at 19 43 25" src="https://user-images.githubusercontent.com/11525018/152063945-f7a97c68-0049-4474-a356-66ea05e1f779.png">


# To Test

1. Open any page. i.e: `Home`
  * Open network selector and select Gnosis Chain
  * You'll see the color of the network has been changed in order to increase the contrast. 

