### PR TITLE
[Explorer] Make internal links open in the same tab - external links in another one

### DIFF
--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -169,7 +169,7 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
             className="span-copybtn-wrap"
             textToCopy={uid}
             contentsToDisplay={
-              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
+              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_self">
                 {shortId}
               </LinkWithPrefixNetwork>
             }

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -171,7 +171,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
             className="span-copybtn-wrap"
             textToCopy={uid}
             contentsToDisplay={
-              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_blank">
+              <LinkWithPrefixNetwork to={`/orders/${order.uid}`} rel="noopener noreferrer" target="_self">
                 {getShortOrderId(shortId)}
               </LinkWithPrefixNetwork>
             }


### PR DESCRIPTION
# Summary

Closes #1020 

Added `_self` to internal links to open same tab.
Added `_blank` to external links to open another tab.

# To Test
1. Open a page with links. i.e : `address/0xb6bad41ae76a11d10f7b0e664c5007b908bc77c9`
     * Click on a Token link or address next to the `User Details` title. Those links will be opened in another tab.
     * Click on an order link in the table. Those links will be opened in the same tab.
     

