### PR TITLE
[Explorer] Add analytics link to header

### DIFF
--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -63,6 +63,11 @@ export const Header: React.FC = () => {
               Community
             </ExternalLink>
           </li>
+          <li>
+            <ExternalLink target={'_blank'} href={'https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2'}>
+              Analytics
+            </ExternalLink>
+          </li>
         </Navigation>
       </FlexWrap>
     </GenericHeader>


### PR DESCRIPTION
# Summary

Closes #1019 

Added Analytics link to the Header

<img width="1229" alt="Screen Shot 2022-02-02 at 21 08 12" src="https://user-images.githubusercontent.com/11525018/152258987-f4e51568-3eba-4d40-8037-01d116893bf6.png">

# To Test

1. Open `home` page 
    * You'll see an Analytics link in the header next to Community one.


