### PR TITLE
[Explorer] Home button redirects to the home page based on the network selected

### DIFF
--- a/src/apps/explorer/layout/Header.tsx
+++ b/src/apps/explorer/layout/Header.tsx
@@ -27,7 +27,7 @@ export const Header: React.FC = () => {
   const handleNavigate = (e: React.MouseEvent<HTMLAnchorElement>): void => {
     e.preventDefault()
     setBarActive(false)
-    history.push('/')
+    history.push(`/${prefixNetwork || ''}`)
   }
 
   return (


### PR DESCRIPTION
# Summary

Closes #1041 

Updated route redirection taking into account the network prefix.


# To Test

1.  Open any page
2. Switch to the Rinkeby/Gnosis Chain network
3. Press on the Home button link 
     * You will be redirected to the home taking into account the network you have selected.



