### PR TITLE
[Explorer] Remove appId from Explorer footer

### DIFF
--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -130,11 +130,6 @@ export const Footer: React.FC<FooterType> = (props) => {
             Web: v{VERSION}
           </a>
         )}
-        {CONFIG.appId && (
-          <a target="_blank" rel="noopener noreferrer" href={url.appId ?? '#'}>
-            App Id: {CONFIG.appId}
-          </a>
-        )}
         {url.contracts && CONTRACT_VERSION && (
           <a target="_blank" rel="noopener noreferrer" href={url.contracts + CONTRACT_VERSION}>
             Contracts: v{CONTRACT_VERSION}


### PR DESCRIPTION
# Summary

Closes #1022 

Removed `appId` from footer in Explorer

<img width="1257" alt="Screen Shot 2022-02-04 at 15 59 38" src="https://user-images.githubusercontent.com/11525018/152587379-6b28121b-086a-4973-aeab-9fe341e3b5f7.png">

# To Test

1. Open any page. i.e: `home`
    * You'll see `AppId` was removed from footer

