### PR TITLE
Fallback to https over websockets for Infura connection in IOS 15

### DIFF
--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -64,7 +64,7 @@ function websocketConnection(): boolean {
   // There's a bug in IOS affecting WebSocket connections reported in https://bugs.webkit.org/show_bug.cgi?id=228296
   // The issue comes with a new experimental feature in Safari "NSURLSession WebSocket" which is toggled on by default
   // and causes a termination on the connection which currently affects Infura. A solution until a fix is released (apparently in version 15.4)
-  // is to disable the "NSURLSession WebSocket" feature, but we could also fallback to https until the fixed is released.
+  // is to disable the "NSURLSession WebSocket" feature, but we could also fallback to https until the fix is released.
   // TODO: Re-test this issue after IOS 15.4 is released and remove this function
 
   const browserInfo = parseUserAgent(navigator.userAgent)

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -1,5 +1,6 @@
 import Web3 from 'web3'
 import { getNetworkFromId } from '@gnosis.pm/dex-js'
+import { parseUserAgent } from 'detect-browser'
 
 import { Network } from 'types'
 
@@ -49,7 +50,37 @@ function infuraProvider(networkId: Network): string {
   if (!INFURA_ID) {
     throw new Error(`INFURA_ID not set`)
   }
-  return `wss://${getNetworkFromId(networkId).toLowerCase()}.infura.io/ws/v3/${INFURA_ID}`
+
+  const network = getNetworkFromId(networkId).toLowerCase()
+
+  if (websocketConnection()) {
+    return `wss://${network}.infura.io/ws/v3/${INFURA_ID}`
+  } else {
+    return `https://${network}.infura.io/v3/${INFURA_ID}`
+  }
+}
+
+function websocketConnection(): boolean {
+  // There's a bug in IOS affecting WebSocket connections reported in https://bugs.webkit.org/show_bug.cgi?id=228296
+  // The issue comes with a new experimental feature in Safari "NSURLSession WebSocket" which is toggled on by default
+  // and causes a termination on the connection which currently affects Infura. A solution until a fix is released (apparently in version 15.4)
+  // is to disable the "NSURLSession WebSocket" feature, but we could also fallback to https until the fixed is released.
+  // TODO: Re-test this issue after IOS 15.4 is released and remove this function
+
+  const browserInfo = parseUserAgent(navigator.userAgent)
+
+  if (!browserInfo || !browserInfo.version) {
+    return true
+  }
+
+  const major = Number(browserInfo.version.split('.')[0])
+  const os = browserInfo.os?.toLocaleLowerCase()
+
+  if (os === 'ios' && major > 14) {
+    return false
+  }
+
+  return true
 }
 
 // For now only infura provider is available

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -53,14 +53,14 @@ function infuraProvider(networkId: Network): string {
 
   const network = getNetworkFromId(networkId).toLowerCase()
 
-  if (websocketConnection()) {
+  if (isWebsocketConnection()) {
     return `wss://${network}.infura.io/ws/v3/${INFURA_ID}`
   } else {
     return `https://${network}.infura.io/v3/${INFURA_ID}`
   }
 }
 
-function websocketConnection(): boolean {
+function isWebsocketConnection(): boolean {
   // There's a bug in IOS affecting WebSocket connections reported in https://bugs.webkit.org/show_bug.cgi?id=228296
   // The issue comes with a new experimental feature in Safari "NSURLSession WebSocket" which is toggled on by default
   // and causes a termination on the connection which currently affects Infura. A solution until a fix is released (apparently in version 15.4)

--- a/test/api/getProviderByNetwork.test.ts
+++ b/test/api/getProviderByNetwork.test.ts
@@ -1,0 +1,25 @@
+import { getProviderByNetwork } from 'api/web3'
+
+describe('getProviderByNetwork', () => {
+  test('Use websockets when not in IOS 15.x', () => {
+    jest
+      .spyOn(navigator, 'userAgent', 'get')
+      .mockReturnValueOnce(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1',
+      )
+    const providerUrl = getProviderByNetwork(1) || ''
+    const protocol = providerUrl.split(':')[0]
+    expect(protocol).toBe('wss')
+  })
+
+  test('Use https when using IOS 15.x', () => {
+    jest
+      .spyOn(navigator, 'userAgent', 'get')
+      .mockReturnValueOnce(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 15_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/167.0.382489606 Mobile/15E148 Safari/604.1',
+      )
+    const providerUrl = getProviderByNetwork(1) || ''
+    const protocol = providerUrl.split(':')[0]
+    expect(protocol).toBe('https')
+  })
+})


### PR DESCRIPTION
# Summary

Closes #1017 

This fixes an issue in IOS 15.x devices due to a bug introduced in Safari websocket's module when trying to connect to Infura through websockets. The proposed solution fallbacks to https only when IOS version is 15 as for version 14.x works fine.

# To Test

Open https://pr1064--gpui.review.gnosisdev.com/rinkeby/address/0xff714b8b0e2700303ec912bd40496c3997ceea2b/ and it should load everything