### PR TITLE
[Explorer] Remove 'This project is in beta. Use at your own risk' message in footer

### DIFF
--- a/src/components/layout/GenericLayout/Footer/config.ts
+++ b/src/components/layout/GenericLayout/Footer/config.ts
@@ -1,5 +1,5 @@
 export const footerConfig = {
-  isBeta: true,
+  isBeta: false,
   url: {
     web: 'https://github.com/gnosis/gp-ui/tree/v',
     // TODO: Pending to move and adapt the wiki

--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -22,7 +22,7 @@ const FooterStyled = styled.footer`
   flex: 1 1 auto;
   color: ${({ theme }): string => theme.textSecondary2};
   width: 100%;
-  justify-content: space-between;
+  justify-content: space-around;
   margin: 0 auto;
 
   ${media.mediumDown} {
@@ -105,7 +105,7 @@ export const Footer: React.FC<FooterType> = (props) => {
   const vaultRelayerContractAddress = getGpV2ContractAddress(networkId, 'GPv2VaultRelayer')
   return (
     <FooterStyled>
-      <BetaWrapper>{isBeta && 'This project is in beta. Use at your own risk.'}</BetaWrapper>
+      {isBeta && <BetaWrapper>This project is in beta. Use at your own risk.</BetaWrapper>}
       <ContractsWrapper>
         {settlementContractAddress && (
           <VerifiedButton

--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -37,6 +37,19 @@ const FooterStyled = styled.footer`
   }
 `
 
+const BetaWrapper = styled.div`
+  display: flex;
+  margin: 0;
+  height: 100%;
+  align-items: center;
+  padding: 0 1rem 0 0;
+  position: relative;
+
+  ${media.mediumDown} {
+    margin: 0 0 1.6rem;
+  }
+`
+
 const ContractsWrapper = styled.div`
   display: flex;
 
@@ -86,12 +99,13 @@ export interface FooterType {
 }
 
 export const Footer: React.FC<FooterType> = (props) => {
-  const { url = footerConfig.url } = props
+  const { isBeta = footerConfig.isBeta, url = footerConfig.url } = props
   const networkId = useNetworkId() || Network.Mainnet
   const settlementContractAddress = getGpV2ContractAddress(networkId, 'GPv2Settlement')
   const vaultRelayerContractAddress = getGpV2ContractAddress(networkId, 'GPv2VaultRelayer')
   return (
     <FooterStyled>
+      <BetaWrapper>{isBeta && 'This project is in beta. Use at your own risk.'}</BetaWrapper>
       <ContractsWrapper>
         {settlementContractAddress && (
           <VerifiedButton

--- a/src/components/layout/GenericLayout/Footer/index.tsx
+++ b/src/components/layout/GenericLayout/Footer/index.tsx
@@ -37,19 +37,6 @@ const FooterStyled = styled.footer`
   }
 `
 
-const BetaWrapper = styled.div`
-  display: flex;
-  margin: 0;
-  height: 100%;
-  align-items: center;
-  padding: 0 1rem 0 0;
-  position: relative;
-
-  ${media.mediumDown} {
-    margin: 0 0 1.6rem;
-  }
-`
-
 const ContractsWrapper = styled.div`
   display: flex;
 
@@ -99,13 +86,12 @@ export interface FooterType {
 }
 
 export const Footer: React.FC<FooterType> = (props) => {
-  const { isBeta = footerConfig.isBeta, url = footerConfig.url } = props
+  const { url = footerConfig.url } = props
   const networkId = useNetworkId() || Network.Mainnet
   const settlementContractAddress = getGpV2ContractAddress(networkId, 'GPv2Settlement')
   const vaultRelayerContractAddress = getGpV2ContractAddress(networkId, 'GPv2VaultRelayer')
   return (
     <FooterStyled>
-      <BetaWrapper>{isBeta && 'This project is in beta. Use at your own risk.'}</BetaWrapper>
       <ContractsWrapper>
         {settlementContractAddress && (
           <VerifiedButton


### PR DESCRIPTION
# Summary

Closes #1035 

Removed 'This project is in beta. Use at your own risk' message in footer

![image](https://user-images.githubusercontent.com/11525018/152871045-a022cffe-71c8-48e9-a180-7dc0e0a14222.png)


# To Test

1. Open any page. i.e: `Home`
    * You'll see the message 'This project is in beta. Use at your own risk' in footer has been removed.

