### PR TITLE
"Search not found" responsive page

### DIFF
--- a/src/apps/explorer/pages/Home/index.tsx
+++ b/src/apps/explorer/pages/Home/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Search } from 'apps/explorer/components/common/Search'
 import { Wrapper as WrapperMod } from 'apps/explorer/pages/styled'
 import styled from 'styled-components'
+import { media } from 'theme/styles/media'
 
 const Wrapper = styled(WrapperMod)`
   max-width: 140rem;
@@ -15,6 +16,10 @@ const Wrapper = styled(WrapperMod)`
     margin: 0 0 2.4rem;
     font-size: 2.4rem;
     line-height: 1;
+
+    ${media.xSmallDown} {
+      font-size: 1.7rem;
+    }
   }
 `
 

--- a/src/apps/explorer/styled.ts
+++ b/src/apps/explorer/styled.ts
@@ -1,6 +1,5 @@
-import styled from 'styled-components'
+import styled, { createGlobalStyle } from 'styled-components'
 import { media } from 'theme/styles/media'
-import { createGlobalStyle } from 'styled-components'
 
 export const GlobalStyle = createGlobalStyle`
   html {
@@ -46,10 +45,7 @@ export const MainWrapper = styled.div`
   ${media.xSmallDown} {
     max-width: 100%;
     flex-grow: 1;
-    header {
-      margin-left: auto;
-      margin-right: auto;
-    }
+
     footer {
       flex-direction: column;
       flex-wrap: nowrap;

--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -19,7 +19,7 @@ const Content = styled.div`
 
   p {
     line-height: ${({ theme }): string => theme.fontLineHeight};
-    overflow-wrap: break-word;
+    word-break: break-word;
   }
 
   strong {

--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -42,7 +42,7 @@ const SearchContent = styled.div`
 
   @media ${MEDIA.mobile} {
     flex-flow: column wrap;
-    gap: 0;
+    gap: 1.5rem;
 
     form {
       width: 100%;
@@ -110,7 +110,7 @@ export const OrderAddressNotFound: React.FC = (): JSX.Element => {
         <SearchSection>
           <SearchContent>
             <Search searchString={wasRedirected ? '' : searchString} submitSearchImmediatly={!wasRedirected} />
-            <p>or</p>
+            <span>or</span>
             <Support href="https://chat.cowswap.exchange/" target="_blank" rel="noopener noreferrer">
               Get Support
               <img src={SupportIcon} />

--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -40,7 +40,7 @@ const SearchContent = styled.div`
   align-items: center;
   gap: 2.5rem;
 
-  @media ${MEDIA.mobile} {
+  @media ${MEDIA.mediumDown} {
     flex-flow: column wrap;
     gap: 1.5rem;
 


### PR DESCRIPTION
# Summary

Closes #1018 
![image](https://user-images.githubusercontent.com/622217/153061146-fb54e5e4-89c7-40ce-b2a4-500857d59560.png)

# To Test

1. Open the explorer with a [wrong address](https://pr1037--gpui.review.gnosisdev.com/search/0x69904ff6d6100799344E5C9A2806936318F6ba4fWRONG) in a mobile device or use the DevTools.

