### PR TITLE
Release 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.6.0",
+  "version": "2.6.0-rc.1",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.6.0-rc.1",
+  "version": "2.6.0",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.6.0-rc.0",
+  "version": "2.6.0",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/src/apps/explorer/components/TransactionsTableWidget/index.tsx
+++ b/src/apps/explorer/components/TransactionsTableWidget/index.tsx
@@ -29,7 +29,7 @@ const tabItems = (isLoadingOrders: boolean): TabItemInterface[] => {
       id: 1,
       tab: (
         <>
-          Transactions
+          Orders
           <StyledTabLoader>{isLoadingOrders && <Spinner spin size="1x" />}</StyledTabLoader>
         </>
       ),

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -4,6 +4,7 @@ import { AnalyticsDimension, Network } from 'types'
 export const ORDER_QUERY_INTERVAL = 10000 // in ms
 export const ORDERS_QUERY_INTERVAL = 30000 // in ms
 export const ORDERS_HISTORY_MINUTES_AGO = 10 // in minutes
+export const PENDING_ORDERS_BUFFER = 60 * 1000 //60s in ms
 
 export const DISPLAY_TEXT_COPIED_CHECK = 1000 // in ms
 

--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -63,6 +63,11 @@ export const Header: React.FC = () => {
               Community
             </ExternalLink>
           </li>
+          <li>
+            <ExternalLink target={'_blank'} href={'https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2'}>
+              Analytics
+            </ExternalLink>
+          </li>
         </Navigation>
       </FlexWrap>
     </GenericHeader>

--- a/src/apps/explorer/styled.ts
+++ b/src/apps/explorer/styled.ts
@@ -1,6 +1,5 @@
-import styled from 'styled-components'
+import styled, { createGlobalStyle } from 'styled-components'
 import { media } from 'theme/styles/media'
-import { createGlobalStyle } from 'styled-components'
 
 export const GlobalStyle = createGlobalStyle`
   html {
@@ -46,10 +45,7 @@ export const MainWrapper = styled.div`
   ${media.xSmallDown} {
     max-width: 100%;
     flex-grow: 1;
-    header {
-      margin-left: auto;
-      margin-right: auto;
-    }
+
     footer {
       flex-direction: column;
       flex-wrap: nowrap;

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -102,8 +102,8 @@ export const NetworkLabel = styled.span`
   }
 
   &.gnosischain {
-    background: ${(): string => `rgb(4 121 91 / 15%);`};
-    color: ${(): string => gnosisChainColor};
+    background: ${(): string => `rgba(7,121,91,1.00);`};
+    color: ${(): string => white};
   }
 `
 

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { COLOURS } from 'styles'
+import { media } from 'theme/styles/media'
 
 const { fadedGreyishWhiteOpacity, white, gnosisChainColor } = COLOURS
 
@@ -20,6 +21,9 @@ export const SelectorContainer = styled.div`
       transform: rotate(0deg);
       transition: transform 0.1s linear;
     }
+  }
+  ${media.xSmallDown} {
+    padding-right: 2rem;
   }
 `
 

--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -130,11 +130,6 @@ export const Footer: React.FC<FooterType> = (props) => {
             Web: v{VERSION}
           </a>
         )}
-        {CONFIG.appId && (
-          <a target="_blank" rel="noopener noreferrer" href={url.appId ?? '#'}>
-            App Id: {CONFIG.appId}
-          </a>
-        )}
         {url.contracts && CONTRACT_VERSION && (
           <a target="_blank" rel="noopener noreferrer" href={url.contracts + CONTRACT_VERSION}>
             Contracts: v{CONTRACT_VERSION}

--- a/src/components/layout/GenericLayout/Header/index.tsx
+++ b/src/components/layout/GenericLayout/Header/index.tsx
@@ -54,6 +54,12 @@ const Logo = styled(Link)`
     justify-content: center;
     color: ${({ theme }): string => theme.textPrimary1};
   }
+
+  ${media.xSmallDown} {
+    > img {
+      max-width: 11.5rem;
+    }
+  }
 `
 
 type Props = PropsWithChildren<{

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -169,7 +169,7 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
             className="span-copybtn-wrap"
             textToCopy={uid}
             contentsToDisplay={
-              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
+              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_self">
                 {shortId}
               </LinkWithPrefixNetwork>
             }

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -171,7 +171,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
             className="span-copybtn-wrap"
             textToCopy={uid}
             contentsToDisplay={
-              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
+              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_self">
                 {getShortOrderId(shortId)}
               </LinkWithPrefixNetwork>
             }

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -54,7 +54,7 @@ export async function getErc20Info({ tokenAddress, networkId, erc20Api, web3 }: 
   return {
     address: tokenAddress,
     symbol: parseStringOrBytes32(symbol, 'UNKNOWN'),
-    name: parseStringOrBytes32(name, 'Unknown Token'),
+    name: parseStringOrBytes32(name, 'Token'),
     decimals: decimals ?? DEFAULT_PRECISION,
   }
 }

--- a/src/styles/colours.ts
+++ b/src/styles/colours.ts
@@ -3,7 +3,7 @@ export const COLOURS = {
   whiteDark: '#e9e9f0',
   blue: '#3F77FF',
   blueDark: '#185afb',
-  gnosisChainColor: '#04795b',
+  gnosisChainColor: '#07795b',
   purple: '#8958FF',
   bgLight: '#edf2f7',
   bgDark: 'linear-gradient(0deg, #21222E 0.05%, #2C2D3F 100%)',

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -8,6 +8,7 @@ import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
 
 import { formattingAmountPrecision, formatSmartMaxPrecision } from 'utils'
+import { PENDING_ORDERS_BUFFER } from 'apps/explorer/const'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount
@@ -44,15 +45,34 @@ function isOrderPresigning(order: RawOrder): boolean {
   return order.status === 'presignaturePending'
 }
 
+/**
+ * An order is considered cancelled if the `invalidated` flag is `true` and
+ * it has been at least `PENDING_ORDERS_BUFFER` since it has been created.
+ * The buffer is used to take into account race conditions where a solver might
+ * execute a transaction after the backend changed the order status.
+ *
+ * We assume the order is not fulfilled.
+ */
+function isOrderCancelled(order: Pick<RawOrder, 'creationDate' | 'invalidated'>): boolean {
+  const creationTime = new Date(order.creationDate).getTime()
+  return order.invalidated && Date.now() - creationTime > PENDING_ORDERS_BUFFER
+}
+
+function isOrderCancelling(order: RawOrder): boolean {
+  return order.status === 'cancelled' && order.invalidated
+}
+
 export function getOrderStatus(order: RawOrder): OrderStatus {
   if (isOrderFilled(order)) {
     return 'filled'
-  } else if (order.invalidated) {
+  } else if (isOrderCancelled(order)) {
     return 'cancelled'
   } else if (isOrderExpired(order)) {
     return 'expired'
   } else if (isOrderPresigning(order)) {
     return 'signing'
+  } else if (isOrderCancelling(order)) {
+    return 'cancelling'
   } else {
     return 'open'
   }

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -2,8 +2,8 @@ export * from './data'
 import { DATE } from './data'
 import BN from 'bn.js'
 
-export function mockTimes(): void {
-  jest.spyOn(global.Date, 'now').mockImplementation(() => DATE.valueOf())
+export function mockTimes(dateToUse: Date = DATE): void {
+  jest.spyOn(global.Date, 'now').mockImplementation(() => dateToUse.valueOf())
 }
 
 /**

--- a/test/utils/format.spec.ts
+++ b/test/utils/format.spec.ts
@@ -8,6 +8,6 @@ describe('parse string or bytes32', () => {
 
   test('parseStringOrBytes32 parse bytes32', () => {
     const name = '0x4865646765547261646500000000000000000000000000000000000000000000'
-    expect(parseStringOrBytes32(name, 'Unknown Token')).toMatch(/HedgeTrade/)
+    expect(parseStringOrBytes32(name, 'Token')).toMatch(/HedgeTrade/)
   })
 })


### PR DESCRIPTION
# Release v2.6.0

:warning: DO NOT SQUASH :warning:

## Main features:
- Added transactions view
- Changes on header and footer (network aware)
- Misc bug fixes and improvements

## Changelog

### Features
8d3716fa Change 'Unknown Token' to Token like Etherscan (#1010)
fe76240a Remove appId from Explorer footer (#1028)
ef32c77b Make internal links open in the same tab - external links in another one (#1029)
3035569e Update Gnosis Chain color and contrast (#1023)
53c4c224 Add analytics link to header (#1027)
fbcdb4e4 Remove margins left/right from header (#1026)
8686cdad 1014 change tab title to Orders (#1025)
4223354b Adding isOrderCancelled and isOrderCancelling cases (#999)
cd395a69 header links (#953)
e7064099 transaction view (#882)
b082c028 Tx table storybook (#897)
9678a7b1 Update XDAI, WXDAI and GNO token logos (#986)
57b33bd9 Adding queue_rules (#955)
d97517e9 Merge remote-tracking branch 'origin/master' into develop
b734984c Search tx every network (#933)
2f911bef Make contracts urls on footer network aware by receiving networkId changes (#934)
6f227a8a Search for tx on search bar (#899)
51885adb Merge pull request #926 from gnosis/release/2.5.0_update_develop
7f147782 Merge branch 'develop' into release/2.5.0_update_develop
fb1d7f2f 917 rename xdai to gc (#918)
ee60fd4f Wire up TransactionDetails page with Tx API (#908)
6795db3c Adding getTxOrders to connect Tx API (#900)

### Dependency Updates
a43a745f Bump follow-redirects from 1.14.5 to 1.14.7 (#987)
c9cef1f6 Bump playwright from 1.16.3 to 1.17.2 (#939)
8411ebd3 Bump @types/styled-components from 5.1.15 to 5.1.19 (#928)
6f463ede Bump @types/node from 14.17.34 to 14.18.1 (#916)

