### PR TITLE
[Explorer] Cow SDK integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.8",
+    "@gnosis.pm/cow-sdk": "file:./../cow-sdk",
     "@gnosis.pm/dex-js": "^0.10.0",
     "@gnosis.pm/gp-v2-contracts": "^1.0.2",
     "@gnosis.pm/safe-apps-react-sdk": "^2.1.0",

--- a/src/api/operator/index.ts
+++ b/src/api/operator/index.ts
@@ -15,9 +15,5 @@ export const {
   getAccountOrders,
   getTxOrders,
   getTrades,
-  // functions that do not have a mock
-  getOrderLink = realApi.getOrderLink,
-  postSignedOrder = realApi.postSignedOrder,
-  getFeeQuote = realApi.getFeeQuote,
   // functions that only have a mock
 } = useMock ? { ...mockApi } : { ...realApi }

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -126,6 +126,9 @@ export async function getTxOrders(params: GetTxOrdersParams): Promise<RawOrder[]
 
   const chainId = networkId as unknown as SupportedChainId
   const cowInstance = new CowSdk(chainId, { isDevEnvironment: !(isProd || isStaging) })
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  //TO DO: Remove these ts comment lines when the SDK version is bumped with the new changes
   return cowInstance.cowApi.getTxOrders(txHash)
 }
 

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -2,6 +2,8 @@ import BigNumber from 'bignumber.js'
 
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 
+import { OrderMetaData, TradeMetaData } from '@gnosis.pm/cow-sdk'
+
 import { Network } from 'types'
 
 export type OrderID = string
@@ -24,27 +26,29 @@ export type OrderStatus = 'open' | 'filled' | 'cancelled' | 'cancelling' | 'expi
 export type RawOrderStatusFromAPI = 'presignaturePending' | 'open' | 'fullfilled' | 'cancelled' | 'expired'
 
 // Raw API response
-export type RawOrder = {
-  creationDate: string
-  owner: string
-  receiver?: string
-  uid: string
-  executedBuyAmount: string
-  executedSellAmount: string
-  executedFeeAmount: string
-  invalidated: boolean
-  sellToken: string
-  buyToken: string
-  sellAmount: string
-  buyAmount: string
-  validTo: number
-  appData: number
-  feeAmount: string
-  kind: OrderKind
-  partiallyFillable: boolean
-  signature: string
-  status: RawOrderStatusFromAPI
-}
+export type RawOrder =
+  | {
+      creationDate: string
+      owner: string
+      receiver?: string
+      uid: string
+      executedBuyAmount: string
+      executedSellAmount: string
+      executedFeeAmount: string
+      invalidated: boolean
+      sellToken: string
+      buyToken: string
+      sellAmount: string
+      buyAmount: string
+      validTo: number
+      appData: number
+      feeAmount: string
+      kind: OrderKind
+      partiallyFillable: boolean
+      signature: string
+      status: RawOrderStatusFromAPI
+    }
+  | OrderMetaData
 
 /**
  * Enriched Order type.
@@ -80,19 +84,21 @@ export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'parti
 /**
  * Raw API trade response type
  */
-export type RawTrade = {
-  blockNumber: number
-  logIndex: number
-  owner: string
-  txHash: string
-  orderUid: string
-  buyAmount: string
-  sellAmount: string
-  sellAmountBeforeFees: string
-  buyToken: string
-  sellToken: string
-  executionTime: string
-}
+export type RawTrade =
+  | {
+      blockNumber: number
+      logIndex: number
+      owner: string
+      txHash: string
+      orderUid: string
+      buyAmount: string
+      sellAmount: string
+      sellAmountBeforeFees: string
+      buyToken: string
+      sellToken: string
+      executionTime: string
+    }
+  | TradeMetaData
 
 /**
  * Enriched Trade type

--- a/src/services/helpers/tryGetOrderOnAllNetworks.ts
+++ b/src/services/helpers/tryGetOrderOnAllNetworks.ts
@@ -1,9 +1,10 @@
 import { GetOrderParams, GetTxOrdersParams, RawOrder } from 'api/operator'
 import { NETWORK_ID_SEARCH_LIST } from 'apps/explorer/const'
 import { Network } from 'types'
+import { OrderMetaData } from '@gnosis.pm/cow-sdk'
 
-export type SingleOrder = RawOrder | null
-export type MultipleOrders = RawOrder[] | null
+export type SingleOrder = RawOrder | OrderMetaData | null
+export type MultipleOrders = RawOrder[] | OrderMetaData[] | null
 
 export interface GetOrderResult<R> {
   order: R | null

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -2,13 +2,15 @@
 import BigNumber from 'bignumber.js'
 
 import { calculatePrice, invertPrice, TokenErc20 } from '@gnosis.pm/dex-js'
+import { TradeMetaData } from '@gnosis.pm/cow-sdk'
 
 import { FILLED_ORDER_EPSILON, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
-import { Order, OrderStatus, RawOrder, RawTrade, Trade } from 'api/operator/types'
+import { Order, OrderStatus, RawOrder, Trade } from 'api/operator/types'
 
 import { formattingAmountPrecision, formatSmartMaxPrecision } from 'utils'
 import { PENDING_ORDERS_BUFFER } from 'apps/explorer/const'
+import BN from 'bn.js'
 
 function isOrderFilled(order: RawOrder): boolean {
   let amount, executedAmount
@@ -194,8 +196,8 @@ export type GetRawOrderPriceParams = CommonPriceParams & {
 }
 
 export type GetOrderLimitPriceParams = CommonPriceParams & {
-  buyAmount: string | BigNumber
-  sellAmount: string | BigNumber
+  buyAmount: string | BigNumber | BN
+  sellAmount: string | BigNumber | BN
 }
 
 /**
@@ -350,9 +352,17 @@ export function transformOrder(rawOrder: RawOrder): Order {
 /**
  * Transforms a RawTrade into a Trade object
  */
-export function transformTrade(rawTrade: RawTrade): Trade {
-  const { orderUid, buyAmount, sellAmount, sellAmountBeforeFees, buyToken, sellToken, executionTime, ...rest } =
-    rawTrade
+export function transformTrade(rawTrade: TradeMetaData & { executionTime?: string }): Trade {
+  const {
+    orderUid,
+    buyAmount,
+    sellAmount,
+    sellAmountBeforeFees,
+    buyToken,
+    sellToken,
+    executionTime = '',
+    ...rest
+  } = rawTrade
 
   return {
     ...rest,

--- a/test/utils/operator/orderFilledAmount.test.ts
+++ b/test/utils/operator/orderFilledAmount.test.ts
@@ -14,7 +14,7 @@ const ONE_HUNDRED_PERCENT = ONE_BIG_NUMBER
 describe('Order not filled', () => {
   describe('Buy order', () => {
     test('0% filled', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '0' }
+      const order = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '0' } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
     })
@@ -27,7 +27,7 @@ describe('Order not filled', () => {
         sellAmount: '100',
         executedSellAmount: '0',
         executedFeeAmount: '0',
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
     })
@@ -37,31 +37,31 @@ describe('Order not filled', () => {
 describe('Order partially filled', () => {
   describe('Buy order', () => {
     test('10% filled', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '10' }
+      const order = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '10' } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
     })
   })
   describe('Sell order', () => {
     test('10% filled, without fee', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '10',
         executedFeeAmount: '0',
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
     })
     test('10% filled, with fee', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '11',
         executedFeeAmount: '1',
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
     })
@@ -71,33 +71,33 @@ describe('Order partially filled', () => {
 describe('Order filled', () => {
   describe('Buy order', () => {
     test('100% filled, no surplus', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
         sellAmount: '100',
         executedSellAmount: '100',
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
     })
     test('100% filled, with surplus', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
         sellAmount: '100',
         executedSellAmount: '90', // sold less for the same buy amount
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
     })
   })
   describe('Sell order', () => {
     test('100% filled, no surplus, no fee', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
@@ -105,12 +105,12 @@ describe('Order filled', () => {
         executedFeeAmount: '0',
         buyAmount: '100',
         executedBuyAmount: '100',
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
     })
     test('100% filled, with fee', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
@@ -118,12 +118,12 @@ describe('Order filled', () => {
         executedFeeAmount: '10',
         buyAmount: '100',
         executedBuyAmount: '100',
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
     })
     test('100% filled, with surplus', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
@@ -131,7 +131,7 @@ describe('Order filled', () => {
         executedFeeAmount: '0',
         buyAmount: '100',
         executedBuyAmount: '110', // bought more for the same sell amount
-      }
+      } as RawOrder
 
       expect(getOrderFilledAmount(order)).toEqual({ amount: ONE_HUNDRED_BIG_NUMBER, percentage: ONE_HUNDRED_PERCENT })
     })

--- a/test/utils/operator/orderPrice.test.ts
+++ b/test/utils/operator/orderPrice.test.ts
@@ -50,13 +50,13 @@ function _assertOrderPriceWithoutFills(_order: RawOrder): void {
 
 describe('Limit price', () => {
   describe('Buy order', () => {
-    const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', sellAmount: '1000' }
+    const order = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', sellAmount: '1000' } as RawOrder
 
     _assertOrderPrice(order, getOrderLimitPrice)
   })
 
   describe('Sell order', () => {
-    const order: RawOrder = { ...RAW_ORDER, kind: 'sell', buyAmount: '100', sellAmount: '1000' }
+    const order = { ...RAW_ORDER, kind: 'sell', buyAmount: '100', sellAmount: '1000' } as RawOrder
 
     _assertOrderPrice(order, getOrderLimitPrice)
   })
@@ -64,14 +64,13 @@ describe('Limit price', () => {
 
 describe('Executed price', () => {
   describe('Buy order', () => {
-    const order: RawOrder = {
+    const order = {
       ...RAW_ORDER,
       kind: 'buy',
       executedBuyAmount: '100',
       executedSellAmount: '1010',
       executedFeeAmount: '10',
-    }
-
+    } as RawOrder
     describe('With fills', () => {
       _assertOrderPrice(order, getOrderExecutedPrice)
     })
@@ -81,13 +80,13 @@ describe('Executed price', () => {
   })
 
   describe('Sell order', () => {
-    const order: RawOrder = {
+    const order = {
       ...RAW_ORDER,
       kind: 'sell',
       executedBuyAmount: '100',
       executedSellAmount: '1010',
       executedFeeAmount: '10',
-    }
+    } as RawOrder
 
     describe('With fills', () => {
       _assertOrderPrice(order, getOrderExecutedPrice)

--- a/test/utils/operator/orderStatus.test.ts
+++ b/test/utils/operator/orderStatus.test.ts
@@ -25,40 +25,40 @@ beforeEach(() => mockTimes(_creationDatePlusMilliseconds(PENDING_ORDERS_BUFFER *
 describe('Filled status', () => {
   describe('Buy order', () => {
     test('Filled, within epsilon', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9999' }
+      const order = { ...RAW_ORDER, kind: 'buy', buyAmount: '10000', executedBuyAmount: '9999' } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, exact amount', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '100' }
+      const order = { ...RAW_ORDER, kind: 'buy', buyAmount: '100', executedBuyAmount: '100' } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, not yet expired', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, sell amount does not affect output', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
         executedBuyAmount: '100',
         sellAmount: '100',
         executedSellAmount: '1100',
-      }
+      } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, fee does not affect output', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '100',
@@ -66,53 +66,53 @@ describe('Filled status', () => {
         sellAmount: '1000',
         executedSellAmount: '1100',
         executedFeeAmount: '100',
-      }
+      } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
   })
   describe('Sell order', () => {
     test('Filled, within epsilon', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9999' }
+      const order = { ...RAW_ORDER, kind: 'sell', sellAmount: '10000', executedSellAmount: '9999' } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, exact amount', () => {
-      const order: RawOrder = { ...RAW_ORDER, kind: 'sell', sellAmount: '100', executedSellAmount: '100' }
+      const order = { ...RAW_ORDER, kind: 'sell', sellAmount: '100', executedSellAmount: '100' } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, not yet expired', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '100',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, with fee', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '90',
         executedSellAmount: '100',
         executedFeeAmount: '10',
-      }
+      } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
     test('Filled, buy amount does not affect output', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '100',
         executedSellAmount: '100',
         buyAmount: '100',
         executedBuyAmount: '1100',
-      }
+      } as RawOrder
 
       expect(getOrderStatus(order)).toEqual('filled')
     })
@@ -121,31 +121,31 @@ describe('Filled status', () => {
 
 describe('Canceled status', () => {
   test('Buy order', () => {
-    const order: RawOrder = {
+    const order = {
       ...RAW_ORDER,
       kind: 'buy',
       buyAmount: '10000',
       invalidated: true,
-    }
+    } as RawOrder
     expect(getOrderStatus(order)).toEqual('cancelled')
   })
   test('Sell order', () => {
-    const order: RawOrder = {
+    const order = {
       ...RAW_ORDER,
       kind: 'sell',
       sellAmount: '10000',
       invalidated: true,
-    }
+    } as RawOrder
     expect(getOrderStatus(order)).toEqual('cancelled')
   })
   test('Expired and invalidated', () => {
-    const order: RawOrder = {
+    const order = {
       ...RAW_ORDER,
       kind: 'sell',
       sellAmount: '10000',
       invalidated: true,
       validTo: _getPastTimestamp(),
-    }
+    } as RawOrder
     expect(getOrderStatus(order)).toEqual('cancelled')
   })
 })
@@ -180,14 +180,14 @@ describe('Cancelling Status', () => {
   test('When creationDate is already longer than the pendingOrderBuffer', () => {
     const millisecondsBefore = -PENDING_ORDERS_BUFFER - milliseconds // ms before the newCurrentDate
     const newCreationDate = _creationDatePlusMilliseconds(millisecondsBefore)
-    const order: RawOrder = {
+    const order = {
       ...RAW_ORDER,
       kind: 'sell',
       sellAmount: '10000',
       invalidated: true,
       validTo: _getCurrentTimestamp(),
       creationDate: newCreationDate.toISOString(),
-    }
+    } as RawOrder
 
     expect(getOrderStatus(order)).not.toEqual('cancelling')
   })
@@ -196,25 +196,25 @@ describe('Cancelling Status', () => {
 describe('Expired status', () => {
   describe('Buy order', () => {
     test('Expired', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '0',
         validTo: _getPastTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('expired')
     })
   })
   describe('Sell order', () => {
     test('Expired', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '0',
         validTo: _getPastTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('expired')
     })
   })
@@ -223,27 +223,27 @@ describe('Expired status', () => {
 describe('Open status', () => {
   describe('Buy order', () => {
     test('Open, no fills', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '0',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('open')
     })
     test('Open, with partial fills', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
         executedBuyAmount: '10',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('open')
     })
     test('Open, sell amount does not affect output', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         buyAmount: '10000',
@@ -251,33 +251,33 @@ describe('Open status', () => {
         sellAmount: '10000',
         executedSellAmount: '123',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('open')
     })
   })
   describe('Sell order', () => {
     test('Open, no fills', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '0',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('open')
     })
     test('Open, with partial fills', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
         executedSellAmount: '10',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('open')
     })
     test('Open, buy amount does not affect output', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         sellAmount: '10000',
@@ -285,7 +285,7 @@ describe('Open status', () => {
         buyAmount: '10000',
         executedBuyAmount: '323',
         validTo: _getCurrentTimestamp(),
-      }
+      } as RawOrder
       expect(getOrderStatus(order)).toEqual('open')
     })
   })

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -15,7 +15,7 @@ describe('getOrderSurplus', () => {
   describe('Buy order', () => {
     describe('fillOrKill', () => {
       test('No surplus', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'buy',
           sellAmount: '100',
@@ -23,11 +23,11 @@ describe('getOrderSurplus', () => {
           feeAmount: '0',
           executedFeeAmount: '0',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
       })
       test('No matches', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'buy',
           sellAmount: '100',
@@ -35,11 +35,11 @@ describe('getOrderSurplus', () => {
           feeAmount: '0',
           executedFeeAmount: '0',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
       })
       test('With fees = 0', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'buy',
           sellAmount: '100',
@@ -47,11 +47,11 @@ describe('getOrderSurplus', () => {
           feeAmount: '0',
           executedFeeAmount: '0',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
       })
       test('With fees > 0', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'buy',
           sellAmount: '100',
@@ -59,12 +59,12 @@ describe('getOrderSurplus', () => {
           feeAmount: '10',
           executedFeeAmount: '10',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
       })
     })
     test.skip('partiallyFillable', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'buy',
         sellAmount: '100',
@@ -72,7 +72,7 @@ describe('getOrderSurplus', () => {
         buyAmount: '100',
         executedBuyAmount: '40',
         partiallyFillable: true,
-      }
+      } as RawOrder
       expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
     })
   })
@@ -80,7 +80,7 @@ describe('getOrderSurplus', () => {
   describe('Sell order', () => {
     describe('fillOrKill', () => {
       test('No surplus', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'sell',
           buyAmount: '100',
@@ -88,11 +88,11 @@ describe('getOrderSurplus', () => {
           feeAmount: '0',
           executedFeeAmount: '0',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
       })
       test('No matches', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'sell',
           buyAmount: '100',
@@ -100,11 +100,11 @@ describe('getOrderSurplus', () => {
           feeAmount: '0',
           executedFeeAmount: '0',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER })
       })
       test('With fees = 0', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'sell',
           buyAmount: '100',
@@ -112,11 +112,11 @@ describe('getOrderSurplus', () => {
           feeAmount: '0',
           executedFeeAmount: '0',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
       })
       test('With fees > 0', () => {
-        const order: RawOrder = {
+        const order = {
           ...RAW_ORDER,
           kind: 'sell',
           buyAmount: '100',
@@ -124,12 +124,12 @@ describe('getOrderSurplus', () => {
           feeAmount: '10',
           executedFeeAmount: '10',
           partiallyFillable: false,
-        }
+        } as RawOrder
         expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
       })
     })
     test.skip('partiallyFillable', () => {
-      const order: RawOrder = {
+      const order = {
         ...RAW_ORDER,
         kind: 'sell',
         buyAmount: '100',
@@ -137,7 +137,7 @@ describe('getOrderSurplus', () => {
         sellAmount: '100',
         executedSellAmount: '40',
         partiallyFillable: true,
-      }
+      } as RawOrder
       expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1442,6 +1442,21 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/abi@5.6.0", "@ethersproject/abi@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.0.tgz#ea07cbc1eec2374d32485679c12408005895e9f3"
+  integrity sha512-AhVByTwdXCc2YQ20v300w6KVHle9g2OFc28ZAFCPnJyEpkv1xKXjZcSTgWOlv1i+0dqlgF8RCF2Rn2KC1t+1Vg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/abstract-provider@5.5.1", "@ethersproject/abstract-provider@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
@@ -1455,6 +1470,19 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/web" "^5.5.0"
 
+"@ethersproject/abstract-provider@5.6.0", "@ethersproject/abstract-provider@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
+  integrity sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+
 "@ethersproject/abstract-signer@5.5.0", "@ethersproject/abstract-signer@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
@@ -1465,6 +1493,17 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/abstract-signer@5.6.0", "@ethersproject/abstract-signer@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
+  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
 
 "@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.5.0":
   version "5.5.0"
@@ -1477,12 +1516,30 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/rlp" "^5.5.0"
 
+"@ethersproject/address@5.6.0", "@ethersproject/address@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
+  integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+
 "@ethersproject/base64@5.5.0", "@ethersproject/base64@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
   integrity sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
+
+"@ethersproject/base64@5.6.0", "@ethersproject/base64@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
+  integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
 
 "@ethersproject/basex@5.5.0", "@ethersproject/basex@^5.5.0":
   version "5.5.0"
@@ -1491,6 +1548,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/basex@5.6.0", "@ethersproject/basex@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.6.0.tgz#9ea7209bf0a1c3ddc2a90f180c3a7f0d7d2e8a69"
+  integrity sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
 
 "@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.5.0":
   version "5.5.0"
@@ -1501,6 +1566,15 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@5.6.0", "@ethersproject/bignumber@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.0.tgz#116c81b075c57fa765a8f3822648cf718a8a0e26"
+  integrity sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    bn.js "^4.11.9"
+
 "@ethersproject/bytes@5.5.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
@@ -1508,12 +1582,26 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/bytes@5.6.0", "@ethersproject/bytes@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.0.tgz#81652f2a0e04533575befadce555213c11d8aa20"
+  integrity sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/constants@5.5.0", "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
   integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
+
+"@ethersproject/constants@5.6.0", "@ethersproject/constants@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
+  integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
 
 "@ethersproject/contracts@5.5.0":
   version "5.5.0"
@@ -1531,6 +1619,22 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
 
+"@ethersproject/contracts@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.0.tgz#60f2cfc7addd99a865c6c8cfbbcec76297386067"
+  integrity sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==
+  dependencies:
+    "@ethersproject/abi" "^5.6.0"
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+
 "@ethersproject/hash@5.5.0", "@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
@@ -1544,6 +1648,20 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
+  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/hdnode@5.5.0", "@ethersproject/hdnode@^5.5.0":
   version "5.5.0"
@@ -1562,6 +1680,24 @@
     "@ethersproject/strings" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/wordlists" "^5.5.0"
+
+"@ethersproject/hdnode@5.6.0", "@ethersproject/hdnode@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.6.0.tgz#9dcbe8d629bbbcf144f2cae476337fe92d320998"
+  integrity sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
 
 "@ethersproject/json-wallets@5.5.0", "@ethersproject/json-wallets@^5.5.0":
   version "5.5.0"
@@ -1582,6 +1718,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.6.0", "@ethersproject/json-wallets@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz#4c2fc27f17e36c583e7a252fb938bc46f98891e5"
+  integrity sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
@@ -1590,10 +1745,23 @@
     "@ethersproject/bytes" "^5.5.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@5.6.0", "@ethersproject/keccak256@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
+  integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.5.0", "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/logger@5.6.0", "@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
 
 "@ethersproject/networks@5.5.1", "@ethersproject/networks@^5.5.0":
   version "5.5.1"
@@ -1601,6 +1769,13 @@
   integrity sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/networks@5.6.0", "@ethersproject/networks@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.0.tgz#486d03fff29b4b6b5414d47a232ded09fe10de5e"
+  integrity sha512-DaVzgyThzHgSDLuURhvkp4oviGoGe9iTZW4jMEORHDRCgSZ9K9THGFKqL+qGXqPAYLEgZTf5z2w56mRrPR1MjQ==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/pbkdf2@5.5.0", "@ethersproject/pbkdf2@^5.5.0":
   version "5.5.0"
@@ -1610,12 +1785,27 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/sha2" "^5.5.0"
 
+"@ethersproject/pbkdf2@5.6.0", "@ethersproject/pbkdf2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz#04fcc2d7c6bff88393f5b4237d906a192426685a"
+  integrity sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+
 "@ethersproject/properties@5.5.0", "@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
   integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/properties@5.6.0", "@ethersproject/properties@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/providers@5.5.1":
   version "5.5.1"
@@ -1642,6 +1832,31 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.1.tgz#9a05f00ecbac59565bf6907c8d2af8ac33303b48"
+  integrity sha512-w8Wx15nH+aVDvnoKCyI1f3x0B5idmk/bDJXMEUqCfdO8Eadd0QpDx9lDMTMmenhOmf9vufLJXjpSm24D3ZnVpg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.5.0", "@ethersproject/random@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.0.tgz#305ed9e033ca537735365ac12eed88580b0f81f9"
@@ -1650,6 +1865,14 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/random@5.6.0", "@ethersproject/random@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
+  integrity sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/rlp@5.5.0", "@ethersproject/rlp@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
@@ -1657,6 +1880,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/rlp@5.6.0", "@ethersproject/rlp@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.0.tgz#55a7be01c6f5e64d6e6e7edb6061aa120962a717"
+  integrity sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/sha2@5.5.0", "@ethersproject/sha2@^5.5.0":
   version "5.5.0"
@@ -1667,6 +1898,15 @@
     "@ethersproject/logger" "^5.5.0"
     hash.js "1.1.7"
 
+"@ethersproject/sha2@5.6.0", "@ethersproject/sha2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
+  integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
 "@ethersproject/signing-key@5.5.0", "@ethersproject/signing-key@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
@@ -1675,6 +1915,18 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.6.0", "@ethersproject/signing-key@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.0.tgz#4f02e3fb09e22b71e2e1d6dc4bcb5dafa69ce042"
+  integrity sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
     bn.js "^4.11.9"
     elliptic "6.5.4"
     hash.js "1.1.7"
@@ -1691,6 +1943,18 @@
     "@ethersproject/sha2" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/solidity@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.6.0.tgz#64657362a596bf7f5630bdc921c07dd78df06dc3"
+  integrity sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/strings@5.5.0", "@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
@@ -1699,6 +1963,15 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/constants" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/strings@5.6.0", "@ethersproject/strings@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
+  integrity sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.5.0":
   version "5.5.0"
@@ -1715,6 +1988,21 @@
     "@ethersproject/rlp" "^5.5.0"
     "@ethersproject/signing-key" "^5.5.0"
 
+"@ethersproject/transactions@5.6.0", "@ethersproject/transactions@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.0.tgz#4b594d73a868ef6e1529a2f8f94a785e6791ae4e"
+  integrity sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+
 "@ethersproject/units@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.5.0.tgz#104d02db5b5dc42cc672cc4587bafb87a95ee45e"
@@ -1723,6 +2011,15 @@
     "@ethersproject/bignumber" "^5.5.0"
     "@ethersproject/constants" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/units@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.0.tgz#e5cbb1906988f5740254a21b9ded6bd51e826d9c"
+  integrity sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/wallet@5.5.0":
   version "5.5.0"
@@ -1745,6 +2042,27 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/wordlists" "^5.5.0"
 
+"@ethersproject/wallet@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.0.tgz#33d11a806d783864208f348709a5a3badac8e22a"
+  integrity sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/json-wallets" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
 "@ethersproject/web@5.5.1", "@ethersproject/web@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.1.tgz#cfcc4a074a6936c657878ac58917a61341681316"
@@ -1756,6 +2074,17 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/web@5.6.0", "@ethersproject/web@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
+  integrity sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==
+  dependencies:
+    "@ethersproject/base64" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/wordlists@5.5.0", "@ethersproject/wordlists@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
@@ -1766,6 +2095,17 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/wordlists@5.6.0", "@ethersproject/wordlists@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.0.tgz#79e62c5276e091d8575f6930ba01a29218ded032"
+  integrity sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@foliojs-fork/fontkit@^1.9.1":
   version "1.9.1"
@@ -1840,6 +2180,24 @@
   dependencies:
     prop-types "^15.7.2"
 
+"@gnosis.pm/cow-sdk@file:../cow-sdk":
+  version "0.0.6"
+  dependencies:
+    "@gnosis.pm/gp-v2-contracts" "^1.1.2"
+    ajv "^8.8.2"
+    cross-fetch "^3.1.5"
+    ethers "^5.5.3"
+    loglevel "^1.8.0"
+
+"@gnosis.pm/cow-sdk@file:./../cow-sdk":
+  version "0.0.6"
+  dependencies:
+    "@gnosis.pm/gp-v2-contracts" "^1.1.2"
+    ajv "^8.8.2"
+    cross-fetch "^3.1.5"
+    ethers "^5.5.3"
+    loglevel "^1.8.0"
+
 "@gnosis.pm/dex-contracts@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.4.3.tgz#b887eb543cae039d1e9607870232394cab5c3be7"
@@ -1855,7 +2213,7 @@
     "@gnosis.pm/dex-contracts" "^0.4.3"
     bignumber.js "^9.0.0"
 
-"@gnosis.pm/gp-v2-contracts@^1.0.2":
+"@gnosis.pm/gp-v2-contracts@^1.0.2", "@gnosis.pm/gp-v2-contracts@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.1.2.tgz#0453bb097377dc63cf46ee195f7e521d429f7e22"
   integrity sha512-BvZMNS+fwITb+qs+trs2fyvYksa6MPjjLze9AOXPnvcKVYFEGwG6cfsecBswEMo+xevLIQNDyF7HZRhN7ply8w==
@@ -4891,6 +5249,16 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.8.2:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d"
+  integrity sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -7231,6 +7599,13 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
     node-fetch "2.6.1"
     whatwg-fetch "2.0.4"
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -9238,6 +9613,42 @@ ethers@^5.0.26:
     "@ethersproject/wallet" "5.5.0"
     "@ethersproject/web" "5.5.1"
     "@ethersproject/wordlists" "5.5.0"
+
+ethers@^5.5.3:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.1.tgz#a56cd67f1595b745dc3dde0ccf2b5de53a41a6d0"
+  integrity sha512-qtl/2W+dwmUa5Z3JqwsbV3JEBZZHNARe5K/A2ePcNAuhJYnEKIgGOT/O9ouPwBijSqVoQnmQMzi5D48LFNOY2A==
+  dependencies:
+    "@ethersproject/abi" "5.6.0"
+    "@ethersproject/abstract-provider" "5.6.0"
+    "@ethersproject/abstract-signer" "5.6.0"
+    "@ethersproject/address" "5.6.0"
+    "@ethersproject/base64" "5.6.0"
+    "@ethersproject/basex" "5.6.0"
+    "@ethersproject/bignumber" "5.6.0"
+    "@ethersproject/bytes" "5.6.0"
+    "@ethersproject/constants" "5.6.0"
+    "@ethersproject/contracts" "5.6.0"
+    "@ethersproject/hash" "5.6.0"
+    "@ethersproject/hdnode" "5.6.0"
+    "@ethersproject/json-wallets" "5.6.0"
+    "@ethersproject/keccak256" "5.6.0"
+    "@ethersproject/logger" "5.6.0"
+    "@ethersproject/networks" "5.6.0"
+    "@ethersproject/pbkdf2" "5.6.0"
+    "@ethersproject/properties" "5.6.0"
+    "@ethersproject/providers" "5.6.1"
+    "@ethersproject/random" "5.6.0"
+    "@ethersproject/rlp" "5.6.0"
+    "@ethersproject/sha2" "5.6.0"
+    "@ethersproject/signing-key" "5.6.0"
+    "@ethersproject/solidity" "5.6.0"
+    "@ethersproject/strings" "5.6.0"
+    "@ethersproject/transactions" "5.6.0"
+    "@ethersproject/units" "5.6.0"
+    "@ethersproject/wallet" "5.6.0"
+    "@ethersproject/web" "5.6.0"
+    "@ethersproject/wordlists" "5.6.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"
@@ -13472,6 +13883,11 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
+loglevel@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
+  integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
+
 longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
@@ -14396,6 +14812,13 @@ node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@~1.7.1:
   version "1.7.3"
@@ -19025,6 +19448,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -20148,6 +20576,11 @@ web3modal@1.9.0:
     styled-components "^5.1.1"
     tslib "^1.10.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -20358,6 +20791,14 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"


### PR DESCRIPTION
# Summary

Closes #1066

Added the following methods from SDK being used in  `operatorApi` :

- GetTrades `/trades`
- GetOrders `/account/${owner}/orders/`
- GetTxOrders `/transactions/${txHash}/orders/`

This is a WIP PR since we need first to merge [this](https://github.com/gnosis/cow-sdk/pull/14) in order for us to bump a new version of the SDK and install it on this PR.

